### PR TITLE
fix: Spanish pages rendered unstyled — page-as-component CSS bundling

### DIFF
--- a/src/pages/es/about.astro
+++ b/src/pages/es/about.astro
@@ -1,6 +1,219 @@
 ---
-// Spanish route - reuse the same page logic (locale detected via Astro.currentLocale)
-import AboutPage from "../about.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import Container from "../../components/layout/Container.astro";
+
+const locale = "es" as const;
+
+const content = {
+  meta: {
+    title: "Acerca — Por Qué las Empresas Confían en CushLabs.ai",
+    description: "20+ años en TI, 500+ conexiones profesionales y soluciones de IA que realmente funcionan. Descubre por qué los negocios eligen CushLabs.",
+  },
+  hero: {
+    badge: "Por Qué CushLabs",
+    headline: "Necesitas IA Que Funcione — No Otro Experimento Tecnológico",
+    subheadline: "Los pequeños negocios merecen las mismas ventajas de IA que las grandes empresas — sin el precio empresarial. He pasado 20+ años construyendo ese puente.",
+    ctaPrimary: "Agendar Llamada Gratis",
+    ctaSecondary: "Ver Soluciones Reales",
+  },
+  trust: {
+    title: "Construido sobre Experiencia, No Promesas",
+    stats: [
+      { value: "20+", label: "Años en TI", sublabel: "Desarrollador → Gerente → Consultor" },
+      { value: "500+", label: "Conexiones en LinkedIn", sublabel: "Red Establecida en TI" },
+      { value: "100%", label: "Bilingüe", sublabel: "Inglés y Español" },
+      { value: "2", label: "Mercados Atendidos", sublabel: "EE.UU. y México" },
+    ],
+  },
+  problem: {
+    title: "El Problema Que Resuelvo",
+    intro: "Probablemente has visto promesas de IA en todas partes. Pero la mayoría de los pequeños negocios enfrentan las mismas frustraciones:",
+    items: [
+      "Las herramientas de IA empresariales son caras y excesivas para tus necesidades",
+      "Los chatbots caseros se sienten robóticos y frustran a tus clientes",
+      "Los consultores de tecnología hablan jerga y sobre-diseñan todo",
+      "Pasas horas en tareas repetitivas que deberían estar automatizadas",
+      "No estás seguro de qué puede hacer realmente la IA por TU negocio",
+    ],
+    conclusion: "¿Te suena familiar? Por eso exactamente empecé CushLabs.",
+  },
+  approach: {
+    title: "Cómo Trabajo Diferente",
+    items: [
+      { title: "Práctico Sobre Perfecto", description: "Construyo soluciones que funcionan en el mundo real, no demos impresionantes que fallan en producción. Obtienes herramientas que tu equipo realmente usará." },
+      { title: "Precios Fijos, Sin Sorpresas", description: "Sabrás el costo desde el inicio. Sin facturación por hora que escala, sin cambios de alcance, sin facturas misteriosas al final." },
+      { title: "Entrega Rápida", description: "La mayoría de proyectos se lanzan en 2-4 semanas. Verás software funcionando rápidamente — no meses de planeación y reuniones." },
+      { title: "Tú Eres Dueño de Todo", description: "Documentación completa, código limpio, sin dependencia de proveedor. Si nos separamos, te quedas con todo lo que construí." },
+    ],
+  },
+  about: {
+    title: "Sobre Robert",
+    intro: "Empecé CushLabs después de 20 años viendo negocios luchar con tecnología que se suponía debía facilitar las cosas.",
+    body: "He sido desarrollador, gerente senior de TI, y gerente de proyectos. He visto qué funciona y qué no — desde adentro. Ahora trabajo directamente con fundadores y equipos pequeños desde mi base en Guadalajara, México. Sin capas, sin ejecutivos de cuenta, sin traspasos. La persona con quien hablas es la persona que construye tu solución.",
+    highlight: "Creo que la IA debe ser accesible para todos — no solo para empresas con presupuestos empresariales.",
+    linkedin: "Conectar en LinkedIn",
+  },
+  clients: {
+    title: "Con Quién Trabajo",
+    intro: "CushLabs es ideal si eres:",
+    items: [
+      "Un dueño de pequeño negocio cansado de tareas repetitivas que consumen tu semana",
+      "Un fundador que quiere IA trabajando para ti, no otra herramienta que administrar",
+      "Un líder de operaciones buscando reducir volumen de soporte sin contratar",
+      "Un equipo en EE.UU. o México que valora la comunicación bilingüe",
+      "Alguien que quiere hablar directo, no jerga técnica",
+    ],
+    notFor: "¿No es para ti? Si necesitas infraestructura a escala empresarial, un gran equipo de desarrollo, o investigación de IA de vanguardia — con gusto te refiero a alguien mejor preparado.",
+  },
+  cta: {
+    title: "¿Listo Para Hablar?",
+    subtitle: "Agenda una llamada de descubrimiento gratuita. Cuéntame qué te está consumiendo el tiempo, y te diré honestamente si la IA puede ayudar — y qué implicaría.",
+    button: "Agendar Llamada Gratis",
+    reassurance: "Sin pitch. Sin presión. Solo claridad.",
+  },
+};
+
+const t = content;
 ---
 
