### PR TITLE
Remove stale retainer pricing from custom automation

### DIFF
--- a/src/components/services2/ServiceBlock.astro
+++ b/src/components/services2/ServiceBlock.astro
@@ -214,7 +214,7 @@ const data = {
         "AI solutions for problems that don't need AI — I'll tell you if that's the case"
       ],
       timeline: "4–8 weeks, depending on complexity and number of integrations.",
-      investment: "Project-based. Starts at **$5,000** for focused single-workflow automation. Multi-system integrations typically **$8,000–$15,000+**. Optional monthly retainer for ongoing optimization starts at **$1,000/month**.",
+      investment: "Project-based. Starts at **$5,000** for focused single-workflow automation. Multi-system integrations typically **$8,000–$15,000+**.",
       investmentDisclaimer: "All projects are scoped and quoted during the free discovery call. No surprises.",
       bestFor: [
         "Teams spending 10+ hours/week on repetitive manual tasks",
@@ -243,7 +243,7 @@ const data = {
         "Soluciones de IA para problemas que no necesitan IA — te lo diré si es el caso"
       ],
       timeline: "4–8 semanas, dependiendo de la complejidad y número de integraciones.",
-      investment: "Por proyecto. Desde **$85,000 MXN** para automatización de un flujo específico. Integraciones multi-sistema típicamente **$136,000–$255,000+ MXN**. Retención mensual opcional para optimización continua desde **$17,000 MXN/mes**.",
+      investment: "Por proyecto. Desde **$85,000 MXN** para automatización de un flujo específico. Integraciones multi-sistema típicamente **$136,000–$255,000+ MXN**.",
       investmentDisclaimer: "Todos los proyectos se dimensionan y cotizan durante la llamada gratuita. Sin sorpresas.",
       bestFor: [
         "Equipos que gastan 10+ horas/semana en tareas manuales repetitivas",


### PR DESCRIPTION
## Summary
- Remove leftover $1,000/mo (EN) and $17,000 MXN/mes (ES) retainer mention from custom automation investment text
- Caught by post-merge audit of PR #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)