### PR TITLE
fix: email signature icon tweaks

### DIFF
--- a/docs/email-signature.html
+++ b/docs/email-signature.html
@@ -27,7 +27,8 @@
         </tr>
         <tr style="border: none;">
           <td style="border: none; font-size: 13px; color: #1a2a3a; padding-bottom: 3px;">
-            <a href="https://wa.me/523315590572" target="_blank" style="color: #0A0A0A; text-decoration: none;">+52 33 1559 0572</a>
+            <a href="https://wa.me/523315590572" target="_blank" style="color: #0A0A0A; text-decoration: none;">
+              <img src="https://cdn-icons-png.flaticon.com/16/220/220236.png" alt="WhatsApp" width="14" height="14" style="display: inline-block; border: none; vertical-align: middle; margin-right: 4px;" />+52 33 1559 0572</a>
           </td>
         </tr>
         <tr style="border: none;">
@@ -38,7 +39,7 @@
         <tr style="border: none;">
           <td style="border: none; padding-top: 6px;">
             <a href="https://www.facebook.com/cushlabs/" target="_blank" style="text-decoration: none;">
-              <img src="https://cdn-icons-png.flaticon.com/16/733/733547.png" alt="Facebook" width="16" height="16" style="display: inline-block; border: none; vertical-align: middle;" />
+              <img src="https://cdn-icons-png.flaticon.com/24/733/733547.png" alt="Facebook" width="24" height="24" style="display: inline-block; border: none; vertical-align: middle;" />
             </a>
           </td>
         </tr>


### PR DESCRIPTION
## Summary
- Facebook icon bumped 16×16 → 24×24
- WhatsApp icon added next to phone number so recipients know they can message on WhatsApp

🤖 Generated with [Claude Code](https://claude.com/claude-code)