### PR TITLE
fix: sync Sentry cron monitor schedule with workflow

### DIFF
--- a/.github/workflows/refresh-projects.yml
+++ b/.github/workflows/refresh-projects.yml
@@ -42,7 +42,15 @@ jobs:
           SENTRY_CHECK_IN_ID=$(node -e "
             const Sentry = require('@sentry/node');
             Sentry.init({ dsn: process.env.SENTRY_DSN });
-            const id = Sentry.captureCheckIn({ monitorSlug: 'weekly-portfolio-refresh', status: 'in_progress' });
+            const id = Sentry.captureCheckIn(
+              { monitorSlug: 'weekly-portfolio-refresh', status: 'in_progress' },
+              {
+                schedule: { type: 'crontab', value: '0 2 * * 0' },
+                checkinMargin: 30,
+                maxRuntime: 15,
+                timezone: 'Etc/UTC',
+              }
+            );
             Sentry.close(5000).then(() => console.log(id));
           ")
           echo "SENTRY_CHECK_IN_ID=$SENTRY_CHECK_IN_ID" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
- Sentry Cron monitor was flagging false missed check-ins because its schedule didn't match the actual `0 2 * * 0` weekly cadence
- Added inline `monitorConfig` to the `captureCheckIn` call so the schedule stays in sync automatically
- Includes 30-min checkin margin and 15-min max runtime

## Test plan
- [ ] Next Sunday run (April 13) should check in without false alarms
- [ ] Verify Sentry monitor shows updated schedule config

🤖 Generated with [Claude Code](https://claude.com/claude-code)