### PR TITLE
fix: portfolio init render + services meta title (prod audit findings)

### DIFF
--- a/scripts/audit-portfolio-filter.py
+++ b/scripts/audit-portfolio-filter.py
@@ -1,0 +1,41 @@
+"""Verify the portfolio default-Featured filter is actually applied."""
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    page = browser.new_page(viewport={"width": 1400, "height": 1200})
+    page.goto("https://cushlabs.ai/portfolio/", wait_until="networkidle")
+    page.wait_for_timeout(1500)  # Give the JS filter time to run
+
+    # Check which filter button has the active state
+    active_btn = page.locator(".filter-btn.active").first.get_attribute("data-filter")
+    print(f"Active filter (DOM): {active_btn}")
+
+    # Check display:none vs visible cards via computed style
+    cards = page.locator(".project-card").all()
+    print(f"Total .project-card in DOM: {len(cards)}")
+
+    visible_count = 0
+    hidden_count = 0
+    visible_names = []
+    for card in cards:
+        display = card.evaluate("el => getComputedStyle(el).display")
+        if display == "none":
+            hidden_count += 1
+        else:
+            visible_count += 1
+            # Try to get the project title from the card
+            try:
+                title = card.locator("h3, h2").first.inner_text()
+                visible_names.append(title.strip()[:50])
+            except Exception:
+                pass
+
+    print(f"Visible cards (display != none): {visible_count}")
+    print(f"Hidden cards: {hidden_count}")
+    print(f"Visible project names:")
+    for n in visible_names:
+        print(f"  - {n}")
+
+    page.screenshot(path="/tmp/portfolio_default.png", full_page=True)
+    browser.close()

--- a/scripts/audit-prod.py
+++ b/scripts/audit-prod.py
@@ -1,0 +1,122 @@
+"""Audit the live cushlabs.ai prod deploy after the positioning rewrite PRs."""
+from playwright.sync_api import sync_playwright
+import json
+import sys
+
+PAGES = [
+    ("EN home",      "https://cushlabs.ai/"),
+    ("ES home",      "https://cushlabs.ai/es/"),
+    ("EN services",  "https://cushlabs.ai/services/"),
+    ("ES services",  "https://cushlabs.ai/es/services/"),
+    ("EN portfolio", "https://cushlabs.ai/portfolio/"),
+    ("ES portfolio", "https://cushlabs.ai/es/portfolio/"),
+]
+
+# Strings we expect to find on each page (proves the new copy is live)
+EXPECTED = {
+    "EN home": [
+        "AI Chatbots & Automation for Small Business",
+        "I Build AI Chatbots, Voice Agents",
+        "Live in 2",  # 2-6 weeks
+        "Workflow Automation",
+        "Does This Sound Like Your Business",
+        "Why Work With Me",
+        "Let's Talk About Automating",
+    ],
+    "ES home": [
+        "Chatbots de IA y Automatización para Pequeñas Empresas",
+        "Construyo Chatbots de IA",
+        "En vivo en 2",
+        "Automatización de Procesos",
+        "Por Qué Trabajar Conmigo",
+        "Hablemos Sobre Automatizar",
+    ],
+    "EN services": [
+        "What I Build — And What It Costs",
+        "AI Customer Support Chatbot",
+        "Google Maps Competitor Tracking",
+        "Custom Workflow Automation",
+        "AI Strategy Session",
+    ],
+    "ES services": [
+        "Lo Que Construyo",
+        "Chatbot de Atención al Cliente",
+        "Monitoreo de Competidores en Google Maps",
+        "Automatización de Procesos a la Medida",
+        "Sesión de Estrategia",
+    ],
+    "EN portfolio": [
+        "Real AI Projects — Built for Real Businesses",
+        "Want Something Like This",
+    ],
+    "ES portfolio": [
+        "Proyectos Reales de IA",
+        "¿Quieres Algo Como Esto",
+    ],
+}
+
+results = []
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    context = browser.new_context(viewport={"width": 1400, "height": 900})
+
+    for label, url in PAGES:
+        page = context.new_page()
+        console_errors = []
+        page.on("pageerror", lambda exc: console_errors.append(f"PAGEERROR: {exc}"))
+        page.on("console", lambda msg: console_errors.append(f"CONSOLE.{msg.type}: {msg.text}") if msg.type == "error" else None)
+
+        try:
+            response = page.goto(url, wait_until="networkidle", timeout=30000)
+            status = response.status if response else "no response"
+        except Exception as e:
+            results.append({"page": label, "url": url, "status": f"FAILED: {e}"})
+            page.close()
+            continue
+
+        title = page.title()
+        body_text = page.locator("body").inner_text()
+
+        # Check expected strings
+        missing = [s for s in EXPECTED.get(label, []) if s not in body_text]
+
+        # For portfolio pages, check the visible card count (default filter behavior)
+        visible_cards = None
+        if "portfolio" in label:
+            try:
+                # Wait briefly for the JS filter to apply
+                page.wait_for_timeout(500)
+                cards = page.locator(".project-card:visible").count()
+                visible_cards = cards
+            except Exception:
+                pass
+
+        # Screenshot
+        slug = label.replace(" ", "_")
+        page.screenshot(path=f"/tmp/audit_{slug}.png", full_page=False)
+
+        results.append({
+            "page": label,
+            "url": url,
+            "status": status,
+            "title": title,
+            "missing_strings": missing,
+            "visible_cards": visible_cards,
+            "console_errors": console_errors[:5],  # cap noise
+        })
+        page.close()
+
+    browser.close()
+
+# Print as JSON for clean parsing
+print(json.dumps(results, indent=2, ensure_ascii=False))
+
+# Exit non-zero if any page failed or had missing strings
+hard_fail = any(
+    isinstance(r.get("status"), str) and "FAILED" in r["status"]
+    or r.get("missing_strings")
+    or (r.get("status") and r["status"] != 200 and r["status"] != "no response")
+    for r in results
+)
+sys.exit(1 if hard_fail else 0)

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -1,6 +1,29 @@
 ---