-<AboutPage />
+<BaseLayout title={t.meta.title} description={t.meta.description}>
+  <section class="relative pt-24 pb-16 overflow-hidden">
+    <div class="absolute inset-0 -z-20">
+      <img src="/images/hero/about-hero.webp" alt="CushLabs founder and AI consultant background" width="1920" height="1080" class="w-full h-full object-cover opacity-[0.05] dark:opacity-[0.03]" />
+      <div class="absolute inset-0 bg-gradient-to-b from-white/50 via-transparent to-white dark:from-gray-950/50 dark:via-transparent dark:to-gray-950"></div>
+    </div>
+    <div class="absolute inset-0 -z-10">
+      <div class="absolute top-1/4 left-1/4 w-[500px] h-[500px] bg-cush-orange/15 rounded-full blur-[120px]"></div>
+      <div class="absolute bottom-1/4 right-1/4 w-[400px] h-[400px] bg-cush-orange/10 rounded-full blur-[100px]"></div>
+    </div>
+
+    <Container>
+      <div class="text-center max-w-4xl mx-auto">
+        <span class="inline-block px-3 py-1 text-xs font-display font-semibold text-cush-orange bg-cush-orange/10 rounded-full mb-4">{t.hero.badge}</span>
+        <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-bold text-gray-900 dark:text-white mb-6 leading-tight">{t.hero.headline}</h1>
+        <p class="text-lg md:text-xl text-gray-600 dark:text-gray-400 mb-8 max-w-3xl mx-auto">{t.hero.subheadline}</p>
+        <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
+          <a href="/es/reservar/" class="group inline-flex items-center gap-2 px-6 py-3 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-all shadow-lg shadow-cush-orange/25">
+            {t.hero.ctaPrimary}
+            <svg class="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" /></svg>
+          </a>
+          <a href="/es/portfolio/" class="group inline-flex items-center gap-2 px-6 py-3 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 font-display font-semibold rounded-lg hover:border-cush-orange hover:text-cush-orange transition-all">
+            {t.hero.ctaSecondary}
+            <svg class="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" /></svg>
+          </a>
+        </div>
+      </div>
+    </Container>
+  </section>
+
+  <section class="py-16 border-y border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900/50">
+    <Container>
+      <h2 class="text-center font-display text-2xl font-bold text-gray-900 dark:text-white mb-10">{t.trust.title}</h2>
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-8">
+        {t.trust.stats.map((stat) => (
+          <div class="text-center">
+            <div class="font-display text-4xl md:text-5xl font-bold text-cush-orange mb-2">{stat.value}</div>
+            <div class="font-display font-semibold text-gray-900 dark:text-white">{stat.label}</div>
+            <div class="text-sm text-gray-500 dark:text-gray-400">{stat.sublabel}</div>
+          </div>
+        ))}
+      </div>
+    </Container>
+  </section>
+
+  <section class="py-20 lg:py-28">
+    <Container>
+      <div class="max-w-3xl mx-auto">
+        <h2 class="font-display text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-6">{t.problem.title}</h2>
+        <p class="text-lg text-gray-600 dark:text-gray-400 mb-8">{t.problem.intro}</p>
+        <ul class="space-y-4 mb-8">
+          {t.problem.items.map((item) => (
+            <li class="flex items-start gap-3">
+              <svg class="w-6 h-6 text-red-500 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+              <span class="text-gray-700 dark:text-gray-300">{item}</span>
+            </li>
+          ))}
+        </ul>
+        <p class="text-xl font-display font-semibold text-cush-orange">{t.problem.conclusion}</p>
+      </div>
+    </Container>
+  </section>
+
+  <section class="py-20 lg:py-28 bg-gray-50 dark:bg-gray-900/50">
+    <Container>
+      <h2 class="font-display text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-12 text-center">{t.approach.title}</h2>
+      <div class="grid md:grid-cols-2 gap-6 max-w-5xl mx-auto">
+        {t.approach.items.map((item, index) => (
+          <div class="p-6 md:p-8 rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800/50">
+            <div class="flex items-center gap-3 mb-4">
+              <div class="w-10 h-10 rounded-lg bg-cush-orange/10 flex items-center justify-center flex-shrink-0">
+                <span class="font-display font-bold text-cush-orange">{String(index + 1).padStart(2, '0')}</span>
+              </div>
+              <h3 class="font-display text-xl font-bold text-gray-900 dark:text-white">{item.title}</h3>
+            </div>
+            <p class="text-gray-600 dark:text-gray-400">{item.description}</p>
+          </div>
+        ))}
+      </div>
+    </Container>
+  </section>
+
+  <section class="py-20 lg:py-28">
+    <Container>
+      <div class="grid lg:grid-cols-2 gap-12 items-center max-w-6xl mx-auto">
+        <div class="order-2 lg:order-1">
+          <h2 class="font-display text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-6">{t.about.title}</h2>
+          <p class="text-lg text-gray-600 dark:text-gray-400 mb-4">{t.about.intro}</p>
+          <p class="text-gray-700 dark:text-gray-300 mb-6 leading-relaxed">{t.about.body}</p>
+          <blockquote class="border-l-4 border-cush-orange pl-6 py-2 mb-8">
+            <p class="text-xl font-display font-medium text-gray-900 dark:text-white italic">"{t.about.highlight}"</p>
+          </blockquote>
+          <a href="https://www.linkedin.com/in/robert-cushman3/" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-2 text-cush-orange font-display font-semibold hover:underline">
+            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+            {t.about.linkedin}
+          </a>
+        </div>
+        <div class="order-1 lg:order-2">
+          <div class="relative aspect-square max-w-md mx-auto rounded-2xl overflow-hidden shadow-2xl">
+            <img src="/images/about/me-blueblazer-winetie.webp" alt="Robert Cushman, Founder of CushLabs.ai" loading="lazy" width="500" height="500" class="w-full h-full object-cover" />
+          </div>
+        </div>
+      </div>
+    </Container>
+  </section>
+
+  <section class="py-20 lg:py-28 bg-gray-50 dark:bg-gray-900/50">
+    <Container>
+      <div class="max-w-3xl mx-auto">
+        <h2 class="font-display text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-6">{t.clients.title}</h2>
+        <p class="text-lg text-gray-600 dark:text-gray-400 mb-8">{t.clients.intro}</p>
+        <ul class="space-y-4 mb-8">
+          {t.clients.items.map((item) => (
+            <li class="flex items-start gap-3">
+              <svg class="w-6 h-6 text-green-500 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
+              <span class="text-gray-700 dark:text-gray-300">{item}</span>
+            </li>
+          ))}
+        </ul>
+        <p class="text-sm text-gray-500 dark:text-gray-400 italic">{t.clients.notFor}</p>
+      </div>
+    </Container>
+  </section>
+
+  <section class="py-24 lg:py-32 relative overflow-hidden">
+    <div class="absolute inset-0 -z-10">
+      <div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-cush-orange/20 rounded-full blur-[120px]"></div>
+    </div>
+    <Container>
+      <div class="max-w-3xl mx-auto text-center">
+        <h2 class="font-display text-4xl md:text-5xl font-bold text-gray-900 dark:text-white mb-6">{t.cta.title}</h2>
+        <p class="text-xl text-gray-600 dark:text-gray-400 mb-8">{t.cta.subtitle}</p>
+        <a href="/es/reservar/" class="inline-flex items-center gap-3 px-8 py-4 bg-cush-orange text-white font-display font-bold text-lg rounded-xl hover:bg-cush-orange/90 transition-all shadow-lg shadow-cush-orange/25 hover:shadow-xl hover:shadow-cush-orange/30">
+          {t.cta.button}
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" /></svg>
+        </a>
+        <p class="mt-4 text-sm text-gray-500 dark:text-gray-400">{t.cta.reassurance}</p>
+      </div>
+    </Container>
+  </section>
+</BaseLayout>

--- a/src/pages/es/contact.astro
+++ b/src/pages/es/contact.astro
@@ -1,6 +1,238 @@
 ---
-// Spanish route - reuse the same page logic
-import ContactPage from "../contact.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import Container from "../../components/layout/Container.astro";
+import { t } from "../../i18n";
+
+const locale = "es" as const;
+const dict = t(locale);
+
+const whatsappNumber = "523315590572";
+const whatsappMessage = "Hola Robert! Te encontré en CushLabs.ai y tengo una pregunta sobre un proyecto.";
+const whatsappLink = `https://api.whatsapp.com/send/?phone=${whatsappNumber}&text=${encodeURIComponent(whatsappMessage)}&type=phone_number&app_absent=0`;
+
+const emailUser = "info";
+const emailDomain = "cushlabs.ai";
+
+const hero = {
+  badge: "Contáctame",
+  headline: "Hablemos de Tu Proyecto",
+  subheadline: "Cuéntame qué estás construyendo. Te responderé con una evaluación honesta y próximos pasos claros — sin presión, sin pitch.",
+  ctaPrimary: "Agendar Llamada Gratis",
+  ctaSecondary: "Enviar Mensaje",
+  reassurance: "Respuesta en 24 horas. Usualmente más rápido.",
+};
 ---
 
