### PR TITLE
feat: services hero rewrite — AI Messenger Assistant becomes the lead

### DIFF
--- a/src/components/services2/ScenarioQualifier.astro
+++ b/src/components/services2/ScenarioQualifier.astro
@@ -26,10 +26,10 @@ const content = {
         anchor: "#support-assistants"
       },
       {
-        iconKey: "eye",
-        title: "My competitors keep showing up above me on Google",
-        body: "They have more reviews, better ratings, and higher positions. You don't know how they got there, what changed, or how to respond. By the time you notice a trend, you've already lost customers.",
-        linkText: "→ Google Maps Competitor Tracking",
+        iconKey: "chat",
+        title: "Customers message my Facebook page after hours and I lose them",
+        body: "Someone messages at 10pm asking about pricing or availability. By morning they've booked with the competitor who answered in two minutes. Meanwhile your team answers the same five questions a hundred times a week.",
+        linkText: "→ AI Messenger Assistant",
         anchor: "#competitive-intelligence"
       },
       {
@@ -59,10 +59,10 @@ const content = {
         anchor: "#support-assistants"
       },
       {
-        iconKey: "eye",
-        title: "Mis competidores aparecen arriba de mí en Google",
-        body: "Tienen más reseñas, mejores calificaciones y posiciones más altas. No sabes cómo llegaron ahí, qué cambió, ni cómo responder. Cuando notas la tendencia, ya perdiste clientes.",
-        linkText: "→ Monitoreo de Competidores en Google Maps",
+        iconKey: "chat",
+        title: "Mis clientes me escriben en Facebook fuera de horario y los pierdo",
+        body: "Alguien escribe a las 10 de la noche preguntando precios o disponibilidad. Para la mañana ya reservó con el competidor que contestó en dos minutos. Mientras tanto tu equipo contesta las mismas cinco preguntas cien veces a la semana.",
+        linkText: "→ Asistente de IA en Messenger",
         anchor: "#competitive-intelligence"
       },
       {

--- a/src/components/services2/ServiceBlock.astro
+++ b/src/components/services2/ServiceBlock.astro
@@ -75,61 +75,61 @@ const data = {
   },
   'competitive-intelligence': {
     en: {
-      heading: "Google Maps Competitor Tracking",
-      subheading: "See who's beating you on Google Maps — rankings, reviews, and ratings — delivered to your WhatsApp every week.",
-      problem: "Your competitors are gaining reviews, climbing Google Maps rankings, and capturing customers who should be yours. You check manually when you remember, but by the time you notice a trend, it's already cost you business. You're making decisions about your market without knowing what's actually happening in it.",
-      whatIBuild: "A competitive monitoring system that tracks your competitors across Google Maps — rankings, reviews, ratings, and movement patterns — and delivers actionable intelligence straight to your WhatsApp every week.\n\nNo dashboards you'll forget to check. No PDF reports you'll never open. Clear, weekly insights with one specific action you can take right now to stay ahead.",
+      heading: "An AI Assistant on Your Facebook Page That Sells While You Sleep",
+      subheading: "Every message answered in seconds. Every customer captured. Every question handled in their language — in your voice — 24 hours a day.",
+      problem: "A customer messages your Facebook page at 10pm asking if you have their size, their date, their flavor. You see it the next morning. By then, they've booked with the competitor who answered in two minutes.\n\nMeanwhile, you're answering the same five questions a hundred times a week — what are your hours, do you deliver, how much, do you have it in red — and it's eating the time you should be spending growing the business.\n\nYou don't need another inbox to check. You need someone answering it for you.",
+      whatIBuild: "A custom AI assistant that lives on your Facebook Messenger and answers your customers the instant they reach out — in Spanish or English, in your brand's voice, trained on your products, your prices, your policies.\n\nIt recommends the right product. It books the appointment. It handles the FAQ a hundred times a day without complaining. And when a real human is needed, it hands the conversation off to you with the context already gathered.\n\nIt's not a generic chatbot. It's an assistant built around your business — the way a great employee would be, except it works every hour and never asks for a raise.",
       included: [
-        { title: "Competitor mapping & baseline", desc: "I identify your top 5–10 local competitors, establish baseline metrics, and map the competitive landscape you're operating in" },
-        { title: "Google Maps position tracking", desc: "Weekly ranking snapshots showing where you stand vs. competitors — and what's changing" },
-        { title: "Review velocity monitoring", desc: "Track who's gaining reviews fastest, who's slipping, and what it means for your visibility" },
-        { title: "Weekly WhatsApp intelligence report", desc: "Monday morning insights delivered directly to your phone — position changes, competitor moves, and trend analysis" },
-        { title: "Threat alerts & early warnings", desc: "When a competitor makes a significant move — review surge, rating jump, new location — you know immediately" },
-        { title: "One clear action item per week", desc: "Not a generic to-do list. A specific, actionable recommendation based on what the data is showing this week" },
-        { title: "Monthly performance dashboard", desc: "Visual trends, progress tracking, and competitive position over time" }
+        { title: "Custom training on your business", desc: "Products, prices, hours, policies, tone, the works — trained on what you actually sell and how you actually talk" },
+        { title: "Bilingual conversations (EN/ES)", desc: "Fluent Spanish and English, switches automatically based on what the customer writes" },
+        { title: "Smart product & service recommendations", desc: "Guides customers toward the right purchase instead of dumping a catalog on them" },
+        { title: "Appointment booking & lead capture", desc: "Collects the details you need — name, contact, intent — and routes them where they belong" },
+        { title: "Human handoff", desc: "Escalates to you with full context when the conversation actually needs a human" },
+        { title: "Weekly performance report", desc: "What your customers are asking, what's converting, what to improve — delivered every Monday" },
+        { title: "Monthly tuning", desc: "I refine the assistant as your business evolves — new products, new pricing, new seasons" }
       ],
       notIncluded: [
-        "SEO, Google Ads, or paid advertising management",
-        "Review generation or response writing (I can recommend partners)",
-        "Social media management or content creation"
+        "Multi-page or franchise setups beyond a single Facebook page (scoped separately)",
+        "Generating new marketing content — the assistant uses YOUR voice and YOUR products",
+        "Paid Facebook ad management or social posting"
       ],
-      timeline: "Live within 1 week. First intelligence report within 5 business days of kickoff.",
-      investment: "Monthly service starting at **$299/month** for single-location monitoring with up to 5 competitors. Multi-location and expanded competitor tracking typically **$499–$1,500/month**.",
-      investmentDisclaimer: "Setup is included in the first month. No long-term contracts — cancel anytime.",
+      timeline: "Live in 2 weeks. Discovery call → training → testing → launch.",
+      investment: "From **$499/month** for single-page setup with unlimited conversations, fully managed by me. Multi-page or higher-volume setups quoted after discovery.",
+      investmentDisclaimer: "No long-term contracts. Cancel anytime.",
       bestFor: [
-        "Local businesses with 5+ competitors on Google Maps",
-        "Multi-location businesses tracking competitive position across markets",
-        "Businesses where Google reviews and visibility directly drive revenue",
-        "Owners who want data-driven decisions, not gut-feel guesses"
+        "Local businesses losing leads to slow response times",
+        "Owners drowning in repeat questions on Messenger and Instagram",
+        "Businesses with bilingual customers (Spanish + English)",
+        "Anyone whose competitors are responding faster than they are"
       ]
     },
     es: {
-      heading: "Monitoreo de Competidores en Google Maps",
-      subheading: "Mira quién te está ganando en Google Maps — rankings, reseñas y calificaciones — entregado a tu WhatsApp cada semana.",
-      problem: "Tus competidores ganan reseñas, suben en Google Maps y captan clientes que deberían ser tuyos. Revisas manualmente cuando te acuerdas, pero cuando notas una tendencia, ya te costó negocio. Tomas decisiones sin saber qué está pasando realmente en tu mercado.",
-      whatIBuild: "Un sistema de monitoreo competitivo que rastrea a tus competidores en Google Maps — rankings, reseñas, calificaciones y patrones de movimiento — y te entrega inteligencia accionable directo a tu WhatsApp cada semana.\n\nSin dashboards que olvidarás revisar. Sin PDFs que nunca abrirás. Información clara con una acción específica que puedes tomar ahora mismo para mantenerte adelante.",
+      heading: "Un Asistente de IA en tu Página de Facebook que Vende Mientras Duermes",
+      subheading: "Cada mensaje contestado en segundos. Cada cliente capturado. Cada pregunta resuelta en su idioma — con tu voz — las 24 horas del día.",
+      problem: "Un cliente le escribe a tu página de Facebook a las 10 de la noche preguntando si tienes su talla, su fecha, su sabor. Lo ves a la mañana siguiente. Para entonces, ya reservó con el competidor que le contestó en dos minutos.\n\nMientras tanto, tú contestas las mismas cinco preguntas cien veces a la semana — cuál es tu horario, si entregas a domicilio, cuánto cuesta, si lo tienes en rojo — y eso te está comiendo el tiempo que deberías estar usando para hacer crecer el negocio.\n\nNo necesitas otra bandeja de entrada que revisar. Necesitas a alguien que la conteste por ti.",
+      whatIBuild: "Un asistente de IA a la medida que vive en tu Facebook Messenger y le contesta a tus clientes en el instante en que escriben — en español o en inglés, con la voz de tu marca, entrenado con tus productos, tus precios y tus políticas.\n\nRecomienda el producto correcto. Agenda la cita. Contesta las preguntas frecuentes cien veces al día sin quejarse. Y cuando se necesita un humano de verdad, te pasa la conversación con todo el contexto ya levantado.\n\nNo es un chatbot genérico. Es un asistente construido alrededor de tu negocio — como sería un gran empleado, excepto que trabaja a toda hora y nunca pide aumento.",
       included: [
-        { title: "Mapeo competitivo y línea base", desc: "Identifico a tus 5–10 competidores principales, establezco métricas de referencia y mapeo el panorama competitivo" },
-        { title: "Seguimiento de posición en Google Maps", desc: "Capturas semanales mostrando tu posición vs. competidores y qué está cambiando" },
-        { title: "Monitoreo de velocidad de reseñas", desc: "Quién gana reseñas más rápido, quién baja, y qué significa para tu visibilidad" },
-        { title: "Reporte semanal de inteligencia por WhatsApp", desc: "Insights los lunes directo a tu teléfono — cambios de posición, movimientos competitivos y análisis de tendencias" },
-        { title: "Alertas de amenazas tempranas", desc: "Cuando un competidor hace un movimiento importante — avalancha de reseñas, salto de calificación — lo sabes de inmediato" },
-        { title: "Una acción clara por semana", desc: "No una lista genérica. Una recomendación específica basada en los datos de esta semana" },
-        { title: "Dashboard mensual de rendimiento", desc: "Tendencias visuales y seguimiento de tu posición competitiva en el tiempo" }
+        { title: "Entrenamiento personalizado", desc: "Productos, precios, horarios, políticas, tono — entrenado con lo que realmente vendes y cómo realmente hablas" },
+        { title: "Conversaciones bilingües (EN/ES)", desc: "Español e inglés con fluidez, cambia automáticamente según el idioma del cliente" },
+        { title: "Recomendaciones inteligentes", desc: "Guía al cliente al producto o servicio correcto en vez de tirarle el catálogo encima" },
+        { title: "Agendado de citas y captura de leads", desc: "Recoge los datos que necesitas — nombre, contacto, intención — y los enruta donde corresponde" },
+        { title: "Transferencia a humano", desc: "Te pasa la conversación con todo el contexto cuando realmente se necesita una persona" },
+        { title: "Reporte semanal de desempeño", desc: "Qué te están preguntando los clientes, qué está convirtiendo, qué mejorar — cada lunes" },
+        { title: "Ajuste mensual", desc: "Refino el asistente conforme tu negocio evoluciona — nuevos productos, nuevos precios, nuevas temporadas" }
       ],
       notIncluded: [
-        "SEO, Google Ads o gestión de publicidad pagada",
-        "Generación de reseñas o escritura de respuestas (puedo recomendar socios)",
-        "Gestión de redes sociales o creación de contenido"
+        "Configuraciones multi-página o de franquicia más allá de una sola página de Facebook (se cotiza aparte)",
+        "Generación de contenido nuevo de marketing — el asistente usa TU voz y TUS productos",
+        "Gestión de anuncios de Facebook o publicaciones en redes sociales"
       ],
-      timeline: "En vivo en 1 semana. Primer reporte dentro de 5 días hábiles.",
-      investment: "Servicio mensual desde **$5,000 MXN/mes** para monitoreo de una ubicación con hasta 5 competidores. Multi-ubicación y seguimiento expandido típicamente **$10,000–$30,000 MXN/mes**.",
-      investmentDisclaimer: "Setup incluido en el primer mes. Sin contratos de largo plazo — cancela cuando quieras.",
+      timeline: "En vivo en 2 semanas. Llamada de descubrimiento → entrenamiento → pruebas → lanzamiento.",
+      investment: "Desde **$499 USD/mes** para una sola página con conversaciones ilimitadas, totalmente gestionado por mí. Multi-página o volúmenes mayores se cotizan después del descubrimiento.",
+      investmentDisclaimer: "Sin contratos de largo plazo. Cancela cuando quieras.",
       bestFor: [
-        "Negocios locales con 5+ competidores en Google Maps",
-        "Negocios multi-ubicación rastreando posición en diferentes mercados",
-        "Empresas donde las reseñas y visibilidad en Google generan ingresos directos",
-        "Dueños que quieren decisiones basadas en datos, no en corazonadas"
+        "Negocios locales perdiendo clientes por respuestas lentas",
+        "Dueños ahogados en preguntas repetitivas en Messenger e Instagram",
+        "Negocios con clientes bilingües (español + inglés)",
+        "Cualquiera cuyos competidores están respondiendo más rápido"
       ]
     }
   },
@@ -255,6 +255,41 @@ const block = data[id as keyof typeof data][locale];
 if (!block) throw new Error(`Block ${id} not found for locale ${locale}`);
 
 const bgClass = isAlternate ? 'bg-gray-50 dark:bg-gray-900/30' : 'bg-white dark:bg-black';
+
+// "Also Available" supporting offers — shown only on the Messenger AI block
+// (id kept as 'competitive-intelligence' to avoid touching anchors elsewhere).
+const alsoAvailable = id === 'competitive-intelligence' ? {
+  en: {
+    heading: "Also Available",
+    items: [
+      {
+        title: "Local Competitor Intelligence — weekly WhatsApp report",
+        body: "See who's beating you on Google Maps — rankings, reviews, ratings, and competitor moves — delivered to your phone every Monday morning. For owners who want to make decisions on data, not gut feel.",
+        price: "From $299/month."
+      },
+      {
+        title: "AI Product Mockups & Visual Content",
+        body: "Professional product photography and lifestyle mockups generated for Instagram, Facebook ads, and your website. Built to stop the scroll and boost engagement.",
+        price: "Project pricing."
+      }
+    ]
+  },
+  es: {
+    heading: "También Disponible",
+    items: [
+      {
+        title: "Inteligencia de Competidores Locales — reporte semanal por WhatsApp",
+        body: "Mira quién te está ganando en Google Maps — rankings, reseñas, calificaciones y movimientos de competidores — entregado a tu teléfono cada lunes en la mañana. Para dueños que quieren decidir con datos, no con corazonadas.",
+        price: "Desde $299 USD/mes."
+      },
+      {
+        title: "Mockups de Producto y Contenido Visual con IA",
+        body: "Fotografía de producto profesional y mockups de estilo de vida generados para Instagram, anuncios de Facebook y tu sitio web. Hechos para detener el scroll y aumentar el engagement.",
+        price: "Precio por proyecto."
+      }
+    ]
+  }
+}[locale] : null;
 ---
 
 <section id={id} class={`py-20 md:py-32 border-b border-gray-100 dark:border-gray-800 ${bgClass}`}>
@@ -369,5 +404,28 @@ const bgClass = isAlternate ? 'bg-gray-50 dark:bg-gray-900/30' : 'bg-white dark:
       </div>
 
     </div>
+
+    {alsoAvailable && (
+      <div class="mt-20 md:mt-24 pt-12 border-t border-gray-200 dark:border-gray-800">
+        <h3 class="font-display font-semibold text-sm text-gray-500 dark:text-gray-400 mb-8 uppercase tracking-wider">
+          {alsoAvailable.heading}
+        </h3>
+        <div class="grid md:grid-cols-2 gap-6 lg:gap-8">
+          {alsoAvailable.items.map(item => (
+            <div class="p-6 md:p-8 rounded-2xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900/50">
+              <h4 class="font-display font-semibold text-lg md:text-xl text-gray-900 dark:text-white mb-3 leading-snug">
+                {item.title}
+              </h4>
+              <p class="text-gray-600 dark:text-gray-400 leading-relaxed mb-4">
+                {item.body}
+              </p>
+              <p class="text-sm font-display font-semibold text-cush-orange">
+                {item.price}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    )}
   </Container>
 </section>


### PR DESCRIPTION
## Summary
- Promote the **Facebook Messenger AI Assistant** to the hero of the second services block (was: Google Maps Competitor Tracking)
- Demote **Google Maps Competitor Tracking** to an "Also Available" supporting offer in the same section
- Add **AI Product Mockups & Visual Content** as a second supporting offer
- Updated **ScenarioQualifier** card #2 to match the new positioning (after-hours messaging pain)
- Bilingual EN/ES throughout
- Pricing set at \$499/month for single-page, unlimited conversations

## Why
The previous lead (competitor tracking) is interesting but it's a report. The Messenger AI assistant is a salesperson that never sleeps — the offer that makes a small business owner lean forward. Leading with the gut-level pain (lost after-hours leads, repeat questions eating the week) and one specific relief is stronger positioning. The two supporting offers stay surface-able without diluting the headline.

## Notes
- Block id kept as `#competitive-intelligence` to avoid breaking external anchors and the ScenarioQualifier wiring
- One CTA per section (Discovery Call) — supporting offers don't get their own button

## Test plan
- [x] `npm run build` succeeds
- [ ] Visual check on Vercel preview: `/services/#competitive-intelligence` and `/es/services/#competitive-intelligence`
- [ ] Confirm "Also Available" panel renders below the main block
- [ ] Confirm ScenarioQualifier card #2 still scrolls to the right anchor

🤖 Generated with [Claude Code](https://claude.com/claude-code)