-// Spanish route - reuse the same page logic
-import IndexPage from "../index.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import Hero from "../../components/home2/Hero.astro";
+import PainPoints from "../../components/home2/PainPoints.astro";
+import SolutionOverview from "../../components/home2/SolutionOverview.astro";
+import HowItWorks from "../../components/home2/HowItWorks.astro";
+import WhyMe from "../../components/home2/WhyMe.astro";
+import SocialProof from "../../components/home2/SocialProof.astro";
+import RecentWork from "../../components/home2/RecentWork.astro";
+import FAQ from "../../components/home2/FAQ.astro";
+import FinalCTA from "../../components/home2/FinalCTA.astro";
+
+const locale = "es" as const;
+
+const title = "CushLabs.ai — Chatbots de IA y Automatización para Pequeñas Empresas";
+const description = "Chatbots de IA, agentes de voz y automatización de procesos para pequeñas empresas en EE.UU. y México. Bilingüe EN/ES. En vivo en 2–6 semanas.";
 ---
 
-<IndexPage />
+<BaseLayout title={title} description={description}>
+  <Hero locale={locale} />
+  <PainPoints locale={locale} />
+  <SocialProof locale={locale} />
+  <SolutionOverview locale={locale} />
+  <HowItWorks locale={locale} />
+  <WhyMe locale={locale} />
+  <RecentWork locale={locale} />
+  <FAQ locale={locale} />
+  <FinalCTA locale={locale} />
+</BaseLayout>

--- a/src/pages/portfolio.astro
+++ b/src/pages/portfolio.astro
@@ -549,6 +549,12 @@ const t = content[locale];
       renderProjects();
     }, 200);
   });
+
+  // Apply the default filter on first load. Without this call, the
+  // active filter button shows "Featured" but no filtering happens
+  // until the visitor clicks something — so they see all 32 cards
+  // instead of the curated 6.
+  renderProjects();
 </script>
 
 <style>

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -13,12 +13,12 @@ const locale = (Astro.currentLocale === "es" ? "es" : "en") as "en" | "es";
 
 const meta = {
   en: {
-    title: "AI Solutions for Growing Businesses — CushLabs.ai",
-    description: "AI assistants, local competitive intelligence, and custom automation for SMBs. Clear pricing, measurable outcomes, bilingual EN/ES. Free discovery call.",
+    title: "Services & Pricing — AI Chatbots, Voice Agents & Automation | CushLabs.ai",
+    description: "AI customer support chatbots, Google Maps competitor tracking, custom workflow automation, and AI strategy sessions. Clear pricing, bilingual EN/ES. Free discovery call.",
   },
   es: {
-    title: "Soluciones de IA para Negocios en Crecimiento — CushLabs.ai",
-    description: "Asistentes de IA, inteligencia competitiva local y automatización a medida para PYMES. Precios claros, resultados medibles. Llamada gratis.",
+    title: "Servicios y Precios — Chatbots de IA, Agentes de Voz y Automatización | CushLabs.ai",
+    description: "Chatbots de atención al cliente, monitoreo de competidores en Google Maps, automatización de procesos a la medida y sesiones de estrategia. Precios claros, bilingüe EN/ES.",
   },
 };
 ---


### PR DESCRIPTION
## Summary

Two real bugs caught by post-deploy audit (scripts/audit-prod.py).

## Bug 1: Portfolio Featured filter never applied on first load
The active button class was correctly on Featured and `currentFilter` was initialized to `"featured"`, but `renderProjects()` was only called from event handlers — never on script init. Visitors landed on all 32 cards instead of the curated 6.

**Fix:** call `renderProjects()` once after the event listeners are wired up.

## Bug 2: Services meta title not updated
PR #49 updated the visible Hero copy on services but I missed the page-level `<title>` tag in `services.astro`. It still said "AI Solutions for Growing Businesses".

**Fix:** `Services & Pricing — AI Chatbots, Voice Agents & Automation | CushLabs.ai` (EN + ES).

## Also includes
- `src/pages/es/index.astro` refactored from `<IndexPage />` shim to direct component imports with hard-coded `locale="es"`. The shim wasn't reliably propagating the new ES title prop.
- `scripts/audit-prod.py` + `scripts/audit-portfolio-filter.py` — re-runnable audit scripts so future sessions can verify prod state without rebuilding the test harness from scratch.

## Test plan
- [x] Build passes (89 pages)
- [x] validate-portfolio-md autofixed a fresh duplicate health_status in cushlabs-marketsignal (the validator is doing its job — silent corruption is now impossible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)