-<ContactPage />
+<BaseLayout
+  title="Contáctanos — Hablemos de IA | CushLabs.ai"
+  description="Cuéntame sobre tu proyecto. Respondo en 24 horas con ideas honestas y un camino claro — sin presión, sin pitch. Servicio bilingüe EN/ES."
+>
+  <section class="relative pt-24 pb-16 overflow-hidden">
+    <div class="absolute inset-0 -z-20">
+      <img src="/images/hero/contact-hero.webp" alt="Contact CushLabs for AI consulting and development services" width="1920" height="1080" class="w-full h-full object-cover opacity-[0.05] dark:opacity-[0.03]" />
+      <div class="absolute inset-0 bg-gradient-to-b from-white/50 via-transparent to-white dark:from-gray-950/50 dark:via-transparent dark:to-gray-950"></div>
+    </div>
+    <div class="absolute inset-0 -z-10">
+      <div class="absolute top-1/4 left-1/4 w-[500px] h-[500px] bg-cush-orange/15 rounded-full blur-[120px]"></div>
+      <div class="absolute bottom-1/4 right-1/4 w-[400px] h-[400px] bg-cush-orange/10 rounded-full blur-[100px]"></div>
+    </div>
+
+    <Container>
+      <div class="text-center max-w-3xl mx-auto">
+        <span class="inline-block px-3 py-1 text-xs font-display font-semibold text-cush-orange bg-cush-orange/10 rounded-full mb-4">{hero.badge}</span>
+        <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-bold text-gray-900 dark:text-white mb-6 leading-tight">{hero.headline}</h1>
+        <p class="text-lg text-gray-600 dark:text-gray-400 mb-8">{hero.subheadline}</p>
+
+        <div class="flex flex-col sm:flex-row items-center justify-center gap-4 mb-4">
+          <a href="/es/reservar/" class="group inline-flex items-center gap-2 px-6 py-3 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-all shadow-lg shadow-cush-orange/25">
+            {hero.ctaPrimary}
+            <svg class="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" /></svg>
+          </a>
+          <a href="#contact-form" class="group inline-flex items-center gap-2 px-6 py-3 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 font-display font-semibold rounded-lg hover:border-cush-orange hover:text-cush-orange transition-all">
+            {hero.ctaSecondary}
+            <svg class="w-5 h-5 group-hover:translate-y-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 14l-7 7m0 0l-7-7m7 7V3" /></svg>
+          </a>
+        </div>
+
+        <p class="text-sm text-gray-500 dark:text-gray-500">{hero.reassurance}</p>
+      </div>
+    </Container>
+  </section>
+
+  <main class="pb-24">
+    <section id="contact-form" class="mx-auto max-w-7xl px-4 pt-12">
+      <div class="grid grid-cols-1 gap-8 lg:grid-cols-2">
+        <div class="rounded-2xl border border-border bg-surface p-6 md:p-8 lg:order-1">
+          <h2 class="font-display text-xl font-bold text-foreground mb-6">Envíame un mensaje</h2>
+          <form id="contact-form-el" class="space-y-4" data-locale={locale}>
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div>
+                <label for="name" class="block text-sm font-display font-semibold text-foreground">{dict.contact.formName}<span class="text-cush-orange">*</span></label>
+                <input id="name" name="name" type="text" required class="mt-2 w-full rounded-lg border border-border bg-canvas/40 px-3 py-2 text-foreground placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-cush-orange" />
+              </div>
+              <div>
+                <label for="email" class="block text-sm font-display font-semibold text-foreground">{dict.contact.formEmail}<span class="text-cush-orange">*</span></label>
+                <input id="email" name="email" type="email" required class="mt-2 w-full rounded-lg border border-border bg-canvas/40 px-3 py-2 text-foreground placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-cush-orange" />
+              </div>
+            </div>
+
+            <div>
+              <label for="phone" class="block text-sm font-display font-semibold text-foreground">{dict.contact.formPhone}</label>
+              <input id="phone" name="phone" type="tel" placeholder={dict.contact.formPhoneHint} class="mt-2 w-full rounded-lg border border-border bg-canvas/40 px-3 py-2 text-foreground placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-cush-orange" />
+            </div>
+
+            <div>
+              <label for="message" class="block text-sm font-display font-semibold text-foreground">{dict.contact.formMessage}<span class="text-cush-orange">*</span></label>
+              <textarea id="message" name="message" required rows={6} placeholder={dict.contact.formMessageHint} class="mt-2 w-full rounded-lg border border-border bg-canvas/40 px-3 py-2 text-foreground placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-cush-orange"></textarea>
+            </div>
+
+            <div class="flex items-start gap-3">
+              <input id="consent" name="consent" type="checkbox" required class="mt-1 h-4 w-4 rounded border-border bg-canvas/40 text-cush-orange focus:ring-cush-orange" />
+              <label for="consent" class="text-sm text-muted">{dict.contact.formConsent}<span class="text-cush-orange">*</span></label>
+            </div>
+
+            <div id="form-error" class="hidden rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-3 text-sm text-red-700 dark:text-red-400" role="alert" aria-live="polite" aria-atomic="true"></div>
+
+            <div class="pt-2">
+              <button type="submit" id="submit-btn" class="inline-flex items-center justify-center gap-2 rounded-lg bg-cush-orange px-6 py-3 text-sm font-display font-semibold text-black hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed">
+                <span id="submit-text">{dict.contact.formSubmit}</span>
+                <svg id="submit-spinner" class="hidden w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                  <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                  <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+                </svg>
+              </button>
+            </div>
+          </form>
+
+          <div id="form-success" class="hidden text-center py-8">
+            <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-green-100 dark:bg-green-900/30 mb-4">
+              <svg class="w-8 h-8 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
+            </div>
+            <h3 class="font-display text-xl font-bold text-foreground mb-2">Mensaje enviado</h3>
+            <p class="text-muted">Te responderé dentro de 24 horas — usualmente más rápido.</p>
+          </div>
+        </div>
+
+        <aside class="rounded-2xl border border-border bg-surface p-6 md:p-8 lg:order-2 h-fit">
+          <h2 class="font-display text-xl font-bold text-foreground">{dict.contact.infoTitle}</h2>
+          <p class="mt-2 text-muted">{dict.contact.infoSubtitle}</p>
+
+          <div class="mt-6 flex flex-col gap-3">
+            <a id="email-btn" href="mailto:" data-u={emailUser} data-d={emailDomain} data-s={encodeURIComponent("CushLabs Inquiry")} class="inline-flex items-center justify-center gap-2 rounded-lg border border-border bg-canvas/40 px-5 py-3 text-sm font-display font-semibold text-foreground hover:border-cush-orange hover:text-cush-orange transition-colors">
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" /></svg>
+              <span>{dict.contact.sendEmail}</span>
+            </a>
+
+            <a href={whatsappLink} target="_blank" rel="noopener noreferrer" class="inline-flex items-center justify-center gap-2 rounded-lg bg-green-600 px-5 py-3 text-sm font-display font-semibold text-white hover:bg-green-700 transition-colors">
+              <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z"/></svg>
+              <span>{dict.contact.whatsapp}</span>
+            </a>
+          </div>
+
+          <dl class="mt-6 space-y-3 text-sm">
+            <div class="flex items-start justify-between gap-4">
+              <dt class="text-muted">{dict.contact.timezone}</dt>
+              <dd class="text-foreground text-right">{dict.contact.timezoneValue}</dd>
+            </div>
+            <div class="flex items-start justify-between gap-4">
+              <dt class="text-muted">{dict.contact.email}</dt>
+              <dd class="text-foreground text-right"><span id="email-display"></span></dd>
+            </div>
+          </dl>
+
+          <div class="mt-6 pt-6 border-t border-border">
+            <p class="text-sm text-muted mb-3">¿Prefieres hablar en vivo?</p>
+            <a href="/es/reservar/" class="inline-flex items-center gap-2 text-sm font-display font-semibold text-cush-orange hover:opacity-80 transition-opacity">
+              {dict.contact.consultation}
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" /></svg>
+            </a>
+          </div>
+        </aside>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const btn = document.getElementById('email-btn') as HTMLAnchorElement | null;
+      if (btn) {
+        const u = btn.dataset.u;
+        const d = btn.dataset.d;
+        const s = btn.dataset.s;
+        const addr = u + '@' + d;
+        btn.href = 'mailto:' + addr + '?subject=' + s;
+
+        const display = document.getElementById('email-display');
+        if (display) display.textContent = addr;
+      }
+
+      const form = document.getElementById('contact-form-el') as HTMLFormElement | null;
+      if (!form) return;
+
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+
+        const submitBtn = document.getElementById('submit-btn') as HTMLButtonElement;
+        const submitText = document.getElementById('submit-text')!;
+        const spinner = document.getElementById('submit-spinner')!;
+        const errorEl = document.getElementById('form-error')!;
+        const successEl = document.getElementById('form-success')!;
+
+        errorEl.classList.add('hidden');
+
+        const name = (form.querySelector('#name') as HTMLInputElement).value.trim();
+        const email = (form.querySelector('#email') as HTMLInputElement).value.trim();
+        const phone = (form.querySelector('#phone') as HTMLInputElement).value.trim();
+        const message = (form.querySelector('#message') as HTMLTextAreaElement).value.trim();
+        const consent = (form.querySelector('#consent') as HTMLInputElement).checked;
+        const locale = form.dataset.locale || 'es';
+
+        if (!name || !email || !message || !consent) {
+          errorEl.textContent = 'Completa los campos requeridos y acepta los términos.';
+          errorEl.classList.remove('hidden');
+          return;
+        }
+
+        submitBtn.disabled = true;
+        submitText.textContent = 'Enviando...';
+        spinner.classList.remove('hidden');
+
+        try {
+          const res = await fetch('https://formspree.io/f/mlgwnqky', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Accept': 'application/json',
+            },
+            body: JSON.stringify({
+              name,
+              email,
+              _replyto: email,
+              phone: phone || undefined,
+              message,
+              _subject: `New contact from ${name} — CushLabs.ai`,
+              _language: locale,
+            }),
+          });
+
+          const data = await res.json();
+
+          if (!res.ok) {
+            const msg = data.errors?.map((e: { message: string }) => e.message).join(', ') || 'Unknown error';
+            throw new Error(msg);
+          }
+
+          form.classList.add('hidden');
+          successEl.classList.remove('hidden');
+        } catch (err) {
+          errorEl.textContent = 'Hubo un error al enviar. Intenta de nuevo o escríbeme por WhatsApp.';
+          errorEl.classList.remove('hidden');
+
+          submitBtn.disabled = false;
+          submitText.textContent = 'Enviar Mensaje';
+          spinner.classList.add('hidden');
+        }
+      });
+    });
+  </script>
+</BaseLayout>

