### PR TITLE
Services page overhaul — monthly pricing, MXN, voice agent, pain-first copy

### DIFF
--- a/src/components/services2/FAQ.astro
+++ b/src/components/services2/FAQ.astro
@@ -12,36 +12,36 @@ const content = {
     heading: "Services FAQ",
     faqs: [
       {
+        q: "How does the free 2-week trial work?",
+        a: "I build and launch your AI system during the trial — you see it working with real customers before you pay anything. If you're not happy with the results, you walk away. No invoice, no awkward conversation. If you decide to continue, your monthly billing starts after the trial ends."
+      },
+      {
         q: "How do I know which service I need?",
-        a: "That's what the discovery call is for. In 30 minutes, I'll assess your situation and recommend the right starting point. If you're genuinely unsure, the Clarity Sprint ($1,500, credited toward a build) gives you a complete evaluation and action plan before you commit to anything larger."
+        a: "That's what the discovery call is for. In 30 minutes, I'll assess your situation and recommend the right starting point. If you're genuinely unsure, the AI Strategy Session ($1,500, credited toward any service) gives you a complete evaluation and action plan before you commit."
       },
       {
-        q: "Can I start small and expand later?",
-        a: "Absolutely. Most clients start with one focused project — usually a support assistant or a Clarity Sprint — and expand once they see results. I design everything to be modular and extensible."
+        q: "Can I start with one service and add more later?",
+        a: "Absolutely. Most clients start with a chatbot or voice agent and add Google Maps monitoring or AI product photos within 60 days once they see results. When you bundle services, I'll build you a custom package at a better monthly rate."
       },
       {
-        q: "Do you offer payment plans?",
-        a: "For engagements over $5,000, I can structure payments across milestones (typically 50% at kickoff, 50% at launch). We'll discuss what works during scoping."
+        q: "What's included in the monthly price?",
+        a: "Everything. Setup, training, deployment, weekly performance reports, monthly tuning, and email support (24-hour response). No hidden fees. No surprise charges. The price you see is the price you pay."
       },
       {
-        q: "What happens after the 30-day optimization window?",
-        a: "The system is yours — fully documented and operational. You can run it independently, or we can set up a monthly retainer for ongoing optimization, content updates, and performance monitoring. No lock-in."
+        q: "What if the AI voice agent goes over 500 minutes?",
+        a: "Overage is billed at $0.50/minute. Most small businesses use 200–400 minutes per month, so most clients never hit the cap. I'll alert you if you're approaching the limit so there are no surprises."
       },
       {
         q: "I've worked with AI vendors before and it didn't go well. How is this different?",
-        a: "I hear this a lot. Most failed AI projects fail for one of three reasons: no clear success metrics, no validation/guardrails, or no iteration based on real usage. I address all three by design — metrics defined upfront, validation built into every system, and a 30-day optimization window where I tune based on actual data. Also: you work directly with me, not an account manager who disappears after the sale."
+        a: "Most failed AI projects fail because there are no clear success metrics, no guardrails, and no iteration based on real usage. I address all three by design — metrics defined upfront, validation built into every system, and ongoing monthly tuning based on actual data. Also: you work directly with me, not an account manager who disappears after the sale."
       },
       {
         q: "Do you sign NDAs?",
         a: "Yes. I'm happy to sign a mutual NDA before our first conversation. Your business information stays confidential."
       },
       {
-        q: "How is the Competitive Intelligence service different from the other services?",
-        a: "The other services are project-based — I build something, hand it off, and you own it. Competitive Intelligence is an ongoing monthly service where I continuously monitor your market and deliver weekly intelligence reports. Setup is included in the first month, and there are no long-term contracts."
-      },
-      {
         q: "What if I need something that doesn't fit these categories?",
-        a: "Start with the discovery call. If your project is within my capabilities, I'll scope it. If it's not, I'll be honest and, where possible, point you toward someone who can help."
+        a: "Start with the discovery call. If your project is within my capabilities, I'll scope it. If it's not, I'll be honest and point you toward someone who can help."
       },
       {
         q: "Do you work with companies outside Mexico and the US?",
@@ -53,40 +53,40 @@ const content = {
     heading: "Preguntas Frecuentes",
     faqs: [
       {
-        q: "¿Como sé qué servicio necesito?",
-        a: "Para eso es la llamada. En 30 minutos, evalúo tu situación y recomiendo el punto de partida preciso. Si aún dudas, el Sprint de Claridad ($1,500, transferibles a desarrollo) te da un plan de acción completo antes de que te comprometas a lo grande."
+        q: "¿Cómo funciona la prueba gratis de 2 semanas?",
+        a: "Construyo y lanzo tu sistema de IA durante la prueba — lo ves trabajando con clientes reales antes de pagar nada. Si no estás contento con los resultados, te vas sin compromiso. Sin factura, sin conversación incómoda. Si decides continuar, la facturación mensual empieza al terminar la prueba."
       },
       {
-        q: "¿Puedo empezar pequeño y crecer después?",
-        a: "Totalmente. La mayoría de los clientes inician con un solo dominio enfocado — a menudo un asistente básico — y lo expanden con el tiempo. Todo lo construyo de forma modular."
+        q: "¿Cómo sé qué servicio necesito?",
+        a: "Para eso es la llamada. En 30 minutos, evalúo tu situación y recomiendo el punto de partida correcto. Si aún dudas, la Sesión de Estrategia de IA ($25,500 MXN, acreditado a cualquier servicio) te da un plan de acción completo antes de que te comprometas."
       },
       {
-        q: "¿Ofrecen métodos de pago y parcialidades?",
-        a: "Para proyectos por arriba de los $5,000, estructuramos pagos contra avances (usualmente 50% inicial, 50% lanzamiento). Todo está a discusión."
+        q: "¿Puedo empezar con un servicio y agregar más después?",
+        a: "Totalmente. La mayoría de los clientes inician con un chatbot o agente de voz y agregan monitoreo de Google Maps o fotos con IA en 60 días cuando ven resultados. Cuando combinas servicios, te armo un paquete personalizado a mejor precio mensual."
       },
       {
-        q: "¿Qué pasa con la ventana post-lanzamiento vital de 30 días?",
-        a: "El sistema final es tuyo y queda operativo con documentos propios. Puedes llevarlo por tus recursos internos, o abrir una cuota mensual de mantenimiento si prefieres soltar el volante — sin plazos forzados."
+        q: "¿Qué incluye el precio mensual?",
+        a: "Todo. Configuración, entrenamiento, despliegue, reportes semanales de desempeño, ajuste mensual y soporte por email (respuesta en 24 horas). Sin cuotas ocultas. Sin sorpresas. El precio que ves es el precio que pagas."
       },
       {
-        q: "Ya perdí dinero en la fiebre inicial generativa comercial y AI agency fluff... ¿Cuál es la diferencia?",
-        a: "Las tragedias de la IA caen en 3 bloques: cero métricas tangibles, cero control de contexto propio, y cero ajustes post-uso en la vida real. Todo proyecto mío ataca esto abriendo puertas a la métrica medible y un tuning fuerte a las 3 semanas del go-live."
+        q: "¿Qué pasa si el agente de voz supera los 500 minutos?",
+        a: "El excedente se cobra a $8.50 MXN/minuto. La mayoría de negocios pequeños usan 200–400 minutos al mes, así que casi nunca alcanzan el tope. Te aviso si te estás acercando al límite para que no haya sorpresas."
+      },
+      {
+        q: "Ya perdí dinero con proveedores de IA antes. ¿Cuál es la diferencia?",
+        a: "La mayoría de los proyectos de IA fracasan porque no hay métricas claras, no hay barreras de protección y no hay ajustes basados en uso real. Yo ataco los tres por diseño — métricas definidas al inicio, validación en cada sistema y ajuste mensual continuo basado en datos reales. Además: trabajas directamente conmigo, no con un ejecutivo de cuenta que desaparece después de la venta."
       },
       {
         q: "¿Firma Acuerdos de Confidencialidad (NDA)?",
         a: "Sí. Feliz de firmar un NDA mutuo estándar previo al intercambio comercial sensible."
       },
       {
-        q: "¿Cómo es diferente el servicio de Inteligencia Competitiva de los demás?",
-        a: "Los otros servicios son por proyecto — construyo algo, lo entrego, y es tuyo. Inteligencia Competitiva es un servicio mensual continuo donde monitoreo tu mercado y entrego reportes de inteligencia semanales. El setup está incluido en el primer mes y no hay contratos de largo plazo."
-      },
-      {
-        q: "¿Qué pasa si mi problema no cuadra con tus especialidades?",
-        a: "Agendemos la llamada igual, y si la dimensión sobrepasa mi experiencia franca... te lo diré directamente y buscaremos canalizarte donde hace sentido."
+        q: "¿Qué pasa si mi problema no cuadra con tus servicios?",
+        a: "Agendemos la llamada igual. Si está dentro de mis capacidades, lo cotizo. Si no, te lo diré directamente y te canalizo con alguien que pueda ayudarte."
       },
       {
         q: "¿Trabaja fuera de México y Estados Unidos?",
-        a: "Mi mercado es el TLCAN, pero tengo clientes de habla española o inglesa internacionales. Si la fibra del proyecto me va, la geografía no es factor, conversemos."
+        a: "Mi mercado principal es México/LATAM y Estados Unidos, pero he trabajado con clientes internacionales. Si el proyecto encaja con mi expertise, la geografía no es barrera. Conversemos."
       }
     ]
   }

--- a/src/components/services2/FinalCTA.astro
+++ b/src/components/services2/FinalCTA.astro
@@ -9,22 +9,22 @@ const { locale } = Astro.props;
 
 const content = {
   en: {
-    heading: "Ready to Talk About What AI Can Do for Your Business?",
-    body: "Book a free 30-minute discovery call. I'll assess your situation, identify the highest-impact opportunity, and give you an honest recommendation — even if that recommendation is \"not yet.\"\n\nNo jargon. No pressure. Just a straight conversation about your business.",
-    primaryCta: "Book Free Discovery Call",
+    heading: "Stop Losing Customers. Start Your Free Trial.",
+    body: "Book a free 30-minute discovery call. I'll assess your situation, recommend the right service, and if we're a fit — your 2-week free trial starts immediately.\n\nNo jargon. No pressure. No commitment until you've seen it working.",
+    primaryCta: "Start Free Trial",
     primaryLink: "/consultation/",
-    secondaryCta: "Or start with a Clarity Sprint →",
+    secondaryCta: "Or start with an AI Strategy Session ($1,500) →",
     secondaryLink: "#clarity-sprint",
-    footer: "I respond within 24 hours · Flexible hours for US & Mexico"
+    footer: "I respond within 24 hours · Free 2-week trial · Cancel anytime"
   },
   es: {
-    heading: "¿Listo para Hablar de lo que la IA Puede Hacer por Ti?",
-    body: "Agenda una llamada gratuita de 30 minutos. Evaluaré tu situación, identificaré la oportunidad de impacto y te daré mi recomendación — incluso si la respuesta por ahora es \"todavía no\".\n\nSin tecnicismos. Sin presión. Solo una plática de frente sobre tu negocio.",
-    primaryCta: "Agendar Llamada Gratis",
+    heading: "Deja de Perder Clientes. Empieza Tu Prueba Gratis.",
+    body: "Agenda una llamada gratuita de 30 minutos. Evalúo tu situación, recomiendo el servicio correcto, y si hacemos match — tu prueba gratis de 2 semanas empieza de inmediato.\n\nSin tecnicismos. Sin presión. Sin compromiso hasta que lo veas funcionando.",
+    primaryCta: "Empezar Prueba Gratis",
     primaryLink: "/es/reservar/",
-    secondaryCta: "O arranca con un Sprint de Claridad →",
+    secondaryCta: "O empieza con una Sesión de Estrategia ($25,500 MXN) →",
     secondaryLink: "#clarity-sprint",
-    footer: "Respondo en < 24 horas · Horarios de EE.UU. y México"
+    footer: "Respondo en < 24 horas · Prueba gratis de 2 semanas · Cancela cuando quieras"
   }
 };
 

--- a/src/components/services2/Hero.astro
+++ b/src/components/services2/Hero.astro
@@ -9,17 +9,17 @@ const { locale } = Astro.props;
 
 const content = {
   en: {
-    headline: "What I Build — And What It Costs",
-    subheadline1: "AI chatbots, voice agents, competitor tracking, and workflow automation — custom-built for small business teams in the US and Mexico.",
+    headline: "You're Losing Customers Right Now. I Fix That With AI.",
+    subheadline1: "Unanswered messages. Invisible Google rankings. Manual busywork eating your team's time. I build AI systems that solve these problems — and you only pay monthly for what's working.",
     subheadline2: "",
-    cta: "Book a Free Discovery Call",
+    cta: "Start Your Free 2-Week Trial",
     ctaLink: "/consultation/"
   },
   es: {
-    headline: "Lo Que Construyo — Y Lo Que Cuesta",
-    subheadline1: "Chatbots de IA, agentes de voz, monitoreo de competidores y automatización de procesos — hechos a la medida para equipos de pequeñas empresas en EE.UU. y México.",
+    headline: "Estás Perdiendo Clientes Ahora Mismo. Lo Resuelvo con IA.",
+    subheadline1: "Mensajes sin contestar. Invisible en Google Maps. Trabajo manual que consume a tu equipo. Construyo sistemas de IA que resuelven estos problemas — y solo pagas mensualmente por lo que funciona.",
     subheadline2: "",
-    cta: "Agendar Llamada Gratis",
+    cta: "Empieza Tu Prueba Gratis de 2 Semanas",
     ctaLink: "/es/reservar/"
   }
 };

--- a/src/components/services2/HowIWork.astro
+++ b/src/components/services2/HowIWork.astro
@@ -10,51 +10,51 @@ const { locale } = Astro.props;
 const content = {
   en: {
     heading: "How I Work",
-    subheading: "Every project follows the same disciplined process — whether it's a 5-day Sprint or an 8-week custom build.",
+    subheading: "From first call to live system in as little as 2 weeks. Here's the process:",
     steps: [
       {
-        title: "Step 1: Discovery Call (Free)",
-        desc: "A 30-minute conversation to understand your business, identify the opportunity with the highest impact, and determine whether we're a good fit. No commitment. If AI isn't the right answer, I'll tell you."
+        title: "Step 1: Free Discovery Call (30 min)",
+        desc: "I assess your situation, identify the highest-impact opportunity, and recommend the right starting point. No commitment. If AI isn't the right answer for your business, I'll tell you — and I won't charge you for the honesty."
       },
       {
-        title: "Step 2: Scope & Agreement",
-        desc: "I define exactly what I'll build, what you'll receive, the timeline, and the investment. You review and approve before any work begins. No vague proposals — you'll know precisely what you're getting."
+        title: "Step 2: Free 2-Week Trial",
+        desc: "I build and launch your AI system at no cost. You see it working with real customers on your real channels before you pay a cent. If it doesn't deliver, you walk away. No hard feelings, no invoice."
       },
       {
-        title: "Step 3: Build With Weekly Checkpoints",
-        desc: "I design and build your solution with progress updates every week. You see what's happening and provide feedback in real time — not just at the end. Built with production-grade discipline: validation, testing, security, and documentation from day one."
+        title: "Step 3: Go Live — Monthly Service",
+        desc: "Happy with the results? Your service continues month-to-month. I handle everything — weekly performance reports, monthly tuning, updates when your business changes. You focus on running your business."
       },
       {
-        title: "Step 4: Launch, Measure, Hand Off",
-        desc: "We deploy to real users, monitor performance against the KPIs we defined, and I optimize during the 30-day post-launch window. Everything is documented and handed over so your team can operate independently."
+        title: "Step 4: Grow When You're Ready",
+        desc: "Start with one service. Add more as you see results. Most clients begin with a chatbot or voice agent and add Google Maps monitoring or AI product photos within 60 days. Bundle multiple services for a better rate."
       }
     ],
-    retainerTitle: "Optional: Ongoing Retainer",
-    retainerDesc: "After the 30-day window, many clients choose a monthly retainer for continuous optimization — knowledge updates, performance tuning, and workflow enhancements as their business evolves. Retainers start at **$1,000/month**."
+    retainerTitle: "No Long-Term Contracts",
+    retainerDesc: "Every monthly service is cancel-anytime. I earn your business every month by delivering results, not by locking you into a contract. If I'm not delivering value, you should leave — and I'll make it easy."
   },
   es: {
     heading: "Cómo Trabajo",
-    subheading: "Cada proyecto sigue el mismo proceso disciplinado — ya sea un Sprint de 5 días o un desarrollo completo de 8 semanas.",
+    subheading: "De la primera llamada a un sistema en vivo en tan solo 2 semanas. Así es el proceso:",
     steps: [
       {
-        title: "Paso 1: Llamada de Descubrimiento (Gratis)",
-        desc: "Una plática de 30 minutos para entender tu negocio, identificar la oportunidad de mayor impacto y determinar si somos un buen match. Sin compromisos. Si la IA no es para ti, te lo diré de frente."
+        title: "Paso 1: Llamada de Descubrimiento Gratis (30 min)",
+        desc: "Evalúo tu situación, identifico la oportunidad de mayor impacto y recomiendo el punto de partida correcto. Sin compromiso. Si la IA no es lo indicado para tu negocio, te lo diré — y no te cobro por la honestidad."
       },
       {
-        title: "Paso 2: Alcance y Acuerdo",
-        desc: "Defino con exactitud qué construiré, qué recibirás, las fechas y la inversión total. Revisas y apruebas antes de que arranque nada. Cero propuestas ambiguas — sabes lo que estás comprando."
+        title: "Paso 2: Prueba Gratis de 2 Semanas",
+        desc: "Construyo y lanzo tu sistema de IA sin costo. Lo ves trabajando con clientes reales en tus canales reales antes de pagar un peso. Si no entrega, te vas sin compromiso. Sin resentimientos, sin factura."
       },
       {
-        title: "Paso 3: Construcción con Puntos de Control Semanales",
-        desc: "Diseño y armo la solución enviando estatus de avances semanal. Ves lo que ocurre en tiempo real — no solo en la junta final. Diseñado con validación de modelo producción."
+        title: "Paso 3: En Vivo — Servicio Mensual",
+        desc: "¿Contento con los resultados? Tu servicio continúa mes a mes. Yo manejo todo — reportes semanales, ajuste mensual, actualizaciones cuando tu negocio cambia. Tú te enfocas en correr tu negocio."
       },
       {
-        title: "Paso 4: Lanzamiento, Medición y Entrega",
-        desc: "Desplegamos tu sistema en vivo, medimos contra los KPIs definidos y yo sigo optimizando durante 30 días ventana crítica de cierre post-lanzamiento. Todo se documenta."
+        title: "Paso 4: Crece Cuando Estés Listo",
+        desc: "Empieza con un servicio. Agrega más conforme ves resultados. La mayoría de los clientes inician con un chatbot o agente de voz y agregan monitoreo de Google Maps o fotos con IA en 60 días. Combina servicios para mejor precio."
       }
     ],
-    retainerTitle: "Opcional: Retención Continua",
-    retainerDesc: "Al concluir los 30 días, la mayoría de los clientes escogen una póliza de retención mensual para optimización de por vida — actualizaciones de la base y afinación general. A partir de **$1,000 USD/mes**."
+    retainerTitle: "Sin Contratos de Largo Plazo",
+    retainerDesc: "Cada servicio mensual es cancela-cuando-quieras. Me gano tu negocio cada mes entregando resultados, no amarrándote a un contrato. Si no estoy entregando valor, deberías irte — y te lo haré fácil."
   }
 };
 

--- a/src/components/services2/InvestmentOverview.astro
+++ b/src/components/services2/InvestmentOverview.astro
@@ -9,82 +9,106 @@ const { locale } = Astro.props;
 
 const content = {
   en: {
-    heading: "Investment Overview",
-    intro: "I believe in transparent pricing. Here's what engagements typically look like:",
-    headers: ["Service", "Starting At", "Typical Range", "Timeline"],
+    heading: "Simple Monthly Pricing",
+    intro: "No setup fees. No long-term contracts. Free 2-week trial on every service. Cancel anytime.",
+    headers: ["Service", "Monthly", "What's Included", "Support"],
     rows: [
       {
-        service: "AI Strategy Session",
-        startingAt: "$1,500",
-        typicalRange: "$1,500 (flat)",
-        timeline: "5–10 days"
+        service: "AI Chatbot (Website/WhatsApp)",
+        startingAt: "$497/mo",
+        typicalRange: "Unlimited conversations, weekly reports, monthly tuning",
+        timeline: "Email (24hr)"
       },
       {
-        service: "AI Customer Support Chatbot",
-        startingAt: "$3,500",
-        typicalRange: "$3,500–$8,500",
-        timeline: "2–4 weeks"
+        service: "AI Messenger Assistant (Facebook)",
+        startingAt: "$497/mo",
+        typicalRange: "Unlimited conversations, weekly reports, monthly tuning",
+        timeline: "Email (24hr)"
       },
       {
-        service: "Google Maps Competitor Tracking",
-        startingAt: "$299/mo",
-        typicalRange: "$299–$1,500/mo",
-        timeline: "Ongoing"
+        service: "AI Voice Agent",
+        startingAt: "$497/mo",
+        typicalRange: "500 min included, appointment booking, lead capture",
+        timeline: "Email (24hr)"
       },
       {
-        service: "Custom Workflow Automation",
-        startingAt: "$5,000",
-        typicalRange: "$5,000–$15,000+",
+        service: "Google Maps Monitoring",
+        startingAt: "$297/mo",
+        typicalRange: "Weekly tracking, 5 competitors, WhatsApp action plan",
+        timeline: "Weekly WhatsApp"
+      },
+      {
+        service: "AI Product Photos",
+        startingAt: "$297/mo",
+        typicalRange: "Fresh images weekly for Instagram, Facebook, Reels",
+        timeline: "24hr turnaround"
+      },
+      {
+        service: "Custom AI Automation",
+        startingAt: "From $5,000",
+        typicalRange: "Project-based. Scoped during discovery call",
         timeline: "4–8 weeks"
       },
       {
-        service: "Ongoing Retainer",
-        startingAt: "$1,000/mo",
-        typicalRange: "$1,000–$2,500/mo",
-        timeline: "Monthly"
+        service: "AI Strategy Session",
+        startingAt: "$1,500",
+        typicalRange: "Flat fee — credited toward any service if you proceed",
+        timeline: "5–10 days"
       }
     ],
-    note: "Every project is scoped during the free discovery call. The ranges above reflect typical engagements — your project may be simpler or more complex. I'll give you an exact quote before you commit to anything.",
-    credit: "**Strategy Session credit:** If you start with an AI Strategy Session and move forward with a build engagement, the full $1,500 is credited toward your project."
+    note: "Every service starts with a free discovery call. I'll assess your situation and recommend the right starting point — no commitment required.",
+    credit: "**Save with bundles:** Combine 2+ services and I'll build you a custom package at a better rate. Most clients bundle the chatbot + Google Maps + product photos for a single monthly price."
   },
   es: {
-    heading: "Resumen de Inversión",
-    intro: "Creo en precios transparentes. Así se ven los proyectos típicamente:",
-    headers: ["Servicio", "Desde", "Rango Típico", "Línea de Tiempo"],
+    heading: "Precios Mensuales Simples",
+    intro: "Sin cuota de instalación. Sin contratos. Prueba gratis de 2 semanas en cada servicio. Cancela cuando quieras.",
+    headers: ["Servicio", "Mensual", "Qué Incluye", "Soporte"],
     rows: [
       {
-        service: "Sesión de Estrategia de IA",
-        startingAt: "$1,500",
-        typicalRange: "$1,500 (fijo)",
-        timeline: "5–10 días"
+        service: "Chatbot de IA (Sitio Web/WhatsApp)",
+        startingAt: "$4,999 MXN/mes",
+        typicalRange: "Conversaciones ilimitadas, reportes semanales, ajuste mensual",
+        timeline: "Email (24hr)"
       },
       {
-        service: "Chatbot de Atención al Cliente con IA",
-        startingAt: "$3,500",
-        typicalRange: "$3,500–$8,500",
-        timeline: "2–4 semanas"
+        service: "Asistente de IA en Facebook Messenger",
+        startingAt: "$4,999 MXN/mes",
+        typicalRange: "Conversaciones ilimitadas, reportes semanales, ajuste mensual",
+        timeline: "Email (24hr)"
       },
       {
-        service: "Monitoreo de Competidores en Google Maps",
-        startingAt: "$299/mes",
-        typicalRange: "$299–$1,500/mes",
-        timeline: "Continuo"
+        service: "Agente de Voz con IA",
+        startingAt: "$4,999 MXN/mes",
+        typicalRange: "500 min incluidos, agendado de citas, captura de leads",
+        timeline: "Email (24hr)"
       },
       {
-        service: "Automatización de Procesos a la Medida",
-        startingAt: "$5,000",
-        typicalRange: "$5,000–$15,000+",
+        service: "Monitoreo de Google Maps",
+        startingAt: "$2,499 MXN/mes",
+        typicalRange: "Rastreo semanal, 5 competidores, plan de acción por WhatsApp",
+        timeline: "WhatsApp semanal"
+      },
+      {
+        service: "Fotos de Producto con IA",
+        startingAt: "$2,499 MXN/mes",
+        typicalRange: "Imágenes frescas cada semana para Instagram, Facebook, Reels",
+        timeline: "24hr de entrega"
+      },
+      {
+        service: "Automatización Personalizada con IA",
+        startingAt: "Desde $85,000 MXN",
+        typicalRange: "Por proyecto. Se define en la llamada de descubrimiento",
         timeline: "4–8 semanas"
       },
       {
-        service: "Retención Continua",
-        startingAt: "$1,000/mes",
-        typicalRange: "$1,000–$2,500/mes",
-        timeline: "Mensual"
+        service: "Sesión de Estrategia de IA",
+        startingAt: "$25,500 MXN",
+        typicalRange: "Tarifa plana — acreditado a cualquier servicio si procedes",
+        timeline: "5–10 días"
       }
     ],
-    note: "Todos los proyectos se miden en la llamada gratuita. Los rangos arriba reflejan montos promedios — el tuyo puede ser diferente. Siéntete libre para conseguir un presupuesto sin compromisos.",
-    credit: "**Crédito de Sesión de Estrategia:** Si empiezas con una Sesión de Estrategia de IA y avanzas a un proyecto de construcción, los $1,500 USD se acreditan completos a tu proyecto."
+    note: "Cada servicio empieza con una llamada de descubrimiento gratuita. Evalúo tu situación y recomiendo el punto de partida correcto — sin compromiso.",
+    credit: "**Ahorra con paquetes:** Combina 2+ servicios y te armo un paquete personalizado a mejor precio. La mayoría de los clientes combinan el chatbot + Google Maps + fotos de producto en un solo precio mensual."
   }
 };
 

--- a/src/components/services2/ScenarioQualifier.astro
+++ b/src/components/services2/ScenarioQualifier.astro
@@ -21,29 +21,36 @@ const content = {
       {
         iconKey: "chat",
         title: "My team answers the same questions all day",
-        body: "Your support team is buried in repetitive inquiries — pricing, policies, order status. Response times are slipping, leads disappear after hours, and you can't hire fast enough to keep up.",
-        linkText: "→ AI Customer Support Chatbot",
+        body: "Your support team is buried in repetitive inquiries — pricing, policies, order status. Response times are slipping, leads disappear after hours, and you're paying $4,000+/month for someone who can only work 8 hours a day.",
+        linkText: "→ AI Chatbot — $497/mo",
         anchor: "#support-assistants"
       },
       {
         iconKey: "chat",
         title: "Customers message my Facebook page after hours and I lose them",
-        body: "Someone messages at 10pm asking about pricing or availability. By morning they've booked with the competitor who answered in two minutes. Meanwhile your team answers the same five questions a hundred times a week.",
-        linkText: "→ AI Messenger Assistant",
+        body: "Someone messages at 10pm asking about pricing or availability. By morning they've booked with the competitor who answered in two minutes. Facebook already removed your \"responds quickly\" badge.",
+        linkText: "→ AI Messenger Assistant — $497/mo",
         anchor: "#competitive-intelligence"
+      },
+      {
+        iconKey: "eye",
+        title: "My phone rings and nobody picks up",
+        body: "You miss 3–5 calls a day while you're with clients, driving, or at lunch. Each one could be a $500 customer. That's $7,500–$12,500/month walking away because nobody answered the phone.",
+        linkText: "→ AI Voice Agent — $497/mo",
+        anchor: "#voice-agent"
       },
       {
         iconKey: "cog",
         title: "We're drowning in repetitive manual work",
-        body: "Data entry, report generation, manual follow-ups, copy-paste workflows. Your team spends hours on tasks that should take minutes — and it's keeping them from higher-value work.",
-        linkText: "→ Custom Workflow Automation",
+        body: "Data entry, report generation, manual follow-ups, copy-paste workflows. Your team spends 10+ hours a week on tasks that should take minutes — that's $25,000–$50,000/year in wasted salary.",
+        linkText: "→ Custom AI Automation — from $5,000",
         anchor: "#custom-tools"
       },
       {
         iconKey: "compass",
         title: "I know AI could help — I just don't know where to start",
         body: "You've seen the hype. Maybe you've been burned by a failed experiment. You need someone to assess your business honestly, identify the real opportunities, and give you a plan you can act on.",
-        linkText: "→ AI Strategy Session ($1,500)",
+        linkText: "→ AI Strategy Session — $1,500",
         anchor: "#clarity-sprint"
       }
     ]
@@ -54,29 +61,36 @@ const content = {
       {
         iconKey: "chat",
         title: "Mi equipo responde lo mismo todo el día",
-        body: "Tu equipo de soporte está enterrado en consultas repetitivas — precios, políticas, estado de pedidos. Los tiempos de respuesta caen, los prospectos se pierden y no puedes contratar lo suficientemente rápido.",
-        linkText: "→ Chatbot de Atención al Cliente con IA",
+        body: "Tu equipo está enterrado en consultas repetitivas — precios, políticas, estado de pedidos. Los tiempos de respuesta caen, los prospectos se pierden y estás pagando $8,000+ MXN/mes por alguien que solo trabaja 8 horas al día.",
+        linkText: "→ Chatbot con IA — $4,999 MXN/mes",
         anchor: "#support-assistants"
       },
       {
         iconKey: "chat",
         title: "Mis clientes me escriben en Facebook fuera de horario y los pierdo",
-        body: "Alguien escribe a las 10 de la noche preguntando precios o disponibilidad. Para la mañana ya reservó con el competidor que contestó en dos minutos. Mientras tanto tu equipo contesta las mismas cinco preguntas cien veces a la semana.",
-        linkText: "→ Asistente de IA en Messenger",
+        body: "Alguien escribe a las 10 de la noche preguntando precios o disponibilidad. Para la mañana ya reservó con el competidor que contestó en dos minutos. Facebook ya te quitó la insignia de \"responde rápido\".",
+        linkText: "→ Asistente de IA en Messenger — $4,999 MXN/mes",
         anchor: "#competitive-intelligence"
+      },
+      {
+        iconKey: "eye",
+        title: "Suena mi teléfono y nadie contesta",
+        body: "Pierdes 3–5 llamadas al día mientras estás con clientes, manejando, o comiendo. Cada una puede ser un cliente de $5,000 MXN. Son $75,000–$125,000 MXN/mes que se van porque nadie contestó.",
+        linkText: "→ Agente de Voz con IA — $4,999 MXN/mes",
+        anchor: "#voice-agent"
       },
       {
         iconKey: "cog",
         title: "Nos ahogamos en trabajo manual",
-        body: "Entrada de datos, reportes, seguimientos manuales. Tu equipo pasa horas en tareas que tomarían minutos — alejándolos de trabajo de mayor valor comercial.",
-        linkText: "→ Automatización de Procesos a la Medida",
+        body: "Entrada de datos, reportes, seguimientos manuales. Tu equipo pasa 10+ horas a la semana en tareas que deberían tomar minutos — son $400,000–$800,000 MXN/año en salario desperdiciado.",
+        linkText: "→ Automatización con IA — desde $85,000 MXN",
         anchor: "#custom-tools"
       },
       {
         iconKey: "compass",
         title: "Sé que la IA ayudaría, pero no sé por dónde empezar",
         body: "Has visto el humo del mercado. Tal vez te decepcionaste con algún demo. Necesitas a alguien que evalúe tu negocio honestamente y te dé un plan en el que puedas confiar y actuar.",
-        linkText: "→ Sesión de Estrategia de IA ($1,500)",
+        linkText: "→ Sesión de Estrategia — $25,500 MXN",
         anchor: "#clarity-sprint"
       }
     ]

--- a/src/components/services2/ServiceBlock.astro
+++ b/src/components/services2/ServiceBlock.astro
@@ -9,32 +9,31 @@ interface Props {
 
 const { locale, id, isAlternate = false } = Astro.props;
 
-// This component handles the rendering logic for all 4 services by selecting the right ID.
+// This component handles the rendering logic for all 5 services by selecting the right ID.
 const data = {
   'support-assistants': {
     en: {
       heading: "AI Customer Support Chatbot",
-      subheading: "Your customers get instant answers, 24/7, in English and Spanish — without hiring anyone.",
-      problem: "Your team answers the same questions dozens of times a day. Customers wait. Leads ask a question at 9pm and never come back. You can't hire fast enough, and the people you do hire spend their first month learning answers that live in scattered documents.",
+      subheading: "A customer asks a question at 9 PM. By morning, they bought from your competitor. That stops today.",
+      problem: "Your team answers the same questions dozens of times a day. Customers wait. Leads ask a question at 9pm and never come back. You can't hire fast enough, and the people you do hire spend their first month learning answers that live in scattered documents.\n\nA community manager costs $4,000–$6,000/month — and only works 8 hours a day. Your AI assistant works 24/7 for a fraction of that.",
       whatIBuild: "An AI assistant trained on YOUR business knowledge — your docs, your policies, your pricing, your product information — that answers customer questions accurately, in English and Spanish, around the clock.\n\nNot a generic chatbot. A system that knows your business, validates its answers against your approved sources, and hands off to your team when human judgment is needed.",
       included: [
-        { title: "Knowledge ingestion and structuring", desc: "I audit your existing content (docs, FAQs, policies, WhatsApp threads) and organize it into a structured knowledge base your assistant can reference" },
-        { title: "AI assistant with validated responses", desc: "Answers grounded in your approved sources, not the open internet. Built-in guardrails to prevent hallucination and off-topic responses" },
+        { title: "Custom setup and training", desc: "I audit your existing content (docs, FAQs, policies, WhatsApp threads) and build a structured knowledge base your assistant references" },
+        { title: "AI assistant with validated responses", desc: "Answers grounded in your approved sources, not the open internet. Built-in guardrails to prevent hallucination" },
         { title: "Bilingual output (EN/ES)", desc: "Professional responses in both languages, matched to your brand voice and tone" },
-        { title: "Human handoff flow", desc: "When the assistant isn't confident or the question requires judgment, it routes to your team with full context — no frustrated customers repeating themselves" },
-        { title: "Lead capture and qualification", desc: "After-hours visitors get engaged immediately. The assistant captures contact info, qualifies intent, and routes to your sales process" },
-        { title: "Analytics dashboard", desc: "See what customers are asking, where they get stuck, what content is missing, and how the assistant is performing against your KPIs" },
-        { title: "Deployment and documentation", desc: "Installed on your website, WhatsApp, or both. Full operational documentation so your team can manage it" },
-        { title: "30-day optimization window", desc: "After launch, I monitor performance, fix gaps, and tune responses based on real usage data" }
+        { title: "Human handoff flow", desc: "Routes to your team with full context when human judgment is needed — no frustrated customers repeating themselves" },
+        { title: "Lead capture and qualification", desc: "After-hours visitors get engaged immediately. Contact info captured, intent qualified, routed to your sales process" },
+        { title: "Weekly performance report", desc: "What customers are asking, where they get stuck, what content is missing, and how the assistant is performing" },
+        { title: "Monthly tuning", desc: "I refine the assistant as your business evolves — new products, new pricing, new seasons" },
+        { title: "Deployment on your website, WhatsApp, or both", desc: "Full operational documentation so your team can manage it" }
       ],
       notIncluded: [
-        "Ongoing content updates beyond the 30-day window (available via retainer)",
         "Integration with custom CRMs or ERPs (scoped separately if needed)",
         "Generating new content — the assistant surfaces YOUR existing knowledge, it doesn't create marketing copy"
       ],
-      timeline: "2–4 weeks from kickoff to launch, depending on the volume and complexity of your knowledge base.",
-      investment: "Engagements start at **$3,500** for a focused assistant with a single knowledge domain (e.g., customer support FAQ). More complex implementations with multiple domains, integrations, or bilingual requirements are typically **$5,000–$8,500**.",
-      investmentDisclaimer: "All projects are scoped and quoted during the free discovery call. No surprises.",
+      timeline: "Live in 2–4 weeks. Discovery call → training → testing → launch.",
+      investment: "**$497/month** — unlimited conversations, fully managed. Includes setup, training, weekly reports, and monthly tuning. No setup fee. No long-term contract.",
+      investmentDisclaimer: "Free 2-week trial. Cancel anytime.",
       bestFor: [
         "Customer support teams handling 500+ inquiries/month",
         "Businesses losing leads after hours or on weekends",
@@ -44,27 +43,26 @@ const data = {
     },
     es: {
       heading: "Chatbot de Atención al Cliente con IA",
-      subheading: "Tus clientes reciben respuestas instantáneas, 24/7, en inglés y español — sin contratar a nadie.",
-      problem: "Tu equipo responde las mismas preguntas docenas de veces al día. Los clientes esperan. Los leads preguntan a las 9pm y nunca regresan. No puedes contratar lo suficientemente rápido.",
+      subheading: "Un cliente pregunta a las 9 de la noche. Para la mañana, ya compró con tu competidor. Eso se acaba hoy.",
+      problem: "Tu equipo responde las mismas preguntas docenas de veces al día. Los clientes esperan. Los leads preguntan a las 9pm y nunca regresan. No puedes contratar lo suficientemente rápido.\n\nUn community manager cuesta $8,000–$15,000 MXN/mes — y solo trabaja 8 horas al día. Tu asistente de IA trabaja 24/7 por una fracción de eso.",
       whatIBuild: "Un asistente de IA entrenado con EL conocimiento de TU negocio — tus documentos, políticas, precios — que responde con precisión en inglés y español todo el día.\n\nNo es un chatbot genérico. Es un sistema que conoce tu negocio, valida sus respuestas contra fuentes aprobadas y transfiere a tu equipo cuando se necesita criterio humano.",
       included: [
-        { title: "Ingestión y estructuración de conocimiento", desc: "Audito tu contenido existente y lo organizo en una base de conocimientos estructurada." },
+        { title: "Configuración y entrenamiento personalizado", desc: "Audito tu contenido existente y construyo una base de conocimientos estructurada." },
         { title: "Asistente con respuestas validadas", desc: "Respuestas basadas en tus fuentes, no en el internet abierto. Barreras de seguridad incorporadas." },
         { title: "Salida bilingüe (EN/ES)", desc: "Respuestas profesionales en ambos idiomas." },
         { title: "Flujo de transferencia humana", desc: "Enruta a tu equipo con todo el contexto necesario, sin clientes frustrados." },
         { title: "Captura y calificación de leads", desc: "Captura información de contacto y califica intención fuera del horario laboral." },
-        { title: "Panel de analíticas", desc: "Mira qué preguntan los clientes y cómo se desempeña el asistente contra tus KPIs." },
-        { title: "Despliegue y documentación", desc: "Instalado en tu sitio web, WhatsApp, o ambos." },
-        { title: "Ventana de optimización de 30 días", desc: "Monitoreo de desempeño y ajuste de respuestas basado en uso real." }
+        { title: "Reporte semanal de desempeño", desc: "Qué preguntan los clientes, dónde se atoran, qué mejorar." },
+        { title: "Ajuste mensual", desc: "Refino el asistente conforme tu negocio evoluciona — nuevos productos, precios, temporadas." },
+        { title: "Instalación en tu sitio web, WhatsApp, o ambos", desc: "Documentación operacional completa." }
       ],
       notIncluded: [
-        "Actualizaciones continuas después de 30 días (disponible como retención)",
         "Integración con CRMs/ERPs personalizados (se cotiza aparte)",
         "Creación de contenido nuevo de marketing"
       ],
-      timeline: "2–4 semanas de principio a fin.",
-      investment: "Proyectos a partir de **$3,500 USD** para un dominio de conocimiento enfocado. Sistemas complejos y multilingües típicamente rondan los **$5,000–$8,500 USD**.",
-      investmentDisclaimer: "Todo se define y cotiza en la llamada gratuita. Sin sorpresas.",
+      timeline: "En vivo en 2–4 semanas. Llamada → entrenamiento → pruebas → lanzamiento.",
+      investment: "**$4,999 MXN/mes** — conversaciones ilimitadas, totalmente gestionado. Incluye configuración, entrenamiento, reportes semanales y ajuste mensual. Sin cuota de instalación. Sin contrato.",
+      investmentDisclaimer: "Prueba gratis de 2 semanas. Cancela cuando quieras.",
       bestFor: [
         "Equipos procesando 500+ consultas al mes",
         "Empresas perdiendo leads fines de semana/noches",
@@ -75,9 +73,9 @@ const data = {
   },
   'competitive-intelligence': {
     en: {
-      heading: "An AI Assistant on Your Facebook Page That Sells While You Sleep",
+      heading: "AI Assistant on Your Facebook Page That Sells While You Sleep",
       subheading: "Every message answered in seconds. Every customer captured. Every question handled in their language — in your voice — 24 hours a day.",
-      problem: "A customer messages your Facebook page at 10pm asking if you have their size, their date, their flavor. You see it the next morning. By then, they've booked with the competitor who answered in two minutes.\n\nMeanwhile, you're answering the same five questions a hundred times a week — what are your hours, do you deliver, how much, do you have it in red — and it's eating the time you should be spending growing the business.\n\nYou don't need another inbox to check. You need someone answering it for you.",
+      problem: "A customer messages your Facebook page at 10pm asking if you have their size, their date, their flavor. You see it the next morning. By then, they've booked with the competitor who answered in two minutes.\n\nMeanwhile, you're answering the same five questions a hundred times a week — what are your hours, do you deliver, how much, do you have it in red — and it's eating the time you should be spending growing the business.\n\nFacebook removes your \"responds quickly\" badge if you take more than 15 minutes. With AI, your response time is under 5 seconds — always.",
       whatIBuild: "A custom AI assistant that lives on your Facebook Messenger and answers your customers the instant they reach out — in Spanish or English, in your brand's voice, trained on your products, your prices, your policies.\n\nIt recommends the right product. It books the appointment. It handles the FAQ a hundred times a day without complaining. And when a real human is needed, it hands the conversation off to you with the context already gathered.\n\nIt's not a generic chatbot. It's an assistant built around your business — the way a great employee would be, except it works every hour and never asks for a raise.",
       included: [
         { title: "Custom training on your business", desc: "Products, prices, hours, policies, tone, the works — trained on what you actually sell and how you actually talk" },
@@ -94,8 +92,8 @@ const data = {
         "Paid Facebook ad management or social posting"
       ],
       timeline: "Live in 2 weeks. Discovery call → training → testing → launch.",
-      investment: "From **$499/month** for single-page setup with unlimited conversations, fully managed by me. Multi-page or higher-volume setups quoted after discovery.",
-      investmentDisclaimer: "No long-term contracts. Cancel anytime.",
+      investment: "**$497/month** — single page, unlimited conversations, fully managed. Includes setup, training, weekly reports, and monthly tuning. No setup fee. No long-term contract.",
+      investmentDisclaimer: "Free 2-week trial. Cancel anytime.",
       bestFor: [
         "Local businesses losing leads to slow response times",
         "Owners drowning in repeat questions on Messenger and Instagram",
@@ -106,7 +104,7 @@ const data = {
     es: {
       heading: "Un Asistente de IA en tu Página de Facebook que Vende Mientras Duermes",
       subheading: "Cada mensaje contestado en segundos. Cada cliente capturado. Cada pregunta resuelta en su idioma — con tu voz — las 24 horas del día.",
-      problem: "Un cliente le escribe a tu página de Facebook a las 10 de la noche preguntando si tienes su talla, su fecha, su sabor. Lo ves a la mañana siguiente. Para entonces, ya reservó con el competidor que le contestó en dos minutos.\n\nMientras tanto, tú contestas las mismas cinco preguntas cien veces a la semana — cuál es tu horario, si entregas a domicilio, cuánto cuesta, si lo tienes en rojo — y eso te está comiendo el tiempo que deberías estar usando para hacer crecer el negocio.\n\nNo necesitas otra bandeja de entrada que revisar. Necesitas a alguien que la conteste por ti.",
+      problem: "Un cliente le escribe a tu página de Facebook a las 10 de la noche preguntando si tienes su talla, su fecha, su sabor. Lo ves a la mañana siguiente. Para entonces, ya reservó con el competidor que le contestó en dos minutos.\n\nMientras tanto, tú contestas las mismas cinco preguntas cien veces a la semana — cuál es tu horario, si entregas a domicilio, cuánto cuesta, si lo tienes en rojo — y eso te está comiendo el tiempo que deberías estar usando para hacer crecer el negocio.\n\nFacebook te quita la insignia de \"responde rápido\" si tardas más de 15 minutos. Con IA, tu tiempo de respuesta es menos de 5 segundos — siempre.",
       whatIBuild: "Un asistente de IA a la medida que vive en tu Facebook Messenger y le contesta a tus clientes en el instante en que escriben — en español o en inglés, con la voz de tu marca, entrenado con tus productos, tus precios y tus políticas.\n\nRecomienda el producto correcto. Agenda la cita. Contesta las preguntas frecuentes cien veces al día sin quejarse. Y cuando se necesita un humano de verdad, te pasa la conversación con todo el contexto ya levantado.\n\nNo es un chatbot genérico. Es un asistente construido alrededor de tu negocio — como sería un gran empleado, excepto que trabaja a toda hora y nunca pide aumento.",
       included: [
         { title: "Entrenamiento personalizado", desc: "Productos, precios, horarios, políticas, tono — entrenado con lo que realmente vendes y cómo realmente hablas" },
@@ -123,8 +121,8 @@ const data = {
         "Gestión de anuncios de Facebook o publicaciones en redes sociales"
       ],
       timeline: "En vivo en 2 semanas. Llamada de descubrimiento → entrenamiento → pruebas → lanzamiento.",
-      investment: "Desde **$499 USD/mes** para una sola página con conversaciones ilimitadas, totalmente gestionado por mí. Multi-página o volúmenes mayores se cotizan después del descubrimiento.",
-      investmentDisclaimer: "Sin contratos de largo plazo. Cancela cuando quieras.",
+      investment: "**$4,999 MXN/mes** — una sola página, conversaciones ilimitadas, totalmente gestionado. Incluye configuración, entrenamiento, reportes semanales y ajuste mensual. Sin cuota de instalación. Sin contrato.",
+      investmentDisclaimer: "Prueba gratis de 2 semanas. Cancela cuando quieras.",
       bestFor: [
         "Negocios locales perdiendo clientes por respuestas lentas",
         "Dueños ahogados en preguntas repetitivas en Messenger e Instagram",
@@ -133,12 +131,74 @@ const data = {
       ]
     }
   },
+  'voice-agent': {
+    en: {
+      heading: "AI Voice Agent That Answers Your Phone Like Your Best Employee",
+      subheading: "Every call answered on the first ring. Appointments booked. Questions handled. Leads captured — even at 2 AM on a Sunday.",
+      problem: "Your phone rings. You're with a client, driving, or eating dinner. It goes to voicemail. The caller hangs up and calls the next business on Google.\n\nYou miss 3–5 calls a day. Each one could be a $500 customer. That's $7,500–$12,500 in potential revenue walking away every month because nobody picked up the phone.\n\nHiring a receptionist costs $3,000–$5,000/month — and they only work 8 hours a day, 5 days a week. Your AI voice agent works 24/7 for a fraction of that.",
+      whatIBuild: "An AI voice agent that answers your business phone with a natural, conversational voice — trained on your services, your pricing, your hours, and your booking process.\n\nIt greets callers by understanding their intent. It answers common questions. It books appointments directly into your calendar. And when a call truly needs you, it transfers with full context so you never start cold.\n\nCallers don't know it's AI. They just know someone picked up on the first ring.",
+      included: [
+        { title: "Custom voice and personality", desc: "Natural-sounding voice matched to your brand — professional, warm, bilingual. Not a robotic IVR menu" },
+        { title: "Business knowledge training", desc: "Trained on your services, pricing, hours, locations, and FAQs — gives accurate answers, not generic scripts" },
+        { title: "Appointment booking", desc: "Books directly into your calendar (Google Calendar, Calendly, or your booking system)" },
+        { title: "Lead capture and routing", desc: "Captures caller name, number, intent, and urgency — texts you a summary instantly" },
+        { title: "Call transfer with context", desc: "When a call needs you, it transfers with a brief of what the caller wants — no cold handoffs" },
+        { title: "Bilingual (EN/ES)", desc: "Handles calls in English and Spanish, switching naturally based on the caller" },
+        { title: "Monthly call report", desc: "Volume, top questions, bookings made, missed-call recovery stats" },
+        { title: "Up to 500 minutes included", desc: "Overage at $0.50/minute. Most small businesses use 200–400 minutes/month" }
+      ],
+      notIncluded: [
+        "Outbound calling campaigns (available as a separate engagement)",
+        "Integration with enterprise phone systems (PBX, Cisco, etc. — scoped separately)",
+        "Call recording storage beyond 30 days"
+      ],
+      timeline: "Live in 1–2 weeks. Discovery call → voice setup → testing → launch.",
+      investment: "**$497/month** — includes up to 500 minutes, setup, training, and monthly reports. Overage at $0.50/min. No setup fee. No long-term contract.",
+      investmentDisclaimer: "Free 2-week trial. Cancel anytime.",
+      bestFor: [
+        "Service businesses missing calls during busy hours (salons, clinics, contractors)",
+        "Small teams with no dedicated receptionist",
+        "Businesses losing customers to competitors who answer faster",
+        "Anyone paying $3,000+/month for a receptionist who only works 40 hours/week"
+      ]
+    },
+    es: {
+      heading: "Agente de Voz con IA que Contesta tu Teléfono Como tu Mejor Empleado",
+      subheading: "Cada llamada contestada al primer timbrazo. Citas agendadas. Preguntas resueltas. Leads capturados — incluso a las 2 AM un domingo.",
+      problem: "Suena tu teléfono. Estás con un cliente, manejando, o cenando. Se va al buzón. La persona cuelga y llama al siguiente negocio en Google.\n\nPierdes 3–5 llamadas al día. Cada una puede ser un cliente de $5,000 MXN. Son $75,000–$125,000 MXN en ingresos potenciales que se van cada mes porque nadie contestó el teléfono.\n\nContratar una recepcionista cuesta $8,000–$15,000 MXN/mes — y solo trabaja 8 horas al día, 5 días a la semana. Tu agente de voz con IA trabaja 24/7 por una fracción de eso.",
+      whatIBuild: "Un agente de voz con IA que contesta el teléfono de tu negocio con una voz natural y conversacional — entrenado con tus servicios, tus precios, tus horarios y tu proceso de reservaciones.\n\nSaluda a los que llaman entendiendo su intención. Responde preguntas comunes. Agenda citas directamente en tu calendario. Y cuando una llamada realmente te necesita, transfiere con todo el contexto para que nunca empieces en frío.\n\nLos que llaman no saben que es IA. Solo saben que alguien contestó al primer timbrazo.",
+      included: [
+        { title: "Voz y personalidad personalizada", desc: "Voz natural que coincide con tu marca — profesional, cálida, bilingüe. No un menú robótico de IVR" },
+        { title: "Entrenamiento con conocimiento del negocio", desc: "Entrenado con tus servicios, precios, horarios, ubicaciones y FAQs" },
+        { title: "Agendado de citas", desc: "Agenda directamente en tu calendario (Google Calendar, Calendly, o tu sistema de reservas)" },
+        { title: "Captura y enrutamiento de leads", desc: "Captura nombre, número, intención y urgencia — te envía un resumen por texto al instante" },
+        { title: "Transferencia con contexto", desc: "Cuando la llamada te necesita, transfiere con un resumen de lo que quiere la persona" },
+        { title: "Bilingüe (EN/ES)", desc: "Maneja llamadas en inglés y español, cambiando naturalmente según el que llama" },
+        { title: "Reporte mensual de llamadas", desc: "Volumen, preguntas frecuentes, citas agendadas, estadísticas de recuperación" },
+        { title: "Hasta 500 minutos incluidos", desc: "Excedente a $8.50 MXN/minuto. La mayoría de negocios pequeños usan 200–400 minutos/mes" }
+      ],
+      notIncluded: [
+        "Campañas de llamadas salientes (disponible como proyecto separado)",
+        "Integración con sistemas telefónicos empresariales (PBX, Cisco — se cotiza aparte)",
+        "Almacenamiento de grabaciones más allá de 30 días"
+      ],
+      timeline: "En vivo en 1–2 semanas. Llamada → configuración de voz → pruebas → lanzamiento.",
+      investment: "**$4,999 MXN/mes** — incluye hasta 500 minutos, configuración, entrenamiento y reportes mensuales. Excedente a $8.50 MXN/min. Sin cuota de instalación. Sin contrato.",
+      investmentDisclaimer: "Prueba gratis de 2 semanas. Cancela cuando quieras.",
+      bestFor: [
+        "Negocios de servicio que pierden llamadas en horas pico (salones, clínicas, contratistas)",
+        "Equipos pequeños sin recepcionista dedicada",
+        "Negocios perdiendo clientes ante competidores que contestan más rápido",
+        "Cualquiera pagando $8,000+ MXN/mes por una recepcionista que solo trabaja 40 horas a la semana"
+      ]
+    }
+  },
   'custom-tools': {
     en: {
-      heading: "Custom Workflow Automation",
-      subheading: "I automate the data entry, follow-ups, reports, and copy-paste tasks eating your team's time.",
-      problem: "Your team spends hours every week on repetitive, structured work — data entry, report generation, manual follow-ups, document processing, or copy-paste tasks between systems.",
-      whatIBuild: "Custom AI-powered tools designed for YOUR specific process. Not a generic automation platform you need to configure — a purpose-built application that handles the exact workflow that's eating your team's time.\n\nExamples: AI writing systems, Resume analysis tools, Web scraping systems.",
+      heading: "Custom AI Automation",
+      subheading: "Your team spends 10+ hours a week on tasks a machine should handle. I build the machine.",
+      problem: "Your team spends hours every week on repetitive, structured work — data entry, report generation, manual follow-ups, document processing, or copy-paste tasks between systems.\n\nEvery hour your team spends on busywork is an hour they're not spending on customers, strategy, or growth. And the cost compounds — that's $25,000–$50,000/year in wasted salary for a single workflow.",
+      whatIBuild: "Custom AI-powered tools designed for YOUR specific process. Not a generic automation platform you need to configure — a purpose-built application that handles the exact workflow that's eating your team's time.\n\nExamples: AI writing systems, document processors, data extraction pipelines, web scraping systems, report generators.",
       included: [
         { title: "Workflow analysis", desc: "I map your current process end-to-end, identify the bottlenecks, and design the automation that delivers the highest time savings" },
         { title: "Custom application development", desc: "Built with production-grade engineering: proper validation, error handling, logging, and security" },
@@ -149,13 +209,13 @@ const data = {
         { title: "30-day optimization window", desc: "Post-launch tuning based on real-world usage" }
       ],
       notIncluded: [
-        "Ongoing feature development beyond the initial scope",
+        "Ongoing feature development beyond the initial scope (available via retainer)",
         "Replacement of core business systems (ERP, CRM migrations, etc.)",
-        "AI solutions for problems that don't need AI"
+        "AI solutions for problems that don't need AI — I'll tell you if that's the case"
       ],
       timeline: "4–8 weeks, depending on complexity and number of integrations.",
-      investment: "Engagements start at **$5,000** for focused single-workflow automation. Multi-system integrations or complex applications are typically **$8,000–$15,000+**.",
-      investmentDisclaimer: "All projects are scoped during the free discovery call.",
+      investment: "Project-based. Starts at **$5,000** for focused single-workflow automation. Multi-system integrations typically **$8,000–$15,000+**. Optional monthly retainer for ongoing optimization starts at **$1,000/month**.",
+      investmentDisclaimer: "All projects are scoped and quoted during the free discovery call. No surprises.",
       bestFor: [
         "Teams spending 10+ hours/week on repetitive manual tasks",
         "Businesses with custom workflows that off-the-shelf tools don't support",
@@ -164,10 +224,10 @@ const data = {
       ]
     },
     es: {
-      heading: "Automatización de Procesos a la Medida",
-      subheading: "Automatizo la entrada de datos, los seguimientos, los reportes y las tareas de copiar y pegar que consumen el tiempo de tu equipo.",
-      problem: "Tu equipo pasa horas cada semana en trabajo repetitivo y estructurado — captura de datos, generación de reportes, seguimientos manuales, procesamiento de documentos, o tareas de copiar y pegar entre sistemas.",
-      whatIBuild: "Herramientas impulsadas por IA diseñadas para TU proceso específico. No una plataforma de automatización genérica que necesitas configurar — una aplicación construida a propósito que maneja el flujo exacto que le está comiendo tiempo a tu equipo.\n\nEjemplos: Sistemas de escritura con IA, herramientas de análisis de CVs, sistemas de web scraping.",
+      heading: "Automatización Personalizada con IA",
+      subheading: "Tu equipo gasta 10+ horas a la semana en tareas que una máquina debería manejar. Yo construyo la máquina.",
+      problem: "Tu equipo pasa horas cada semana en trabajo repetitivo y estructurado — captura de datos, generación de reportes, seguimientos manuales, procesamiento de documentos, o tareas de copiar y pegar entre sistemas.\n\nCada hora que tu equipo gasta en trabajo manual es una hora que no gastan en clientes, estrategia o crecimiento. Y el costo se acumula — son $400,000–$800,000 MXN/año en salario desperdiciado por un solo flujo de trabajo.",
+      whatIBuild: "Herramientas impulsadas por IA diseñadas para TU proceso específico. No una plataforma de automatización genérica que necesitas configurar — una aplicación construida a propósito que maneja el flujo exacto que le está comiendo tiempo a tu equipo.\n\nEjemplos: Sistemas de escritura con IA, procesadores de documentos, pipelines de extracción de datos, sistemas de web scraping, generadores de reportes.",
       included: [
         { title: "Análisis de flujo de trabajo", desc: "Mapeo tu proceso actual de principio a fin, identifico los cuellos de botella, y diseño la automatización que entrega el mayor ahorro de tiempo" },
         { title: "Desarrollo de aplicación a medida", desc: "Construida con ingeniería de producción: validación adecuada, manejo de errores, logging y seguridad" },
@@ -178,13 +238,13 @@ const data = {
         { title: "Ventana de optimización de 30 días", desc: "Ajustes post-lanzamiento basados en uso real" }
       ],
       notIncluded: [
-        "Desarrollo continuo de funcionalidades fuera del alcance inicial",
+        "Desarrollo continuo fuera del alcance inicial (disponible como retención mensual)",
         "Reemplazo de sistemas centrales de negocio (migraciones de ERP, CRM, etc.)",
-        "Soluciones de IA para problemas que no necesitan IA"
+        "Soluciones de IA para problemas que no necesitan IA — te lo diré si es el caso"
       ],
       timeline: "4–8 semanas, dependiendo de la complejidad y número de integraciones.",
-      investment: "Proyectos desde **$5,000 USD** para automatización de un flujo específico. Integraciones multi-sistema o aplicaciones complejas típicamente **$8,000–$15,000+ USD**.",
-      investmentDisclaimer: "Todos los proyectos se dimensionan durante la llamada de descubrimiento gratuita.",
+      investment: "Por proyecto. Desde **$85,000 MXN** para automatización de un flujo específico. Integraciones multi-sistema típicamente **$136,000–$255,000+ MXN**. Retención mensual opcional para optimización continua desde **$17,000 MXN/mes**.",
+      investmentDisclaimer: "Todos los proyectos se dimensionan y cotizan durante la llamada gratuita. Sin sorpresas.",
       bestFor: [
         "Equipos que gastan 10+ horas/semana en tareas manuales repetitivas",
         "Negocios con flujos personalizados que las herramientas genéricas no soportan",
@@ -196,9 +256,9 @@ const data = {
   'clarity-sprint': {
     en: {
       heading: "AI Strategy Session",
-      subheading: "Not sure if AI can help your business? I'll find out in 5–10 days and give you a plan — or tell you it's not worth it. $1,500, credited if you move forward.",
-      problem: "You know AI could probably help your business, but you're not sure where to focus, what's realistic, or how much it should cost. You've seen impressive demos that turned into expensive disappointments.",
-      whatIBuild: "In 5–10 business days, I'll map your business operations, identify the highest-impact AI opportunity, and deliver a clear action plan you can execute — with me or on your own.",
+      subheading: "Not sure where AI fits in your business? I'll find out in 5–10 days and give you a plan — or tell you it's not worth it. $1,500, credited if you move forward.",
+      problem: "You know AI could probably help your business, but you're not sure where to focus, what's realistic, or how much it should cost. You've seen impressive demos that turned into expensive disappointments.\n\nMeanwhile, your competitors are already using AI to answer customers faster, rank higher on Google, and automate the busywork your team still does by hand.",
+      whatIBuild: "In 5–10 business days, I'll map your business operations, identify the highest-impact AI opportunity, and deliver a clear action plan you can execute — with me or on your own.\n\nThis isn't a sales pitch disguised as consulting. If AI isn't the right move for your business right now, I'll tell you exactly that — and what would actually help instead.",
       included: [
         { title: "Discovery session (60–90 minutes)", desc: "Deep dive into your business operations, pain points, existing tools, and goals" },
         { title: "Opportunity assessment", desc: "I evaluate where AI can deliver measurable results vs. where it's not worth the investment" },
@@ -212,7 +272,7 @@ const data = {
         "Ongoing consulting beyond the Sprint deliverable"
       ],
       timeline: "5–10 business days from kickoff to delivered plan.",
-      investment: "**$1,500** flat fee. If you move forward with a build engagement, I credit the full Sprint fee toward your project.",
+      investment: "**$1,500** flat fee. If you move forward with any monthly service or custom project, I credit the full $1,500 toward your first engagement.",
       investmentDisclaimer: "This is the most popular starting point for businesses that want clarity before commitment.",
       bestFor: [
         "Founders and ops leaders who know AI could help but aren't sure where",
@@ -223,9 +283,9 @@ const data = {
     },
     es: {
       heading: "Sesión de Estrategia de IA",
-      subheading: "¿No estás seguro si la IA puede ayudar a tu negocio? Lo descubro en 5–10 días y te doy un plan — o te digo que no vale la pena. $1,500 USD, acreditado si decides seguir adelante.",
-      problem: "Sabes que la IA podría ayudar a tu negocio, pero no estás seguro de dónde enfocarte, qué es realista, o cuánto debería costar. Has visto demos impresionantes que se convirtieron en decepciones costosas.",
-      whatIBuild: "En 5–10 días hábiles, mapearé tus operaciones de negocio, identificaré la oportunidad de mayor impacto con IA, y te entregaré un plan de acción claro que puedes ejecutar — conmigo o por tu cuenta.",
+      subheading: "¿No estás seguro dónde encaja la IA en tu negocio? Lo descubro en 5–10 días y te doy un plan — o te digo que no vale la pena. $25,500 MXN, acreditado si decides seguir adelante.",
+      problem: "Sabes que la IA podría ayudar a tu negocio, pero no estás seguro de dónde enfocarte, qué es realista, o cuánto debería costar. Has visto demos impresionantes que se convirtieron en decepciones costosas.\n\nMientras tanto, tus competidores ya están usando IA para contestar clientes más rápido, aparecer más alto en Google, y automatizar el trabajo manual que tu equipo todavía hace a mano.",
+      whatIBuild: "En 5–10 días hábiles, mapearé tus operaciones de negocio, identificaré la oportunidad de mayor impacto con IA, y te entregaré un plan de acción claro que puedes ejecutar — conmigo o por tu cuenta.\n\nEsto no es un pitch de ventas disfrazado de consultoría. Si la IA no es la jugada correcta para tu negocio ahora mismo, te lo diré exactamente — y te diré qué sí ayudaría.",
       included: [
         { title: "Sesión de descubrimiento (60–90 minutos)", desc: "Inmersión profunda en tus operaciones, puntos de dolor, herramientas existentes y objetivos" },
         { title: "Evaluación de oportunidades", desc: "Evalúo dónde la IA puede entregar resultados medibles vs. dónde no vale la inversión" },
@@ -239,7 +299,7 @@ const data = {
         "Consultoría continua más allá del entregable del Sprint"
       ],
       timeline: "5–10 días hábiles desde el inicio hasta el plan entregado.",
-      investment: "**$1,500 USD** tarifa plana. Si avanzas con un proyecto de desarrollo, acredito la totalidad del Sprint al costo del proyecto.",
+      investment: "**$25,500 MXN** tarifa plana. Si avanzas con cualquier servicio mensual o proyecto a medida, acredito los $25,500 MXN completos a tu primer proyecto.",
       investmentDisclaimer: "El punto de entrada más popular para negocios que quieren claridad antes de compromiso.",
       bestFor: [
         "Fundadores y líderes de operaciones que saben que la IA puede ayudar pero no están seguros dónde",
@@ -263,14 +323,14 @@ const alsoAvailable = id === 'competitive-intelligence' ? {
     heading: "Also Available",
     items: [
       {
-        title: "Local Competitor Intelligence — weekly WhatsApp report",
-        body: "See who's beating you on Google Maps — rankings, reviews, ratings, and competitor moves — delivered to your phone every Monday morning. For owners who want to make decisions on data, not gut feel.",
-        price: "From $299/month."
+        title: "Google Maps Monitoring & Weekly Action Plan",
+        body: "Every week I check where you rank on Google Maps, monitor up to 5 competitors, and send you one WhatsApp message with one clear action to take this week. No dashboards to learn. Just results.",
+        price: "From $297/month."
       },
       {
-        title: "AI Product Mockups & Visual Content",
-        body: "Professional product photography and lifestyle mockups generated for Instagram, Facebook ads, and your website. Built to stop the scroll and boost engagement.",
-        price: "Project pricing."
+        title: "AI Product Photos — No Photo Shoot Needed",
+        body: "Send me your product photos. I put them on AI-generated models with realistic settings — beaches, storefronts, studios. Fresh content every week for Instagram, Facebook, and Reels. No photographer. No studio.",
+        price: "From $297/month."
       }
     ]
   },
@@ -278,14 +338,14 @@ const alsoAvailable = id === 'competitive-intelligence' ? {
     heading: "También Disponible",
     items: [
       {
-        title: "Inteligencia de Competidores Locales — reporte semanal por WhatsApp",
-        body: "Mira quién te está ganando en Google Maps — rankings, reseñas, calificaciones y movimientos de competidores — entregado a tu teléfono cada lunes en la mañana. Para dueños que quieren decidir con datos, no con corazonadas.",
-        price: "Desde $299 USD/mes."
+        title: "Monitoreo de Google Maps y Plan de Acción Semanal",
+        body: "Cada semana reviso dónde apareces en Google Maps, monitoreo hasta 5 competidores, y te mando un WhatsApp con una acción clara para esta semana. Sin dashboards que aprender. Solo resultados.",
+        price: "Desde $2,499 MXN/mes."
       },
       {
-        title: "Mockups de Producto y Contenido Visual con IA",
-        body: "Fotografía de producto profesional y mockups de estilo de vida generados para Instagram, anuncios de Facebook y tu sitio web. Hechos para detener el scroll y aumentar el engagement.",
-        price: "Precio por proyecto."
+        title: "Fotos de Producto con IA — Sin Sesión Fotográfica",
+        body: "Mándame tus fotos de producto. Las pongo en modelos generados con IA en escenarios realistas — playas, aparadores, estudios. Contenido fresco cada semana para Instagram, Facebook y Reels. Sin fotógrafo. Sin estudio.",
+        price: "Desde $2,499 MXN/mes."
       }
     ]
   }

--- a/src/pages/es/services.astro
+++ b/src/pages/es/services.astro
@@ -20,8 +20,9 @@ const description = "Chatbots de atención al cliente, monitoreo de competidores
   <ScenarioQualifier locale={locale} />
   <ServiceBlock locale={locale} id="support-assistants" />
   <ServiceBlock locale={locale} id="competitive-intelligence" isAlternate={true} />
-  <ServiceBlock locale={locale} id="custom-tools" />
-  <ServiceBlock locale={locale} id="clarity-sprint" isAlternate={true} />
+  <ServiceBlock locale={locale} id="voice-agent" />
+  <ServiceBlock locale={locale} id="custom-tools" isAlternate={true} />
+  <ServiceBlock locale={locale} id="clarity-sprint" />
   <HowIWork locale={locale} />
   <WhoItIsFor locale={locale} />
   <InvestmentOverview locale={locale} />

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -31,8 +31,9 @@ const meta = {
   
   <ServiceBlock locale={locale} id="support-assistants" />
   <ServiceBlock locale={locale} id="competitive-intelligence" isAlternate={true} />
-  <ServiceBlock locale={locale} id="custom-tools" />
-  <ServiceBlock locale={locale} id="clarity-sprint" isAlternate={true} />
+  <ServiceBlock locale={locale} id="voice-agent" />
+  <ServiceBlock locale={locale} id="custom-tools" isAlternate={true} />
+  <ServiceBlock locale={locale} id="clarity-sprint" />
 
   <HowIWork locale={locale} />
   


### PR DESCRIPTION
## Summary
- Switch AI chatbot and Messenger from one-time project pricing ($3,500-8,500) to monthly recurring ($497/mo USD / $4,999 MXN/mes)
- Add new AI Voice Agent service ($497/mo, 500 min included, $0.50/min overage)
- Spanish page now shows MXN pricing throughout (was showing USD — brand credibility issue)
- Rewrite all service copy to lead with pain and cost-of-inaction, inspired by MarketSignal landing page
- Add free 2-week trial messaging and cancel-anytime positioning across all services
- Replace mixed à la carte pricing table with clean monthly pricing grid
- Add Google Maps monitoring ($297/mo) and AI Product Photos ($297/mo) as explicit add-ons
- Custom automation stays project-based ($5,000+), strategy session stays $1,500 (credited)
- Update FAQ, HowIWork, FinalCTA, ScenarioQualifier to match new model

## Test plan
- [ ] Verify EN /services renders with all 5 service blocks + correct USD pricing
- [ ] Verify ES /es/services renders with all 5 service blocks + correct MXN pricing
- [ ] Check mobile responsiveness on pricing table and scenario cards
- [ ] Confirm voice-agent anchor (#voice-agent) links work from ScenarioQualifier
- [ ] Verify build passes (confirmed locally — 89 pages, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)