### PR TITLE
ci: bump actions/setup-node from 4 to 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/refresh-projects.yml
+++ b/.github/workflows/refresh-projects.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"


### PR DESCRIPTION
## Summary
- Bumps `actions/setup-node` from v4 to v6 in both CI and refresh-projects workflows
- Replaces conflicting Dependabot PR #14

## Test plan
- [ ] CI build passes with setup-node@v6

🤖 Generated with [Claude Code](https://claude.com/claude-code)