--- a/src/pages/es/portfolio.astro
+++ b/src/pages/es/portfolio.astro
@@ -1,6 +1,444 @@
 ---
-// Spanish route - reuse the same page logic
-import PortfolioPage from "../portfolio.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import Container from "../../components/layout/Container.astro";
+import Section from "../../components/layout/Section.astro";
+import projectsData from "../../data/projects.generated.json";
+import { getProjectDetailOverride } from "../../data/projectDetails";
+
+const projects = projectsData.projects.filter(p => p.priority < 99);
+const allCategories = [...new Set(projects.flatMap(p => p.categories).filter(Boolean))].sort();
+
+function getThumbnail(project: typeof projects[number]): string {
+  const override = getProjectDetailOverride(project.name);
+  if (override?.thumbnail) return override.thumbnail;
+  if ('thumbnail' in project && project.thumbnail) {
+    const thumb = project.thumbnail as string;
+    if (thumb.startsWith('/images/') || thumb.startsWith('https://cdn.cushlabs.ai/')) return thumb;
+  }
+  if (project.slides?.length > 0 && project.slides[0].src) {
+    return project.slides[0].src;
+  }
+  return '/images/portfolio/default-card.svg';
+}
+
+const locale = "es" as const;
+
+const title = "Proyectos de IA y Casos de Estudio — CushLabs.ai";
+const description = "Sistemas de IA listos para producción: automatización de soporte, procesamiento de documentos y operaciones. Proyectos reales con ROI medible.";
+
+const t = {
+  badge: "Portafolio",
+  headline: "Proyectos Reales de IA — Construidos para Negocios Reales",
+  subheadline: "Chatbots, agentes de voz, automatización y monitoreo de competidores — construidos y desplegados para equipos pequeños en EE.UU. y México.",
+  ctaPrimary: "Agendar Consulta Gratis",
+  ctaSecondary: "Ver Video del Portafolio",
+  reassurance: "Sin pitch de ventas. Sin compromiso. Solo claridad.",
+  filters: { all: "Todo", featured: "Destacados", search: "Buscar proyectos..." },
+  card: { featured: "Destacado", details: "Ver Proyecto", demo: "Demo en Vivo" },
+  empty: { title: "No se encontraron proyectos", subtitle: "Intenta ajustar los filtros" },
+  video: {
+    src: "/videos/CushLabs_AI_Portfolio-es.mp4",
+    poster: "/videos/CushLabs_AI_Portfolio-es-poster.jpg",
+    alt: "Video de Análisis de Portafolio CushLabs",
+  },
+  bottomCta: {
+    headline: "¿Quieres Algo Como Esto Para Tu Negocio?",
+    subtitle: "Agenda una llamada de descubrimiento gratuita y te mostraré cómo una solución similar podría funcionar para ti.",
+    button: "Agendar Llamada",
+  },
+};
 ---
 
-<PortfolioPage />
+<BaseLayout title={title} description={description}>
+  <section class="relative pt-24 pb-16 overflow-hidden">
+    <div class="absolute inset-0 -z-20">
+      <img src="/images/hero/solutuions-hero.webp" alt="CushLabs portfolio of AI and software development projects" loading="eager" fetchpriority="high" width="1920" height="1080" class="w-full h-full object-cover opacity-[0.05] dark:opacity-[0.03]" />
+      <div class="absolute inset-0 bg-gradient-to-b from-white/50 via-transparent to-white dark:from-gray-950/50 dark:via-transparent dark:to-gray-950"></div>
+    </div>
+    <div class="absolute inset-0 -z-10">
+      <div class="absolute top-1/4 left-1/4 w-[500px] h-[500px] bg-cush-orange/15 rounded-full blur-[120px]"></div>
+      <div class="absolute bottom-1/4 right-1/4 w-[400px] h-[400px] bg-cush-orange/10 rounded-full blur-[100px]"></div>
+    </div>
+    <Container>
+      <div class="text-center max-w-3xl mx-auto">
+        <span class="inline-block px-3 py-1 text-xs font-display font-semibold text-cush-orange bg-cush-orange/10 rounded-full mb-4">{t.badge}</span>
+        <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-bold text-gray-900 dark:text-white mb-6 leading-tight">{t.headline}</h1>
+        <p class="text-lg text-gray-600 dark:text-gray-400 mb-8">{t.subheadline}</p>
+
+        <div class="flex flex-col sm:flex-row items-center justify-center gap-4 mb-4">
+          <a href="/es/reservar/" class="group inline-flex items-center gap-2 px-6 py-3 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-all shadow-lg shadow-cush-orange/25">
+            {t.ctaPrimary}
+            <svg class="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" /></svg>
+          </a>
+          <button id="open-video-modal" type="button" class="group inline-flex items-center gap-2 px-6 py-3 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 font-display font-semibold rounded-lg hover:border-cush-orange hover:text-cush-orange transition-all">
+            {t.ctaSecondary}
+            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M8 5v14l11-7z" /></svg>
+          </button>
+        </div>
+
+        <p class="text-sm text-gray-500 dark:text-gray-500">{t.reassurance}</p>
+      </div>
+    </Container>
+  </section>
+
+  <dialog id="video-modal" class="video-modal">
+    <div class="video-modal-backdrop" data-close-modal></div>
+    <div class="video-modal-content">
+      <button type="button" class="video-modal-close" data-close-modal aria-label="Close">
+        <svg class="w-6 h-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+      </button>
+      <div class="relative aspect-video bg-black rounded-xl overflow-hidden">
+        <div id="modal-poster" class="absolute inset-0 cursor-pointer group z-10">
+          <img src={t.video.poster} alt={t.video.alt} width="1280" height="720" class="w-full h-full object-cover" />
+          <div class="absolute inset-0 flex items-center justify-center bg-black/20 group-hover:bg-black/30 transition-colors">
+            <div class="w-20 h-20 rounded-full bg-cush-orange/90 flex items-center justify-center group-hover:bg-cush-orange group-hover:scale-110 transition-all duration-300 shadow-lg shadow-black/30">
+              <svg class="w-10 h-10 text-white ml-1" fill="currentColor" viewBox="0 0 24 24"><path d="M8 5v14l11-7z" /></svg>
+            </div>
+          </div>
+        </div>
+        <video id="modal-video" class="w-full h-full object-contain" controls preload="none" playsinline>
+          <source src={t.video.src} type="video/mp4" />
+          <track kind="captions" />
+        </video>
+      </div>
+    </div>
+  </dialog>
+
+  <Section id="projects" spacing="sm">
+    <Container>
+      <div class="flex justify-center mb-6">
+        <div class="relative w-full max-w-md">
+          <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>
+          <input type="text" id="search-input" placeholder={t.filters.search} class="w-full pl-9 pr-4 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 font-display text-sm text-gray-700 dark:text-gray-300 placeholder-gray-400 dark:placeholder-gray-500 focus:border-cush-orange focus:outline-none focus:ring-1 focus:ring-cush-orange transition-all" />
+        </div>
+      </div>
+
+      <div class="flex flex-wrap gap-2 justify-center mb-4" id="filters">
+        <button class="filter-btn active px-4 py-2 rounded-lg border border-cush-orange bg-cush-orange/10 font-display text-sm font-semibold text-cush-orange transition-all" data-filter="featured">{t.filters.featured}</button>
+        <button class="filter-btn px-4 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-transparent font-display text-sm font-semibold text-gray-600 dark:text-gray-400 hover:border-cush-orange hover:text-cush-orange transition-all" data-filter="all">{t.filters.all}</button>
+        {allCategories.map(cat => (
+          <button class="filter-btn px-4 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-transparent font-display text-sm font-semibold text-gray-600 dark:text-gray-400 hover:border-cush-orange hover:text-cush-orange transition-all" data-filter={`cat:${cat}`}>{cat}</button>
+        ))}
+      </div>
+
+      <p id="showing-count" class="text-center text-sm text-gray-500 dark:text-gray-400 mb-8 font-display">
+        {`Mostrando ${projects.length} de ${projects.length} proyectos`}
+      </p>
+
+      <div id="projects-grid" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {projects.map((project) => {
+          const thumb = getThumbnail(project);
+          const detailHref = `/es/projects/${project.name}/`;
+          const tagline = project.tagline || project.summary || project.description || "";
+          const category = project.categories[0] || null;
+          const techBadges = project.stack.slice(0, 4);
+          const searchText = [project.title, tagline, category, ...project.stack, ...project.tags].filter(Boolean).join(" ").toLowerCase();
+
+          return (
+            <article
+              class:list={[
+                "project-card group relative flex flex-col bg-white dark:bg-gray-900 border rounded-xl overflow-hidden transition-all duration-300 hover:-translate-y-1 hover:shadow-lg",
+                project.isFeatured ? "border-cush-orange/50" : "border-gray-200 dark:border-gray-800 hover:border-cush-orange/30"
+              ]}
+              data-categories={project.categories.join(",")}
+              data-featured={String(project.isFeatured)}
+              data-search={searchText}
+            >
+              <a href={detailHref} class="block">
+                <div class="aspect-[16/9] overflow-hidden bg-gray-100 dark:bg-gray-800 shimmer">
+                  {thumb ? (
+                    <img src={thumb} alt={project.title} loading="lazy" width="760" height="428" class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300 img-fade" onload="this.classList.add('loaded');this.parentElement.classList.remove('shimmer')" />
+                  ) : (
+                    <div class="w-full h-full flex items-center justify-center">
+                      <span class="font-display text-2xl font-bold text-gray-300 dark:text-gray-600">{project.title.slice(0, 2)}</span>
+                    </div>
+                  )}
+                </div>
+              </a>
+
+              <div class="flex flex-col flex-1 p-5">
+                <div class="flex items-center gap-2 mb-3 flex-wrap">
+                  {category && (
+                    <span class="px-2 py-0.5 bg-cush-orange/10 text-cush-orange text-xs font-display font-semibold rounded">{category}</span>
+                  )}
+                  {project.status && (
+                    <span class:list={[
+                      "px-2 py-0.5 text-xs font-display font-semibold rounded",
+                      project.status === "Production" ? "bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400" :
+                      project.status === "Demo" ? "bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400" :
+                      "bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400"
+                    ]}>
+                      {project.status === "Production" ? "Produccion" :
+                       project.status === "Demo" ? "Demo" :
+                       project.status === "Archived" ? "Archivado" :
+                       project.status}
+                    </span>
+                  )}
+                  {project.isFeatured && (
+                    <span class="px-2 py-0.5 bg-cush-orange text-white text-xs font-display font-semibold rounded">{t.card.featured}</span>
+                  )}
+                </div>
+
+                <h2 class="font-display text-lg font-bold text-gray-900 dark:text-white mb-1.5 leading-tight">
+                  <a href={detailHref} class="hover:text-cush-orange transition-colors">{project.title}</a>
+                </h2>
+
+                <p class="text-sm text-gray-600 dark:text-gray-400 mb-4 line-clamp-2">{tagline}</p>
+
+                <div class="flex flex-wrap gap-1.5 mb-4 mt-auto">
+                  {techBadges.map((tech) => (
+                    <span class="px-2 py-0.5 bg-gray-100 dark:bg-gray-800 rounded text-xs text-gray-500 dark:text-gray-400 font-display">{tech}</span>
+                  ))}
+                </div>
+
+                <div class="flex items-center gap-2 pt-3 border-t border-gray-100 dark:border-gray-800">
+                  <a href={detailHref} class="inline-flex items-center gap-1 px-3 py-1.5 bg-cush-orange text-white text-xs font-display font-semibold rounded hover:bg-cush-orange/90 transition-all">{t.card.details} →</a>
+                  {project.demoUrl && (
+                    <a href={project.demoUrl} target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 px-3 py-1.5 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300 text-xs font-display font-semibold rounded hover:border-cush-orange hover:text-cush-orange transition-all">{t.card.demo} ↗</a>
+                  )}
+                </div>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+
+      <div id="empty" class="hidden text-center py-24">
+        <h3 class="font-display text-2xl font-bold text-gray-900 dark:text-white mb-4">{t.empty.title}</h3>
+        <p class="text-gray-600 dark:text-gray-400">{t.empty.subtitle}</p>
+      </div>
+    </Container>
+  </Section>
+
+  <Section spacing="xl" class="bg-gray-900 dark:bg-black">
+    <Container size="md">
+      <div class="relative text-center">
+        <div class="absolute inset-0 -z-10">
+          <div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[500px] h-[250px] bg-cush-orange/20 rounded-full blur-[80px]"></div>
+        </div>
+        <h2 class="text-3xl md:text-4xl font-display font-bold text-white mb-4">{t.bottomCta.headline}</h2>
+        <p class="text-lg text-gray-400 mb-8 max-w-xl mx-auto">{t.bottomCta.subtitle}</p>
+        <a href="/es/reservar/" class="group inline-flex items-center gap-2 px-8 py-4 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-all shadow-lg shadow-cush-orange/25">
+          {t.bottomCta.button}
+          <svg class="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" /></svg>
+        </a>
+      </div>
+    </Container>
+  </Section>
+</BaseLayout>
+
+<script>
+  const modal = document.getElementById('video-modal') as HTMLDialogElement;
+  const openBtn = document.getElementById('open-video-modal');
+  const modalVideo = document.getElementById('modal-video') as HTMLVideoElement | null;
+  const modalPoster = document.getElementById('modal-poster');
+
+  function closeModal() {
+    if (!modal || !modalVideo || !modalPoster) return;
+    modalVideo.pause();
+    modalVideo.currentTime = 0;
+    modalPoster.classList.remove('hidden');
+    modal.close();
+  }
+
+  if (modal && openBtn && modalVideo && modalPoster) {
+    openBtn.addEventListener('click', () => {
+      modalVideo.preload = 'auto';
+      modal.showModal();
+    });
+
+    modalPoster.addEventListener('click', () => {
+      modalPoster.classList.add('hidden');
+      modalVideo.play();
+    });
+
+    modal.querySelectorAll('[data-close-modal]').forEach((el) => {
+      el.addEventListener('click', closeModal);
+    });
+
+    modal.addEventListener('close', () => {
+      modalVideo.pause();
+      modalVideo.currentTime = 0;
+      modalPoster.classList.remove('hidden');
+    });
+
+    modalVideo.addEventListener('ended', closeModal);
+  }
+</script>
+
+<script>
+  let currentFilter = "featured";
+  let searchQuery = "";
+  let debounceTimer: ReturnType<typeof setTimeout>;
+  const totalProjects = document.querySelectorAll(".project-card").length;
+  const showingCountEl = document.getElementById("showing-count");
+
+  function setFilter(filter: string) {
+    currentFilter = filter;
+
+    document.querySelectorAll(".filter-btn").forEach((btn) => {
+      if (!(btn instanceof HTMLButtonElement)) return;
+      const isActive = btn.getAttribute("data-filter") === filter;
+
+      if (isActive) {
+        btn.classList.add("border-cush-orange", "bg-cush-orange/10", "text-cush-orange");
+        btn.classList.remove("border-gray-200", "dark:border-gray-700", "text-gray-600", "dark:text-gray-400");
+      } else {
+        btn.classList.remove("border-cush-orange", "bg-cush-orange/10", "text-cush-orange");
+        btn.classList.add("border-gray-200", "dark:border-gray-700", "text-gray-600", "dark:text-gray-400");
+      }
+    });
+
+    renderProjects();
+  }
+
+  function renderProjects() {
+    const projects = document.querySelectorAll(".project-card");
+    let visibleCount = 0;
+    const query = searchQuery.toLowerCase().trim();
+
+    projects.forEach((card) => {
+      if (!(card instanceof HTMLElement)) return;
+      const isFeatured = card.getAttribute("data-featured") === "true";
+      const categories = (card.getAttribute("data-categories") || "").split(",");
+      const searchData = card.getAttribute("data-search") || "";
+
+      let show = true;
+      if (currentFilter === "featured") {
+        show = isFeatured;
+      } else if (currentFilter.startsWith("cat:")) {
+        const cat = currentFilter.replace("cat:", "");
+        show = categories.includes(cat);
+      }
+
+      if (show && query) {
+        show = searchData.includes(query);
+      }
+
+      card.style.display = show ? "flex" : "none";
+      if (show) visibleCount++;
+    });
+
+    if (showingCountEl) {
+      showingCountEl.textContent = `Mostrando ${visibleCount} de ${totalProjects} proyectos`;
+    }
+
+    const empty = document.getElementById("empty");
+    const projectsGrid = document.getElementById("projects-grid") as HTMLElement | null;
+    if (visibleCount === 0) {
+      empty?.classList.remove("hidden");
+      if (projectsGrid) projectsGrid.classList.add("hidden");
+    } else {
+      empty?.classList.add("hidden");
+      if (projectsGrid) projectsGrid.classList.remove("hidden");
+    }
+  }
+
+  document.querySelectorAll(".filter-btn").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      if (!(btn instanceof HTMLButtonElement)) return;
+      const filter = btn.getAttribute("data-filter");
+      if (filter) setFilter(filter);
+    });
+  });
+
+  const searchInput = document.getElementById("search-input") as HTMLInputElement | null;
+  searchInput?.addEventListener("input", () => {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      searchQuery = searchInput.value;
+      renderProjects();
+    }, 200);
+  });
+
+  renderProjects();
+</script>
+
+<style>
+  .video-modal {
+    position: fixed;
+    inset: 0;
+    width: 100vw;
+    height: 100vh;
+    max-width: 100vw;
+    max-height: 100vh;
+    margin: 0;
+    padding: 0;
+    border: none;
+    background: transparent;
+    overflow: hidden;
+  }
+
+  .video-modal::backdrop {
+    background: rgba(0, 0, 0, 0.9);
+  }
+
+  .video-modal-backdrop {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+  }
+
+  .video-modal-content {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    padding: 2rem;
+  }
+
+  .video-modal-content > .relative {
+    width: 100%;
+    max-width: 64rem;
+  }
+
+  .video-modal-close {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    z-index: 20;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 9999px;
+    background: rgba(0, 0, 0, 0.5);
+    color: white;
+    border: none;
+    cursor: pointer;
+    transition: background-color 0.2s;
+  }
+
+  .video-modal-close:hover {
+    background: rgba(0, 0, 0, 0.8);
+  }
+
+  .video-modal[open] {
+    animation: modal-fade-in 0.2s ease-out;
+  }
+
+  .video-modal[open]::backdrop {
+    animation: backdrop-fade-in 0.2s ease-out;
+  }
+
+  @keyframes modal-fade-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+
+  @keyframes backdrop-fade-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+
+  .line-clamp-2 {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+</style>

--- a/src/pages/es/reservar.astro
+++ b/src/pages/es/reservar.astro
@@ -1,5 +1,82 @@
 ---
-import ConsultationPage from "../consultation.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BookingFormSteps from "../../components/booking/BookingFormSteps.astro";
+import { t } from "../../i18n";
+
+const locale = "es" as const;
+const dict = t(locale);
 ---
 
-<ConsultationPage />
+<BaseLayout
+  title={`${dict.consultation.title} | CushLabs.ai`}
+  description={dict.consultation.description}
+>
+  <main class="pb-24">
+    <section class="relative overflow-hidden border-b border-border">
+      <div class="absolute inset-0 -z-10">
+        <div class="absolute inset-0 bg-gradient-to-br from-cush-orange/15 via-transparent to-transparent"></div>
+        <div class="absolute -left-24 top-16 h-64 w-64 rounded-full bg-cush-orange/10 blur-3xl"></div>
+      </div>
+
+      <div class="mx-auto max-w-7xl px-4 py-14 md:py-18">
+        <div class="max-w-3xl">
+          <p class="inline-flex items-center rounded-full border border-border bg-surface px-3 py-1 text-xs font-display font-semibold uppercase tracking-wider text-muted">
+            {dict.consultation.kicker}
+          </p>
+          <h1 class="mt-4 font-display text-4xl font-bold text-foreground tracking-tight md:text-6xl">
+            {dict.consultation.headline}
+          </h1>
+          <p class="mt-4 max-w-2xl text-lg text-muted">
+            {dict.consultation.subheadline}
+          </p>
+
+          <div class="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
+            <a
+              href="#schedule"
+              class="inline-flex items-center justify-center gap-2 rounded-xl bg-cush-orange px-6 py-3 text-sm font-display font-semibold text-black hover:opacity-90 transition-opacity glow-orange"
+            >
+              {dict.consultation.primaryCta}
+              <span aria-hidden="true">→</span>
+            </a>
+            <a
+              href="/es/portfolio/"
+              class="inline-flex items-center justify-center gap-2 rounded-xl border border-border bg-surface px-6 py-3 text-sm font-display font-semibold text-foreground hover:border-cush-orange hover:text-cush-orange transition-colors"
+            >
+              {dict.consultation.secondaryCta}
+            </a>
+          </div>
+
+          <dl class="mt-10 grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div class="rounded-2xl border border-border bg-surface p-4">
+              <dt class="text-xs font-display font-semibold uppercase tracking-wider text-muted">{dict.consultation.detail1Label}</dt>
+              <dd class="mt-2 text-sm font-display font-semibold text-foreground">{dict.consultation.detail1Value}</dd>
+            </div>
+            <div class="rounded-2xl border border-border bg-surface p-4">
+              <dt class="text-xs font-display font-semibold uppercase tracking-wider text-muted">{dict.consultation.detail2Label}</dt>
+              <dd class="mt-2 text-sm font-display font-semibold text-foreground">{dict.consultation.detail2Value}</dd>
+            </div>
+            <div class="rounded-2xl border border-border bg-surface p-4">
+              <dt class="text-xs font-display font-semibold uppercase tracking-wider text-muted">{dict.consultation.detail3Label}</dt>
+              <dd class="mt-2 text-sm font-display font-semibold text-foreground">{dict.consultation.detail3Value}</dd>
+            </div>
+          </dl>
+        </div>
+      </div>
+    </section>
+
+    <section id="schedule" class="mx-auto max-w-7xl px-4 pt-10">
+      <BookingFormSteps locale={locale} />
+
+      <div class="mt-8 grid grid-cols-1 gap-4 md:grid-cols-2 max-w-4xl mx-auto">
+        <div class="rounded-2xl border border-border bg-surface p-6">
+          <h3 class="font-display text-lg font-bold text-foreground">{dict.consultation.whatWeCoverTitle}</h3>
+          <p class="mt-2 text-muted">{dict.consultation.whatWeCoverBody}</p>
+        </div>
+        <div class="rounded-2xl border border-border bg-surface p-6">
+          <h3 class="font-display text-lg font-bold text-foreground">{dict.consultation.afterCallTitle}</h3>
+          <p class="mt-2 text-muted">{dict.consultation.afterCallBody}</p>
+        </div>
+      </div>
+    </section>
+  </main>
+</BaseLayout>

--- a/src/pages/es/services.astro
+++ b/src/pages/es/services.astro
@@ -1,6 +1,30 @@
 ---
-// Spanish route - reuse the same page logic
-import ServicesPage from "../services.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import Hero from "../../components/services2/Hero.astro";
+import ScenarioQualifier from "../../components/services2/ScenarioQualifier.astro";
+import ServiceBlock from "../../components/services2/ServiceBlock.astro";
+import HowIWork from "../../components/services2/HowIWork.astro";
+import WhoItIsFor from "../../components/services2/WhoItIsFor.astro";
+import InvestmentOverview from "../../components/services2/InvestmentOverview.astro";
+import FAQ from "../../components/services2/FAQ.astro";
+import FinalCTA from "../../components/services2/FinalCTA.astro";
+
+const locale = "es" as const;
+
+const title = "Servicios y Precios — Chatbots de IA, Agentes de Voz y Automatización | CushLabs.ai";
+const description = "Chatbots de atención al cliente, monitoreo de competidores en Google Maps, automatización de procesos a la medida y sesiones de estrategia. Precios claros, bilingüe EN/ES.";
 ---
 
-<ServicesPage />
+<BaseLayout title={title} description={description}>
+  <Hero locale={locale} />
+  <ScenarioQualifier locale={locale} />
+  <ServiceBlock locale={locale} id="support-assistants" />
+  <ServiceBlock locale={locale} id="competitive-intelligence" isAlternate={true} />
+  <ServiceBlock locale={locale} id="custom-tools" />
+  <ServiceBlock locale={locale} id="clarity-sprint" isAlternate={true} />
+  <HowIWork locale={locale} />
+  <WhoItIsFor locale={locale} />
+  <InvestmentOverview locale={locale} />
+  <FAQ locale={locale} />
+  <FinalCTA locale={locale} />
+</BaseLayout>

--- a/src/pages/es/video.astro
+++ b/src/pages/es/video.astro
@@ -1,6 +1,115 @@
 ---
-// Spanish route - reuse the same page logic
-import VideoPage from "../video.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import Container from "../../components/layout/Container.astro";
+
+const locale = "es" as const;
+const DEFAULT_VIDEO = "CushLabs_AI_Portfolio";
+
+const t = {
+  title: "Ver Video | CushLabs.ai",
+  description: "Mira las soluciones de IA de CushLabs en acción — demos reales de chatbots, herramientas de automatización y apps a medida para PYMES. Resultados comprobables.",
+  badge: "Ver Video",
+  headline: "Míralo en Acción",
+  subheadline: "Descubre cómo la IA encaja en tu negocio.",
+  playLabel: "Reproducir video",
+  ctaPrimary: "Agendar Llamada Gratis",
+  ctaSecondary: "Ver Portafolio",
+  reassurance: "Sin pitch de ventas. Sin compromiso. Solo claridad.",
+};
+
+const esSuffix = "-es";
+const defaultVideoSrc = `/videos/${DEFAULT_VIDEO}${esSuffix}.mp4`;
+const defaultPoster = `/videos/${DEFAULT_VIDEO}${esSuffix}-poster.jpg`;
 ---
 
-<VideoPage />
+<BaseLayout title={t.title} description={t.description}>
+  <main class="py-[8vh] md:py-[10vh]">
+    <section class="relative overflow-hidden">
+      <div class="absolute inset-0 -z-10">
+        <div class="absolute top-1/4 left-1/4 w-[500px] h-[500px] bg-cush-orange/10 rounded-full blur-[120px]"></div>
+        <div class="absolute bottom-1/4 right-1/3 w-[400px] h-[400px] bg-cush-orange/5 rounded-full blur-[100px]"></div>
+      </div>
+
+      <Container size="md">
+        <div class="text-center mb-[5vh]">
+          <span class="inline-block px-3 py-1 text-xs font-display font-semibold text-cush-orange bg-cush-orange/10 rounded-full mb-4">{t.badge}</span>
+          <h1 class="font-display text-4xl md:text-5xl font-bold text-gray-900 dark:text-white mb-4 leading-tight">{t.headline}</h1>
+          <p class="text-xl md:text-2xl text-gray-600 dark:text-gray-400 max-w-2xl mx-auto font-light">{t.subheadline}</p>
+        </div>
+
+        <div class="px-[2vw]">
+          <div class="relative rounded-2xl overflow-hidden border border-border bg-black shadow-2xl shadow-black/20">
+            <div id="video-container" class="relative aspect-video cursor-pointer group">
+              <div id="video-poster" class="absolute inset-0 z-10">
+                <img id="poster-img" src={defaultPoster} alt={t.headline} width="1280" height="720" class="w-full h-full object-cover" fetchpriority="high" />
+                <div class="absolute inset-0 flex items-center justify-center bg-black/20 group-hover:bg-black/30 transition-colors">
+                  <div class="text-center">
+                    <div class="w-20 h-20 md:w-24 md:h-24 mx-auto mb-4 rounded-full bg-cush-orange/90 flex items-center justify-center group-hover:bg-cush-orange group-hover:scale-110 transition-all duration-300 shadow-lg shadow-black/30">
+                      <svg class="w-10 h-10 md:w-12 md:h-12 text-white ml-1" fill="currentColor" viewBox="0 0 24 24"><path d="M8 5v14l11-7z" /></svg>
+                    </div>
+                    <p class="text-white font-display font-medium text-lg drop-shadow-md">{t.playLabel}</p>
+                  </div>
+                </div>
+              </div>
+              <video id="video-player" class="w-full h-full object-contain bg-black hidden" controls playsinline preload="none">
+                <source id="video-source" src={defaultVideoSrc} type="video/mp4" />
+                <track kind="captions" />
+              </video>
+            </div>
+          </div>
+        </div>
+
+        <div class="mt-[5vh] text-center">
+          <div class="flex flex-col sm:flex-row items-center justify-center gap-4 mb-4">
+            <a href="/es/reservar/" class="group inline-flex items-center gap-2 px-6 py-3 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-all shadow-lg shadow-cush-orange/25">
+              {t.ctaPrimary}
+              <svg class="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" /></svg>
+            </a>
+            <a href="/es/portfolio/" class="group inline-flex items-center gap-2 px-6 py-3 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 font-display font-semibold rounded-lg hover:border-cush-orange hover:text-cush-orange transition-all">
+              {t.ctaSecondary}
+              <svg class="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" /></svg>
+            </a>
+          </div>
+          <p class="text-sm text-gray-500 dark:text-gray-500">{t.reassurance}</p>
+        </div>
+      </Container>
+    </section>
+  </main>
+
+  <script define:vars={{ DEFAULT_VIDEO, esSuffix }}>
+    const poster = document.getElementById('video-poster');
+    const posterImg = document.getElementById('poster-img');
+    const video = document.getElementById('video-player');
+    const source = document.getElementById('video-source');
+
+    if (poster && video && source && posterImg) {
+      const params = new URLSearchParams(window.location.search);
+      const videoName = params.get('v');
+
+      if (videoName && videoName !== DEFAULT_VIDEO) {
+        const safe = videoName.replace(/[^a-zA-Z0-9_\-]/g, '');
+        source.setAttribute('src', `/videos/${safe}${esSuffix}.mp4`);
+        posterImg.setAttribute('src', `/videos/${safe}${esSuffix}-poster.jpg`);
+      }
+
+      if ('requestIdleCallback' in window) {
+        requestIdleCallback(() => { video.preload = 'auto'; }, { timeout: 3000 });
+      } else {
+        setTimeout(() => { video.preload = 'auto'; }, 2000);
+      }
+
+      poster.addEventListener('click', () => {
+        poster.classList.add('hidden');
+        video.classList.remove('hidden');
+        video.play();
+      });
+
+      video.addEventListener('ended', () => {
+        video.pause();
+        video.currentTime = 0;
+        video.classList.add('hidden');
+        poster.classList.remove('hidden');
+      });
+    }
+  </script>
+</BaseLayout>


### PR DESCRIPTION
## Summary
- **Production issue**: every Spanish page on cushlabs.ai/es/* shipped as raw unstyled HTML — no Tailwind, broken layout
- **Root cause**: `src/pages/es/*.astro` files were thin wrappers that imported the English page as a component (e.g. `import IndexPage from "../index.astro"`). Astro's CSS bundler does not crawl through page-as-component imports, so the resulting Spanish pages had no `<link rel="stylesheet">` in `<head>`
- **Fix**: rewrote each broken ES wrapper as a real page that imports `BaseLayout` + sub-components directly with `locale="es"` (or hardcoded ES content)

Files fixed:
- `es/index.astro`
- `es/about.astro`
- `es/contact.astro`
- `es/portfolio.astro`
- `es/services.astro`
- `es/reservar.astro`
- `es/video.astro`

`es/faq.astro`, `es/privacy.astro`, `es/terms.astro` were already real pages and not affected.

## Test plan
- [x] `npm run build` succeeds (89 pages)
- [x] All 44 `dist/es/**/index.html` files contain the `_astro/BaseLayout.*.css` link
- [ ] Visual smoke check on Vercel preview for `/es/`, `/es/about/`, `/es/contact/`, `/es/portfolio/`, `/es/services/`, `/es/reservar/`, `/es/video/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)