### PR TITLE
feat: bundle-first pricing overhaul + voice agent + pain-first copy

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -14,9 +14,8 @@ const content = {
     services: {
       title: "Services",
       links: [
-        { label: "AI Support Automation", href: "/services/#support-assistants" },
-        { label: "Document Processing", href: "/services/#knowledge-systems" },
-        { label: "SOP Systems", href: "/services/#custom-tools" },
+        { label: "AI Growth Bundle", href: "/services/#pricing" },
+        { label: "AI Voice Agent", href: "/services/#voice-agent" },
         { label: "Pricing", href: "/services/#pricing" },
       ],
     },
@@ -53,9 +52,8 @@ const content = {
     services: {
       title: "Servicios",
       links: [
-        { label: "Automatización de Soporte", href: "/es/services/#support-assistants" },
-        { label: "Procesamiento de Documentos", href: "/es/services/#knowledge-systems" },
-        { label: "Sistemas de SOPs", href: "/es/services/#custom-tools" },
+        { label: "Paquete de Crecimiento IA", href: "/es/services/#pricing" },
+        { label: "Agente de Voz IA", href: "/es/services/#voice-agent" },
         { label: "Precios", href: "/es/services/#pricing" },
       ],
     },

--- a/src/components/ServicesSection.astro
+++ b/src/components/ServicesSection.astro
@@ -21,14 +21,9 @@ const services = [
     anchor: "competitive-intelligence",
   },
   {
-    key: "tools" as const,
-    icon: `<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" /><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />`,
-    anchor: "custom-tools",
-  },
-  {
-    key: "clarity" as const,
-    icon: `<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />`,
-    anchor: "clarity-sprint",
+    key: "voice" as const,
+    icon: `<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />`,
+    anchor: "voice-agent",
   },
 ];
 ---
@@ -44,7 +39,7 @@ const services = [
       </p>
     </div>
 
-    <div class="grid md:grid-cols-2 gap-6 lg:gap-8">
+    <div class="grid md:grid-cols-3 gap-6 lg:gap-8">
       {services.map(({ key, icon, anchor }) => (
         <a
           href={`${servicesUrl}#${anchor}`}

--- a/src/components/home2/SolutionOverview.astro
+++ b/src/components/home2/SolutionOverview.astro
@@ -13,7 +13,7 @@ const content = {
     body: "Your FAQs, pricing, policies, and procedures — stuck in Google Docs, WhatsApp, and someone's head — become an AI assistant that answers customers, captures leads, and handles repetitive tasks. In English and Spanish.",
     pillars: [
       {
-        title: "AI Customer Support Chatbot",
+        title: "Intelligent Customer Support AI Chatbot",
         desc: "Answers your customers' questions 24/7 in English and Spanish. Captures leads while you sleep. Hands off to your team when a human is needed.",
         icon: "M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"
       },
@@ -37,7 +37,7 @@ const content = {
     body: "Tus FAQs, precios, políticas y procedimientos — atorados en Google Docs, WhatsApp y la cabeza de alguien — se convierten en un asistente de IA que responde a clientes, captura leads y maneja tareas repetitivas. En inglés y español.",
     pillars: [
       {
-        title: "Chatbot de Atención al Cliente con IA",
+        title: "Chatbot Inteligente de Atención al Cliente",
         desc: "Responde las preguntas de tus clientes 24/7 en inglés y español. Captura leads mientras duermes. Transfiere a tu equipo cuando se necesita un humano.",
         icon: "M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"
       },

--- a/src/components/services2/FAQ.astro
+++ b/src/components/services2/FAQ.astro
@@ -17,15 +17,11 @@ const content = {
       },
       {
         q: "How do I know which service I need?",
-        a: "That's what the discovery call is for. In 30 minutes, I'll assess your situation and recommend the right starting point. If you're genuinely unsure, the AI Strategy Session ($1,500, credited toward any service) gives you a complete evaluation and action plan before you commit."
+        a: "That's what the discovery call is for. In 30 minutes, I'll assess your situation and recommend the right starting point — the Growth Bundle for most businesses, or the Voice Agent if phone calls are your biggest bottleneck."
       },
       {
-        q: "Can I start with one service and add more later?",
-        a: "Absolutely. Most clients start with a chatbot or voice agent and add Google Maps monitoring or AI product photos within 60 days once they see results. When you bundle services, I'll build you a custom package at a better monthly rate."
-      },
-      {
-        q: "What's included in the monthly price?",
-        a: "Everything. Setup, training, deployment, weekly performance reports, monthly tuning, and email support (24-hour response). No hidden fees. No surprise charges. The price you see is the price you pay."
+        q: "What's included in the Growth Bundle?",
+        a: "Everything. An AI assistant on the channel of your choice (website, WhatsApp, Facebook, Instagram, or Telegram), Google Maps competitive monitoring with a weekly action plan, AI-generated product photos for social media, weekly performance reports, monthly tuning, and email support (24-hour response). No hidden fees. No surprise charges."
       },
       {
         q: "What if the AI voice agent goes over 500 minutes?",
@@ -58,15 +54,11 @@ const content = {
       },
       {
         q: "¿Cómo sé qué servicio necesito?",
-        a: "Para eso es la llamada. En 30 minutos, evalúo tu situación y recomiendo el punto de partida correcto. Si aún dudas, la Sesión de Estrategia de IA ($25,500 MXN, acreditado a cualquier servicio) te da un plan de acción completo antes de que te comprometas."
+        a: "Para eso es la llamada. En 30 minutos, evalúo tu situación y recomiendo el punto de partida correcto — el Paquete de Crecimiento para la mayoría de los negocios, o el Agente de Voz si las llamadas telefónicas son tu mayor cuello de botella."
       },
       {
-        q: "¿Puedo empezar con un servicio y agregar más después?",
-        a: "Totalmente. La mayoría de los clientes inician con un chatbot o agente de voz y agregan monitoreo de Google Maps o fotos con IA en 60 días cuando ven resultados. Cuando combinas servicios, te armo un paquete personalizado a mejor precio mensual."
-      },
-      {
-        q: "¿Qué incluye el precio mensual?",
-        a: "Todo. Configuración, entrenamiento, despliegue, reportes semanales de desempeño, ajuste mensual y soporte por email (respuesta en 24 horas). Sin cuotas ocultas. Sin sorpresas. El precio que ves es el precio que pagas."
+        q: "¿Qué incluye el Paquete de Crecimiento?",
+        a: "Todo. Un asistente de IA en el canal de tu preferencia (sitio web, WhatsApp, Facebook, Instagram o Telegram), monitoreo competitivo en Google Maps con plan de acción semanal, fotos de producto con IA para redes sociales, reportes semanales de desempeño, ajuste mensual y soporte por email (respuesta en 24 horas). Sin cuotas ocultas. Sin sorpresas."
       },
       {
         q: "¿Qué pasa si el agente de voz supera los 500 minutos?",
@@ -95,7 +87,7 @@ const content = {
 const t = content[locale];
 ---
 
-<section class="py-20 md:py-32 bg-white dark:bg-black">
+<section id="faq" class="py-20 md:py-32 bg-white dark:bg-black">
   <Container size="sm">
     <div class="text-center mb-16">
       <h2 class="font-display font-bold text-3xl md:text-5xl text-gray-900 dark:text-white leading-tight tracking-tight">

--- a/src/components/services2/FinalCTA.astro
+++ b/src/components/services2/FinalCTA.astro
@@ -13,8 +13,8 @@ const content = {
     body: "Book a free 30-minute discovery call. I'll assess your situation, recommend the right service, and if we're a fit — your 2-week free trial starts immediately.\n\nNo jargon. No pressure. No commitment until you've seen it working.",
     primaryCta: "Start Free Trial",
     primaryLink: "/consultation/",
-    secondaryCta: "Or start with an AI Strategy Session ($1,500) →",
-    secondaryLink: "#clarity-sprint",
+    secondaryCta: "Have questions? See the FAQ →",
+    secondaryLink: "#faq",
     footer: "I respond within 24 hours · Free 2-week trial · Cancel anytime"
   },
   es: {
@@ -22,8 +22,8 @@ const content = {
     body: "Agenda una llamada gratuita de 30 minutos. Evalúo tu situación, recomiendo el servicio correcto, y si hacemos match — tu prueba gratis de 2 semanas empieza de inmediato.\n\nSin tecnicismos. Sin presión. Sin compromiso hasta que lo veas funcionando.",
     primaryCta: "Empezar Prueba Gratis",
     primaryLink: "/es/reservar/",
-    secondaryCta: "O empieza con una Sesión de Estrategia ($25,500 MXN) →",
-    secondaryLink: "#clarity-sprint",
+    secondaryCta: "¿Tienes preguntas? Ve las FAQ →",
+    secondaryLink: "#faq",
     footer: "Respondo en < 24 horas · Prueba gratis de 2 semanas · Cancela cuando quieras"
   }
 };

--- a/src/components/services2/InvestmentOverview.astro
+++ b/src/components/services2/InvestmentOverview.astro
@@ -11,117 +11,95 @@ const content = {
   en: {
     heading: "Simple Monthly Pricing",
     intro: "No setup fees. No long-term contracts. Free 2-week trial on every service. Cancel anytime.",
-    headers: ["Service", "Monthly", "What's Included", "Support"],
-    rows: [
-      {
-        service: "AI Chatbot (Website/WhatsApp)",
-        startingAt: "$497/mo",
-        typicalRange: "Unlimited conversations, weekly reports, monthly tuning",
-        timeline: "Email (24hr)"
-      },
-      {
-        service: "AI Messenger Assistant (Facebook)",
-        startingAt: "$497/mo",
-        typicalRange: "Unlimited conversations, weekly reports, monthly tuning",
-        timeline: "Email (24hr)"
-      },
-      {
-        service: "AI Voice Agent",
-        startingAt: "$497/mo",
-        typicalRange: "500 min included, appointment booking, lead capture",
-        timeline: "Email (24hr)"
-      },
-      {
-        service: "Google Maps Monitoring",
-        startingAt: "$297/mo",
-        typicalRange: "Weekly tracking, 5 competitors, WhatsApp action plan",
-        timeline: "Weekly WhatsApp"
-      },
-      {
-        service: "AI Product Photos",
-        startingAt: "$297/mo",
-        typicalRange: "Fresh images weekly for Instagram, Facebook, Reels",
-        timeline: "24hr turnaround"
-      },
-      {
-        service: "Custom AI Automation",
-        startingAt: "From $5,000",
-        typicalRange: "Project-based. Scoped during discovery call",
-        timeline: "4–8 weeks"
-      },
-      {
-        service: "AI Strategy Session",
-        startingAt: "$1,500",
-        typicalRange: "Flat fee — credited toward any service if you proceed",
-        timeline: "5–10 days"
-      }
-    ],
-    note: "Every service starts with a free discovery call. I'll assess your situation and recommend the right starting point — no commitment required.",
-    credit: "**Save with bundles:** Combine 2+ services and I'll build you a custom package at a better rate. Most clients bundle the chatbot + Google Maps + product photos for a single monthly price."
+    bundleLabel: "Most Popular",
+    bundle: {
+      name: "AI Growth Bundle",
+      price: "$997",
+      period: "/mo",
+      description: "Everything your business needs to capture more leads, monitor competitors, and look great online — powered by AI, fully managed by me.",
+      features: [
+        "AI assistant on your website, WhatsApp, Facebook, Instagram, or Telegram",
+        "Google Maps competitive monitoring + weekly action plan",
+        "AI-generated product photos — fresh content weekly for social media",
+        "Bilingual (English & Spanish) — automatic language detection",
+        "Weekly performance reports delivered to your inbox",
+        "Monthly tuning as your business evolves",
+        "Human handoff when conversations need a real person"
+      ],
+      cta: "Start Free Trial",
+      ctaLink: "/consultation/"
+    },
+    voiceLabel: "Premium",
+    voice: {
+      name: "AI Voice Agent",
+      price: "$1,497",
+      period: "/mo",
+      description: "Your phone answered on the first ring, 24/7. Appointments booked. Leads captured. Callers never know it's AI.",
+      features: [
+        "Natural-sounding voice matched to your brand",
+        "500 minutes included (overage at $0.50/min)",
+        "Appointment booking directly into your calendar",
+        "Lead capture — name, number, intent texted to you instantly",
+        "Call transfer with context when a human is needed",
+        "Bilingual (English & Spanish)",
+        "Monthly call reports and ongoing optimization"
+      ],
+      cta: "Start Free Trial",
+      ctaLink: "/consultation/"
+    },
+    roi: "A part-time employee costs $3,000+/month and works 20 hours a week. Your AI works 24/7 for a fraction of that — and never calls in sick.",
+    note: "Every service starts with a free discovery call. I'll assess your situation and recommend the right starting point — no commitment required."
   },
   es: {
     heading: "Precios Mensuales Simples",
     intro: "Sin cuota de instalación. Sin contratos. Prueba gratis de 2 semanas en cada servicio. Cancela cuando quieras.",
-    headers: ["Servicio", "Mensual", "Qué Incluye", "Soporte"],
-    rows: [
-      {
-        service: "Chatbot de IA (Sitio Web/WhatsApp)",
-        startingAt: "$4,999 MXN/mes",
-        typicalRange: "Conversaciones ilimitadas, reportes semanales, ajuste mensual",
-        timeline: "Email (24hr)"
-      },
-      {
-        service: "Asistente de IA en Facebook Messenger",
-        startingAt: "$4,999 MXN/mes",
-        typicalRange: "Conversaciones ilimitadas, reportes semanales, ajuste mensual",
-        timeline: "Email (24hr)"
-      },
-      {
-        service: "Agente de Voz con IA",
-        startingAt: "$4,999 MXN/mes",
-        typicalRange: "500 min incluidos, agendado de citas, captura de leads",
-        timeline: "Email (24hr)"
-      },
-      {
-        service: "Monitoreo de Google Maps",
-        startingAt: "$2,499 MXN/mes",
-        typicalRange: "Rastreo semanal, 5 competidores, plan de acción por WhatsApp",
-        timeline: "WhatsApp semanal"
-      },
-      {
-        service: "Fotos de Producto con IA",
-        startingAt: "$2,499 MXN/mes",
-        typicalRange: "Imágenes frescas cada semana para Instagram, Facebook, Reels",
-        timeline: "24hr de entrega"
-      },
-      {
-        service: "Automatización Personalizada con IA",
-        startingAt: "Desde $85,000 MXN",
-        typicalRange: "Por proyecto. Se define en la llamada de descubrimiento",
-        timeline: "4–8 semanas"
-      },
-      {
-        service: "Sesión de Estrategia de IA",
-        startingAt: "$25,500 MXN",
-        typicalRange: "Tarifa plana — acreditado a cualquier servicio si procedes",
-        timeline: "5–10 días"
-      }
-    ],
-    note: "Cada servicio empieza con una llamada de descubrimiento gratuita. Evalúo tu situación y recomiendo el punto de partida correcto — sin compromiso.",
-    credit: "**Ahorra con paquetes:** Combina 2+ servicios y te armo un paquete personalizado a mejor precio. La mayoría de los clientes combinan el chatbot + Google Maps + fotos de producto en un solo precio mensual."
+    bundleLabel: "Más Popular",
+    bundle: {
+      name: "Paquete de Crecimiento con IA",
+      price: "$8,497",
+      period: " MXN/mes",
+      description: "Todo lo que tu negocio necesita para captar más clientes, monitorear competidores y verse increíble en línea — impulsado por IA, gestionado completamente por mí.",
+      features: [
+        "Asistente de IA en tu sitio web, WhatsApp, Facebook, Instagram o Telegram",
+        "Monitoreo competitivo en Google Maps + plan de acción semanal",
+        "Fotos de producto con IA — contenido fresco cada semana para redes sociales",
+        "Bilingüe (inglés y español) — detección automática de idioma",
+        "Reportes semanales de desempeño en tu bandeja de entrada",
+        "Ajuste mensual conforme tu negocio evoluciona",
+        "Transferencia a humano cuando la conversación lo requiere"
+      ],
+      cta: "Empezar Prueba Gratis",
+      ctaLink: "/es/reservar/"
+    },
+    voiceLabel: "Premium",
+    voice: {
+      name: "Agente de Voz con IA",
+      price: "$10,997",
+      period: " MXN/mes",
+      description: "Tu teléfono contestado al primer timbrazo, 24/7. Citas agendadas. Leads capturados. Los que llaman nunca saben que es IA.",
+      features: [
+        "Voz natural que coincide con tu marca",
+        "500 minutos incluidos (excedente a $8.50 MXN/min)",
+        "Agendado de citas directo en tu calendario",
+        "Captura de leads — nombre, número e intención enviados por texto al instante",
+        "Transferencia con contexto cuando se necesita una persona",
+        "Bilingüe (inglés y español)",
+        "Reportes mensuales de llamadas y optimización continua"
+      ],
+      cta: "Empezar Prueba Gratis",
+      ctaLink: "/es/reservar/"
+    },
+    roi: "Un empleado de medio tiempo cuesta $8,000+ MXN/mes y trabaja 20 horas a la semana. Tu IA trabaja 24/7 por una fracción de eso — y nunca falta.",
+    note: "Cada servicio empieza con una llamada de descubrimiento gratuita. Evalúo tu situación y recomiendo el punto de partida correcto — sin compromiso."
   }
 };
 
 const t = content[locale];
-
-function formatBold(text: string) {
-  return text.replace(/\*\*(.*?)\*\*/g, '<strong class="text-gray-900 dark:text-white font-semibold">$1</strong>');
-}
 ---
 
 <section id="pricing" class="py-20 md:py-32 bg-gray-50 dark:bg-gray-900/40 border-y border-gray-200 dark:border-gray-800">
   <Container size="lg">
-    <div class="text-center mb-12 max-w-3xl mx-auto">
+    <div class="text-center mb-16 max-w-3xl mx-auto">
       <h2 class="font-display font-bold text-3xl md:text-5xl text-gray-900 dark:text-white mb-6 leading-tight tracking-tight">
         {t.heading}
       </h2>
@@ -130,69 +108,98 @@ function formatBold(text: string) {
       </p>
     </div>
 
-    <!-- Desktop Table (Hidden on small screens) -->
-    <div class="hidden md:block overflow-hidden bg-white dark:bg-black rounded-xl border border-gray-200 dark:border-gray-800 shadow-sm max-w-5xl mx-auto mb-8">
-      <table class="w-full text-left border-collapse">
-        <thead class="bg-gray-50 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800">
-          <tr>
-            {t.headers.map(header => (
-              <th class="py-4 px-6 font-display font-bold text-gray-900 dark:text-white uppercase tracking-wider text-sm">
-                {header}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody class="divide-y divide-gray-100 dark:divide-gray-800">
-          {t.rows.map((row) => (
-            <tr class="hover:bg-cush-orange/5 dark:hover:bg-cush-orange/10 transition-colors">
-              <td class="py-5 px-6 font-semibold text-gray-900 dark:text-white whitespace-nowrap">
-                {row.service}
-              </td>
-              <td class="py-5 px-6 font-mono text-gray-600 dark:text-gray-400 whitespace-nowrap">
-                {row.startingAt}
-              </td>
-              <td class="py-5 px-6 text-gray-600 dark:text-gray-400 whitespace-nowrap">
-                {row.typicalRange}
-              </td>
-              <td class="py-5 px-6 text-sm text-gray-600 dark:text-gray-400 whitespace-nowrap">
-                {row.timeline}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <div class="grid md:grid-cols-2 gap-8 max-w-5xl mx-auto mb-12">
 
-    <!-- Mobile Cards (Visible only on small screens) -->
-    <div class="md:hidden space-y-4 max-w-lg mx-auto mb-8">
-      {t.rows.map(row => (
-        <div class="bg-white dark:bg-black border border-gray-200 dark:border-gray-800 rounded-xl p-5 shadow-sm">
-          <h3 class="font-display font-bold text-lg text-gray-900 dark:text-white mb-4 pb-2 border-b border-gray-100 dark:border-gray-800">
-            {row.service}
-          </h3>
-          <div class="grid grid-cols-2 gap-4 text-sm">
-            <div>
-              <span class="block text-gray-500 dark:text-gray-500 uppercase tracking-wider text-xs mb-1 mb-1">{t.headers[1]}</span>
-              <span class="font-mono text-gray-900 dark:text-gray-200 font-medium">{row.startingAt}</span>
-            </div>
-            <div>
-              <span class="block text-gray-500 dark:text-gray-500 uppercase tracking-wider text-xs mb-1">{t.headers[3]}</span>
-              <span class="text-gray-900 dark:text-gray-200">{row.timeline}</span>
-            </div>
-            <div class="col-span-2 pt-2">
-              <span class="block text-gray-500 dark:text-gray-500 uppercase tracking-wider text-xs mb-1">{t.headers[2]}</span>
-              <span class="text-gray-900 dark:text-gray-200">{row.typicalRange}</span>
-            </div>
-          </div>
+      <!-- Growth Bundle Card -->
+      <div class="relative bg-white dark:bg-black rounded-2xl border-2 border-cush-orange shadow-xl shadow-cush-orange/10 p-8 md:p-10 flex flex-col">
+        <div class="absolute -top-4 left-8">
+          <span class="inline-block bg-cush-orange text-white text-xs font-display font-bold uppercase tracking-wider px-4 py-1.5 rounded-full">
+            {t.bundleLabel}
+          </span>
         </div>
-      ))}
+
+        <h3 class="font-display font-bold text-2xl text-gray-900 dark:text-white mt-2 mb-2">
+          {t.bundle.name}
+        </h3>
+
+        <div class="mb-4">
+          <span class="font-display font-bold text-5xl text-gray-900 dark:text-white">{t.bundle.price}</span>
+          <span class="text-gray-500 dark:text-gray-400 text-lg">{t.bundle.period}</span>
+        </div>
+
+        <p class="text-gray-600 dark:text-gray-400 leading-relaxed mb-8">
+          {t.bundle.description}
+        </p>
+
+        <ul class="space-y-3 mb-8 flex-grow">
+          {t.bundle.features.map(feature => (
+            <li class="flex gap-3">
+              <svg class="w-5 h-5 text-green-500 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+              </svg>
+              <span class="text-gray-700 dark:text-gray-300 text-sm leading-relaxed">{feature}</span>
+            </li>
+          ))}
+        </ul>
+
+        <a
+          href={t.bundle.ctaLink}
+          class="block w-full text-center px-6 py-4 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-colors duration-300 shadow-lg shadow-cush-orange/20"
+        >
+          {t.bundle.cta}
+        </a>
+      </div>
+
+      <!-- Voice Agent Card -->
+      <div class="relative bg-white dark:bg-black rounded-2xl border border-gray-200 dark:border-gray-800 shadow-sm p-8 md:p-10 flex flex-col">
+        <div class="absolute -top-4 left-8">
+          <span class="inline-block bg-gray-900 dark:bg-gray-700 text-white text-xs font-display font-bold uppercase tracking-wider px-4 py-1.5 rounded-full">
+            {t.voiceLabel}
+          </span>
+        </div>
+
+        <h3 class="font-display font-bold text-2xl text-gray-900 dark:text-white mt-2 mb-2">
+          {t.voice.name}
+        </h3>
+
+        <div class="mb-4">
+          <span class="font-display font-bold text-5xl text-gray-900 dark:text-white">{t.voice.price}</span>
+          <span class="text-gray-500 dark:text-gray-400 text-lg">{t.voice.period}</span>
+        </div>
+
+        <p class="text-gray-600 dark:text-gray-400 leading-relaxed mb-8">
+          {t.voice.description}
+        </p>
+
+        <ul class="space-y-3 mb-8 flex-grow">
+          {t.voice.features.map(feature => (
+            <li class="flex gap-3">
+              <svg class="w-5 h-5 text-green-500 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+              </svg>
+              <span class="text-gray-700 dark:text-gray-300 text-sm leading-relaxed">{feature}</span>
+            </li>
+          ))}
+        </ul>
+
+        <a
+          href={t.voice.ctaLink}
+          class="block w-full text-center px-6 py-4 bg-gray-900 dark:bg-white text-white dark:text-gray-900 font-display font-semibold rounded-lg hover:bg-gray-800 dark:hover:bg-gray-100 transition-colors duration-300"
+        >
+          {t.voice.cta}
+        </a>
+      </div>
+
     </div>
 
-    <div class="max-w-4xl mx-auto space-y-4">
-      <p class="text-gray-600 dark:text-gray-400 text-sm leading-relaxed text-center">
+    <!-- ROI Message -->
+    <div class="max-w-3xl mx-auto text-center space-y-4">
+      <div class="bg-orange-50 dark:bg-orange-900/20 text-orange-800 dark:text-orange-200 p-5 rounded-xl text-base border border-orange-100 dark:border-orange-800/50 font-medium leading-relaxed">
+        {t.roi}
+      </div>
+      <p class="text-gray-500 dark:text-gray-500 text-sm">
         {t.note}
       </p>
-      <div class="bg-orange-50 dark:bg-orange-900/20 text-orange-800 dark:text-orange-200 p-4 rounded-lg text-sm text-center border border-orange-100 dark:border-orange-800/50" set:html={formatBold(t.credit)} />
     </div>
   </Container>
 </section>

--- a/src/components/services2/ScenarioQualifier.astro
+++ b/src/components/services2/ScenarioQualifier.astro
@@ -22,36 +22,29 @@ const content = {
         iconKey: "chat",
         title: "My team answers the same questions all day",
         body: "Your support team is buried in repetitive inquiries — pricing, policies, order status. Response times are slipping, leads disappear after hours, and you're paying $4,000+/month for someone who can only work 8 hours a day.",
-        linkText: "→ AI Chatbot — $497/mo",
+        linkText: "→ AI Chatbot — Growth Bundle $997/mo",
         anchor: "#support-assistants"
       },
       {
         iconKey: "chat",
         title: "Customers message my Facebook page after hours and I lose them",
         body: "Someone messages at 10pm asking about pricing or availability. By morning they've booked with the competitor who answered in two minutes. Facebook already removed your \"responds quickly\" badge.",
-        linkText: "→ AI Messenger Assistant — $497/mo",
+        linkText: "→ AI Messenger Assistant — Growth Bundle $997/mo",
         anchor: "#competitive-intelligence"
       },
       {
         iconKey: "eye",
+        title: "I have no idea what my competitors are doing on Google Maps",
+        body: "A new competitor appeared in your area last month with 40 five-star reviews. They're outranking you in local search and you didn't even notice. By the time you react, they've already taken your customers.",
+        linkText: "→ Competitive Monitoring — Growth Bundle $997/mo",
+        anchor: "#competitive-intelligence"
+      },
+      {
+        iconKey: "chat",
         title: "My phone rings and nobody picks up",
         body: "You miss 3–5 calls a day while you're with clients, driving, or at lunch. Each one could be a $500 customer. That's $7,500–$12,500/month walking away because nobody answered the phone.",
-        linkText: "→ AI Voice Agent — $497/mo",
+        linkText: "→ AI Voice Agent — $1,497/mo",
         anchor: "#voice-agent"
-      },
-      {
-        iconKey: "cog",
-        title: "We're drowning in repetitive manual work",
-        body: "Data entry, report generation, manual follow-ups, copy-paste workflows. Your team spends 10+ hours a week on tasks that should take minutes — that's $25,000–$50,000/year in wasted salary.",
-        linkText: "→ Custom AI Automation — from $5,000",
-        anchor: "#custom-tools"
-      },
-      {
-        iconKey: "compass",
-        title: "I know AI could help — I just don't know where to start",
-        body: "You've seen the hype. Maybe you've been burned by a failed experiment. You need someone to assess your business honestly, identify the real opportunities, and give you a plan you can act on.",
-        linkText: "→ AI Strategy Session — $1,500",
-        anchor: "#clarity-sprint"
       }
     ]
   },
@@ -62,36 +55,29 @@ const content = {
         iconKey: "chat",
         title: "Mi equipo responde lo mismo todo el día",
         body: "Tu equipo está enterrado en consultas repetitivas — precios, políticas, estado de pedidos. Los tiempos de respuesta caen, los prospectos se pierden y estás pagando $8,000+ MXN/mes por alguien que solo trabaja 8 horas al día.",
-        linkText: "→ Chatbot con IA — $4,999 MXN/mes",
+        linkText: "→ Chatbot con IA — Paquete de Crecimiento $8,497 MXN/mes",
         anchor: "#support-assistants"
       },
       {
         iconKey: "chat",
         title: "Mis clientes me escriben en Facebook fuera de horario y los pierdo",
         body: "Alguien escribe a las 10 de la noche preguntando precios o disponibilidad. Para la mañana ya reservó con el competidor que contestó en dos minutos. Facebook ya te quitó la insignia de \"responde rápido\".",
-        linkText: "→ Asistente de IA en Messenger — $4,999 MXN/mes",
+        linkText: "→ Asistente de IA en Messenger — Paquete de Crecimiento $8,497 MXN/mes",
         anchor: "#competitive-intelligence"
       },
       {
         iconKey: "eye",
+        title: "No tengo idea qué hacen mis competidores en Google Maps",
+        body: "Un nuevo competidor apareció en tu zona el mes pasado con 40 reseñas de cinco estrellas. Te está superando en búsqueda local y ni te enteraste. Cuando reacciones, ya se llevó a tus clientes.",
+        linkText: "→ Monitoreo Competitivo — Paquete de Crecimiento $8,497 MXN/mes",
+        anchor: "#competitive-intelligence"
+      },
+      {
+        iconKey: "chat",
         title: "Suena mi teléfono y nadie contesta",
         body: "Pierdes 3–5 llamadas al día mientras estás con clientes, manejando, o comiendo. Cada una puede ser un cliente de $5,000 MXN. Son $75,000–$125,000 MXN/mes que se van porque nadie contestó.",
-        linkText: "→ Agente de Voz con IA — $4,999 MXN/mes",
+        linkText: "→ Agente de Voz con IA — $10,997 MXN/mes",
         anchor: "#voice-agent"
-      },
-      {
-        iconKey: "cog",
-        title: "Nos ahogamos en trabajo manual",
-        body: "Entrada de datos, reportes, seguimientos manuales. Tu equipo pasa 10+ horas a la semana en tareas que deberían tomar minutos — son $400,000–$800,000 MXN/año en salario desperdiciado.",
-        linkText: "→ Automatización con IA — desde $85,000 MXN",
-        anchor: "#custom-tools"
-      },
-      {
-        iconKey: "compass",
-        title: "Sé que la IA ayudaría, pero no sé por dónde empezar",
-        body: "Has visto el humo del mercado. Tal vez te decepcionaste con algún demo. Necesitas a alguien que evalúe tu negocio honestamente y te dé un plan en el que puedas confiar y actuar.",
-        linkText: "→ Sesión de Estrategia — $25,500 MXN",
-        anchor: "#clarity-sprint"
       }
     ]
   }

--- a/src/components/services2/ServiceBlock.astro
+++ b/src/components/services2/ServiceBlock.astro
@@ -13,7 +13,7 @@ const { locale, id, isAlternate = false } = Astro.props;
 const data = {
   'support-assistants': {
     en: {
-      heading: "AI Customer Support Chatbot",
+      heading: "Intelligent Customer Support AI Chatbot",
       subheading: "A customer asks a question at 9 PM. By morning, they bought from your competitor. That stops today.",
       problem: "Your team answers the same questions dozens of times a day. Customers wait. Leads ask a question at 9pm and never come back. You can't hire fast enough, and the people you do hire spend their first month learning answers that live in scattered documents.\n\nA community manager costs $4,000–$6,000/month — and only works 8 hours a day. Your AI assistant works 24/7 for a fraction of that.",
       whatIBuild: "An AI assistant trained on YOUR business knowledge — your docs, your policies, your pricing, your product information — that answers customer questions accurately, in English and Spanish, around the clock.\n\nNot a generic chatbot. A system that knows your business, validates its answers against your approved sources, and hands off to your team when human judgment is needed.",
@@ -32,7 +32,7 @@ const data = {
         "Generating new content — the assistant surfaces YOUR existing knowledge, it doesn't create marketing copy"
       ],
       timeline: "Live in 2–4 weeks. Discovery call → training → testing → launch.",
-      investment: "**$497/month** — unlimited conversations, fully managed. Includes setup, training, weekly reports, and monthly tuning. No setup fee. No long-term contract.",
+      investment: "Included in the **AI Growth Bundle — $997/month**. Unlimited conversations, fully managed. Includes setup, training, weekly reports, and monthly tuning. No setup fee. No long-term contract.",
       investmentDisclaimer: "Free 2-week trial. Cancel anytime.",
       bestFor: [
         "Customer support teams handling 500+ inquiries/month",
@@ -42,7 +42,7 @@ const data = {
       ]
     },
     es: {
-      heading: "Chatbot de Atención al Cliente con IA",
+      heading: "Chatbot Inteligente de Atención al Cliente",
       subheading: "Un cliente pregunta a las 9 de la noche. Para la mañana, ya compró con tu competidor. Eso se acaba hoy.",
       problem: "Tu equipo responde las mismas preguntas docenas de veces al día. Los clientes esperan. Los leads preguntan a las 9pm y nunca regresan. No puedes contratar lo suficientemente rápido.\n\nUn community manager cuesta $8,000–$15,000 MXN/mes — y solo trabaja 8 horas al día. Tu asistente de IA trabaja 24/7 por una fracción de eso.",
       whatIBuild: "Un asistente de IA entrenado con EL conocimiento de TU negocio — tus documentos, políticas, precios — que responde con precisión en inglés y español todo el día.\n\nNo es un chatbot genérico. Es un sistema que conoce tu negocio, valida sus respuestas contra fuentes aprobadas y transfiere a tu equipo cuando se necesita criterio humano.",
@@ -61,7 +61,7 @@ const data = {
         "Creación de contenido nuevo de marketing"
       ],
       timeline: "En vivo en 2–4 semanas. Llamada → entrenamiento → pruebas → lanzamiento.",
-      investment: "**$4,999 MXN/mes** — conversaciones ilimitadas, totalmente gestionado. Incluye configuración, entrenamiento, reportes semanales y ajuste mensual. Sin cuota de instalación. Sin contrato.",
+      investment: "Incluido en el **Paquete de Crecimiento con IA — $8,497 MXN/mes**. Conversaciones ilimitadas, totalmente gestionado. Incluye configuración, entrenamiento, reportes semanales y ajuste mensual. Sin cuota de instalación. Sin contrato.",
       investmentDisclaimer: "Prueba gratis de 2 semanas. Cancela cuando quieras.",
       bestFor: [
         "Equipos procesando 500+ consultas al mes",
@@ -92,7 +92,7 @@ const data = {
         "Paid Facebook ad management or social posting"
       ],
       timeline: "Live in 2 weeks. Discovery call → training → testing → launch.",
-      investment: "**$497/month** — single page, unlimited conversations, fully managed. Includes setup, training, weekly reports, and monthly tuning. No setup fee. No long-term contract.",
+      investment: "Included in the **AI Growth Bundle — $997/month**. Single page, unlimited conversations, fully managed. Includes setup, training, weekly reports, and monthly tuning. No setup fee. No long-term contract.",
       investmentDisclaimer: "Free 2-week trial. Cancel anytime.",
       bestFor: [
         "Local businesses losing leads to slow response times",
@@ -121,7 +121,7 @@ const data = {
         "Gestión de anuncios de Facebook o publicaciones en redes sociales"
       ],
       timeline: "En vivo en 2 semanas. Llamada de descubrimiento → entrenamiento → pruebas → lanzamiento.",
-      investment: "**$4,999 MXN/mes** — una sola página, conversaciones ilimitadas, totalmente gestionado. Incluye configuración, entrenamiento, reportes semanales y ajuste mensual. Sin cuota de instalación. Sin contrato.",
+      investment: "Incluido en el **Paquete de Crecimiento con IA — $8,497 MXN/mes**. Una sola página, conversaciones ilimitadas, totalmente gestionado. Incluye configuración, entrenamiento, reportes semanales y ajuste mensual. Sin cuota de instalación. Sin contrato.",
       investmentDisclaimer: "Prueba gratis de 2 semanas. Cancela cuando quieras.",
       bestFor: [
         "Negocios locales perdiendo clientes por respuestas lentas",
@@ -153,7 +153,7 @@ const data = {
         "Call recording storage beyond 30 days"
       ],
       timeline: "Live in 1–2 weeks. Discovery call → voice setup → testing → launch.",
-      investment: "**$497/month** — includes up to 500 minutes, setup, training, and monthly reports. Overage at $0.50/min. No setup fee. No long-term contract.",
+      investment: "**$1,497/month** — includes up to 500 minutes, setup, training, and monthly reports. Overage at $0.50/min. No setup fee. No long-term contract.",
       investmentDisclaimer: "Free 2-week trial. Cancel anytime.",
       bestFor: [
         "Service businesses missing calls during busy hours (salons, clinics, contractors)",
@@ -183,129 +183,13 @@ const data = {
         "Almacenamiento de grabaciones más allá de 30 días"
       ],
       timeline: "En vivo en 1–2 semanas. Llamada → configuración de voz → pruebas → lanzamiento.",
-      investment: "**$4,999 MXN/mes** — incluye hasta 500 minutos, configuración, entrenamiento y reportes mensuales. Excedente a $8.50 MXN/min. Sin cuota de instalación. Sin contrato.",
+      investment: "**$10,997 MXN/mes** — incluye hasta 500 minutos, configuración, entrenamiento y reportes mensuales. Excedente a $8.50 MXN/min. Sin cuota de instalación. Sin contrato.",
       investmentDisclaimer: "Prueba gratis de 2 semanas. Cancela cuando quieras.",
       bestFor: [
         "Negocios de servicio que pierden llamadas en horas pico (salones, clínicas, contratistas)",
         "Equipos pequeños sin recepcionista dedicada",
         "Negocios perdiendo clientes ante competidores que contestan más rápido",
         "Cualquiera pagando $8,000+ MXN/mes por una recepcionista que solo trabaja 40 horas a la semana"
-      ]
-    }
-  },
-  'custom-tools': {
-    en: {
-      heading: "Custom AI Automation",
-      subheading: "Your team spends 10+ hours a week on tasks a machine should handle. I build the machine.",
-      problem: "Your team spends hours every week on repetitive, structured work — data entry, report generation, manual follow-ups, document processing, or copy-paste tasks between systems.\n\nEvery hour your team spends on busywork is an hour they're not spending on customers, strategy, or growth. And the cost compounds — that's $25,000–$50,000/year in wasted salary for a single workflow.",
-      whatIBuild: "Custom AI-powered tools designed for YOUR specific process. Not a generic automation platform you need to configure — a purpose-built application that handles the exact workflow that's eating your team's time.\n\nExamples: AI writing systems, document processors, data extraction pipelines, web scraping systems, report generators.",
-      included: [
-        { title: "Workflow analysis", desc: "I map your current process end-to-end, identify the bottlenecks, and design the automation that delivers the highest time savings" },
-        { title: "Custom application development", desc: "Built with production-grade engineering: proper validation, error handling, logging, and security" },
-        { title: "Testing with real data", desc: "I test with your actual workflows, not synthetic examples" },
-        { title: "User interface (when needed)", desc: "Clean, simple interfaces your team can use without training" },
-        { title: "Integration with existing tools", desc: "Connected to the systems you already use (Google Workspace, WhatsApp, Slack, email, databases)" },
-        { title: "Documentation and handoff", desc: "Full technical and operational documentation" },
-        { title: "30-day optimization window", desc: "Post-launch tuning based on real-world usage" }
-      ],
-      notIncluded: [
-        "Ongoing feature development beyond the initial scope (available via retainer)",
-        "Replacement of core business systems (ERP, CRM migrations, etc.)",
-        "AI solutions for problems that don't need AI — I'll tell you if that's the case"
-      ],
-      timeline: "4–8 weeks, depending on complexity and number of integrations.",
-      investment: "Project-based. Starts at **$5,000** for focused single-workflow automation. Multi-system integrations typically **$8,000–$15,000+**.",
-      investmentDisclaimer: "All projects are scoped and quoted during the free discovery call. No surprises.",
-      bestFor: [
-        "Teams spending 10+ hours/week on repetitive manual tasks",
-        "Businesses with custom workflows that off-the-shelf tools don't support",
-        "Companies ready to automate a specific, well-understood process",
-        "Operations leaders who know exactly what's eating their team's time"
-      ]
-    },
-    es: {
-      heading: "Automatización Personalizada con IA",
-      subheading: "Tu equipo gasta 10+ horas a la semana en tareas que una máquina debería manejar. Yo construyo la máquina.",
-      problem: "Tu equipo pasa horas cada semana en trabajo repetitivo y estructurado — captura de datos, generación de reportes, seguimientos manuales, procesamiento de documentos, o tareas de copiar y pegar entre sistemas.\n\nCada hora que tu equipo gasta en trabajo manual es una hora que no gastan en clientes, estrategia o crecimiento. Y el costo se acumula — son $400,000–$800,000 MXN/año en salario desperdiciado por un solo flujo de trabajo.",
-      whatIBuild: "Herramientas impulsadas por IA diseñadas para TU proceso específico. No una plataforma de automatización genérica que necesitas configurar — una aplicación construida a propósito que maneja el flujo exacto que le está comiendo tiempo a tu equipo.\n\nEjemplos: Sistemas de escritura con IA, procesadores de documentos, pipelines de extracción de datos, sistemas de web scraping, generadores de reportes.",
-      included: [
-        { title: "Análisis de flujo de trabajo", desc: "Mapeo tu proceso actual de principio a fin, identifico los cuellos de botella, y diseño la automatización que entrega el mayor ahorro de tiempo" },
-        { title: "Desarrollo de aplicación a medida", desc: "Construida con ingeniería de producción: validación adecuada, manejo de errores, logging y seguridad" },
-        { title: "Pruebas con datos reales", desc: "Pruebo con tus flujos de trabajo reales, no con ejemplos sintéticos" },
-        { title: "Interfaz de usuario (cuando se necesita)", desc: "Interfaces limpias y simples que tu equipo puede usar sin capacitación" },
-        { title: "Integración con herramientas existentes", desc: "Conectada a los sistemas que ya usas (Google Workspace, WhatsApp, Slack, email, bases de datos)" },
-        { title: "Documentación y entrega", desc: "Documentación técnica y operacional completa" },
-        { title: "Ventana de optimización de 30 días", desc: "Ajustes post-lanzamiento basados en uso real" }
-      ],
-      notIncluded: [
-        "Desarrollo continuo fuera del alcance inicial (disponible como retención mensual)",
-        "Reemplazo de sistemas centrales de negocio (migraciones de ERP, CRM, etc.)",
-        "Soluciones de IA para problemas que no necesitan IA — te lo diré si es el caso"
-      ],
-      timeline: "4–8 semanas, dependiendo de la complejidad y número de integraciones.",
-      investment: "Por proyecto. Desde **$85,000 MXN** para automatización de un flujo específico. Integraciones multi-sistema típicamente **$136,000–$255,000+ MXN**.",
-      investmentDisclaimer: "Todos los proyectos se dimensionan y cotizan durante la llamada gratuita. Sin sorpresas.",
-      bestFor: [
-        "Equipos que gastan 10+ horas/semana en tareas manuales repetitivas",
-        "Negocios con flujos personalizados que las herramientas genéricas no soportan",
-        "Empresas listas para automatizar un proceso específico y bien entendido",
-        "Líderes de operaciones que saben exactamente qué les está comiendo el tiempo"
-      ]
-    }
-  },
-  'clarity-sprint': {
-    en: {
-      heading: "AI Strategy Session",
-      subheading: "Not sure where AI fits in your business? I'll find out in 5–10 days and give you a plan — or tell you it's not worth it. $1,500, credited if you move forward.",
-      problem: "You know AI could probably help your business, but you're not sure where to focus, what's realistic, or how much it should cost. You've seen impressive demos that turned into expensive disappointments.\n\nMeanwhile, your competitors are already using AI to answer customers faster, rank higher on Google, and automate the busywork your team still does by hand.",
-      whatIBuild: "In 5–10 business days, I'll map your business operations, identify the highest-impact AI opportunity, and deliver a clear action plan you can execute — with me or on your own.\n\nThis isn't a sales pitch disguised as consulting. If AI isn't the right move for your business right now, I'll tell you exactly that — and what would actually help instead.",
-      included: [
-        { title: "Discovery session (60–90 minutes)", desc: "Deep dive into your business operations, pain points, existing tools, and goals" },
-        { title: "Opportunity assessment", desc: "I evaluate where AI can deliver measurable results vs. where it's not worth the investment" },
-        { title: "Recommended solution architecture", desc: "What to build, how it works, what tools it uses, and how it integrates with your current systems" },
-        { title: "Success metrics definition", desc: "Clear KPIs so you'll know if the solution is working" },
-        { title: "Implementation roadmap", desc: "Timeline, milestones, deliverables, and realistic investment range" },
-        { title: "Honest go/no-go recommendation", desc: "If AI isn't the right move for your situation, I'll tell you what would actually help instead" }
-      ],
-      notIncluded: [
-        "Building or implementing anything (that's a separate engagement)",
-        "Ongoing consulting beyond the Sprint deliverable"
-      ],
-      timeline: "5–10 business days from kickoff to delivered plan.",
-      investment: "**$1,500** flat fee. If you move forward with any monthly service or custom project, I credit the full $1,500 toward your first engagement.",
-      investmentDisclaimer: "This is the most popular starting point for businesses that want clarity before commitment.",
-      bestFor: [
-        "Founders and ops leaders who know AI could help but aren't sure where",
-        "Businesses that have been burned by AI vendors and want an honest assessment",
-        "Companies with multiple potential use cases who need help prioritizing",
-        "Anyone who wants a plan before writing a check"
-      ]
-    },
-    es: {
-      heading: "Sesión de Estrategia de IA",
-      subheading: "¿No estás seguro dónde encaja la IA en tu negocio? Lo descubro en 5–10 días y te doy un plan — o te digo que no vale la pena. $25,500 MXN, acreditado si decides seguir adelante.",
-      problem: "Sabes que la IA podría ayudar a tu negocio, pero no estás seguro de dónde enfocarte, qué es realista, o cuánto debería costar. Has visto demos impresionantes que se convirtieron en decepciones costosas.\n\nMientras tanto, tus competidores ya están usando IA para contestar clientes más rápido, aparecer más alto en Google, y automatizar el trabajo manual que tu equipo todavía hace a mano.",
-      whatIBuild: "En 5–10 días hábiles, mapearé tus operaciones de negocio, identificaré la oportunidad de mayor impacto con IA, y te entregaré un plan de acción claro que puedes ejecutar — conmigo o por tu cuenta.\n\nEsto no es un pitch de ventas disfrazado de consultoría. Si la IA no es la jugada correcta para tu negocio ahora mismo, te lo diré exactamente — y te diré qué sí ayudaría.",
-      included: [
-        { title: "Sesión de descubrimiento (60–90 minutos)", desc: "Inmersión profunda en tus operaciones, puntos de dolor, herramientas existentes y objetivos" },
-        { title: "Evaluación de oportunidades", desc: "Evalúo dónde la IA puede entregar resultados medibles vs. dónde no vale la inversión" },
-        { title: "Arquitectura de solución recomendada", desc: "Qué construir, cómo funciona, qué herramientas usa, y cómo se integra con tus sistemas actuales" },
-        { title: "Definición de métricas de éxito", desc: "KPIs claros para que sepas si la solución está funcionando" },
-        { title: "Ruta de implementación", desc: "Timeline, hitos, entregables y rango de inversión realista" },
-        { title: "Recomendación honesta de go/no-go", desc: "Si la IA no es la jugada correcta para tu situación, te diré qué sí ayudaría" }
-      ],
-      notIncluded: [
-        "Construir o implementar algo (eso es un proyecto separado)",
-        "Consultoría continua más allá del entregable del Sprint"
-      ],
-      timeline: "5–10 días hábiles desde el inicio hasta el plan entregado.",
-      investment: "**$25,500 MXN** tarifa plana. Si avanzas con cualquier servicio mensual o proyecto a medida, acredito los $25,500 MXN completos a tu primer proyecto.",
-      investmentDisclaimer: "El punto de entrada más popular para negocios que quieren claridad antes de compromiso.",
-      bestFor: [
-        "Fundadores y líderes de operaciones que saben que la IA puede ayudar pero no están seguros dónde",
-        "Negocios que han tenido malas experiencias con proveedores de IA y quieren una evaluación honesta",
-        "Empresas con múltiples casos de uso potenciales que necesitan ayuda para priorizar",
-        "Cualquiera que quiera un plan antes de firmar un cheque"
       ]
     }
   }
@@ -316,40 +200,7 @@ if (!block) throw new Error(`Block ${id} not found for locale ${locale}`);
 
 const bgClass = isAlternate ? 'bg-gray-50 dark:bg-gray-900/30' : 'bg-white dark:bg-black';
 
-// "Also Available" supporting offers — shown only on the Messenger AI block
-// (id kept as 'competitive-intelligence' to avoid touching anchors elsewhere).
-const alsoAvailable = id === 'competitive-intelligence' ? {
-  en: {
-    heading: "Also Available",
-    items: [
-      {
-        title: "Google Maps Monitoring & Weekly Action Plan",
-        body: "Every week I check where you rank on Google Maps, monitor up to 5 competitors, and send you one WhatsApp message with one clear action to take this week. No dashboards to learn. Just results.",
-        price: "From $297/month."
-      },
-      {
-        title: "AI Product Photos — No Photo Shoot Needed",
-        body: "Send me your product photos. I put them on AI-generated models with realistic settings — beaches, storefronts, studios. Fresh content every week for Instagram, Facebook, and Reels. No photographer. No studio.",
-        price: "From $297/month."
-      }
-    ]
-  },
-  es: {
-    heading: "También Disponible",
-    items: [
-      {
-        title: "Monitoreo de Google Maps y Plan de Acción Semanal",
-        body: "Cada semana reviso dónde apareces en Google Maps, monitoreo hasta 5 competidores, y te mando un WhatsApp con una acción clara para esta semana. Sin dashboards que aprender. Solo resultados.",
-        price: "Desde $2,499 MXN/mes."
-      },
-      {
-        title: "Fotos de Producto con IA — Sin Sesión Fotográfica",
-        body: "Mándame tus fotos de producto. Las pongo en modelos generados con IA en escenarios realistas — playas, aparadores, estudios. Contenido fresco cada semana para Instagram, Facebook y Reels. Sin fotógrafo. Sin estudio.",
-        price: "Desde $2,499 MXN/mes."
-      }
-    ]
-  }
-}[locale] : null;
+// "Also Available" section removed — maps and product photos are now included in the Growth Bundle.
 ---
 
 <section id={id} class={`py-20 md:py-32 border-b border-gray-100 dark:border-gray-800 ${bgClass}`}>
@@ -465,27 +316,5 @@ const alsoAvailable = id === 'competitive-intelligence' ? {
 
     </div>
 
-    {alsoAvailable && (
-      <div class="mt-20 md:mt-24 pt-12 border-t border-gray-200 dark:border-gray-800">
-        <h3 class="font-display font-semibold text-sm text-gray-500 dark:text-gray-400 mb-8 uppercase tracking-wider">
-          {alsoAvailable.heading}
-        </h3>
-        <div class="grid md:grid-cols-2 gap-6 lg:gap-8">
-          {alsoAvailable.items.map(item => (
-            <div class="p-6 md:p-8 rounded-2xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900/50">
-              <h4 class="font-display font-semibold text-lg md:text-xl text-gray-900 dark:text-white mb-3 leading-snug">
-                {item.title}
-              </h4>
-              <p class="text-gray-600 dark:text-gray-400 leading-relaxed mb-4">
-                {item.body}
-              </p>
-              <p class="text-sm font-display font-semibold text-cush-orange">
-                {item.price}
-              </p>
-            </div>
-          ))}
-        </div>
-      </div>
-    )}
   </Container>
 </section>

--- a/src/i18n/translations/en.ts
+++ b/src/i18n/translations/en.ts
@@ -22,23 +22,19 @@ export const en = {
   },
   services: {
     title: 'How I Can Help',
-    subtitle: 'Four services, clear outcomes — pick the one that fits or start with a free call',
+    subtitle: 'AI that works 24/7 so your team doesn\'t have to — start with a free trial',
     learnMore: 'See all services',
     assistants: {
-      title: 'AI Support Assistants',
+      title: 'Intelligent Customer Support AI Chatbot',
       description: 'AI trained on YOUR knowledge — answers customers in English and Spanish, captures leads after hours, hands off to humans when needed.',
     },
     intelligence: {
       title: 'Competitive Intelligence',
       description: 'Track competitors on Google Maps — rankings, reviews, and moves — with weekly WhatsApp reports and one clear action item.',
     },
-    tools: {
-      title: 'Custom AI Tools',
-      description: 'Purpose-built applications that automate your most time-consuming workflows. Not a generic platform — built for your exact process.',
-    },
-    clarity: {
-      title: 'AI Clarity Sprint',
-      description: 'Not sure where to start? Get a clear plan with architecture, timeline, and investment range in 5-10 days. $1,500 — credited toward a build.',
+    voice: {
+      title: 'AI Voice Agent',
+      description: 'Your phone answered on the first ring, 24/7. Appointments booked, leads captured, callers transferred — they never know it\'s AI.',
     },
   },
   process: {

--- a/src/i18n/translations/es.ts
+++ b/src/i18n/translations/es.ts
@@ -22,23 +22,19 @@ export const es = {
   },
   services: {
     title: 'Cómo Puedo Ayudarte',
-    subtitle: 'Cuatro servicios, resultados claros — elige el que encaje o empieza con una llamada gratis',
+    subtitle: 'IA que trabaja 24/7 para que tu equipo no tenga que hacerlo — empieza con una prueba gratis',
     learnMore: 'Ver todos los servicios',
     assistants: {
-      title: 'Asistentes de Soporte IA',
+      title: 'Chatbot Inteligente de Atención al Cliente',
       description: 'IA entrenada con TU conocimiento — responde clientes en inglés y español, captura leads fuera de horario y transfiere a humanos cuando se necesita.',
     },
     intelligence: {
       title: 'Inteligencia Competitiva',
       description: 'Rastrea competidores en Google Maps — rankings, reseñas y movimientos — con reportes semanales por WhatsApp y una acción clara.',
     },
-    tools: {
-      title: 'Herramientas IA a Medida',
-      description: 'Aplicaciones construidas para automatizar tus flujos más tardados. No una plataforma genérica — hecha para tu proceso exacto.',
-    },
-    clarity: {
-      title: 'Sprint de Claridad IA',
-      description: '¿No sabes por dónde empezar? Obtén un plan claro con arquitectura, timeline e inversión en 5-10 días. $1,500 USD — acreditado al proyecto.',
+    voice: {
+      title: 'Agente de Voz IA',
+      description: 'Tu teléfono contestado al primer timbrazo, 24/7. Citas agendadas, leads capturados, llamadas transferidas — nunca saben que es IA.',
     },
   },
   process: {

--- a/src/pages/es/services.astro
+++ b/src/pages/es/services.astro
@@ -21,8 +21,6 @@ const description = "Chatbots de atención al cliente, monitoreo de competidores
   <ServiceBlock locale={locale} id="support-assistants" />
   <ServiceBlock locale={locale} id="competitive-intelligence" isAlternate={true} />
   <ServiceBlock locale={locale} id="voice-agent" />
-  <ServiceBlock locale={locale} id="custom-tools" isAlternate={true} />
-  <ServiceBlock locale={locale} id="clarity-sprint" />
   <HowIWork locale={locale} />
   <WhoItIsFor locale={locale} />
   <InvestmentOverview locale={locale} />

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -32,8 +32,6 @@ const meta = {
   <ServiceBlock locale={locale} id="support-assistants" />
   <ServiceBlock locale={locale} id="competitive-intelligence" isAlternate={true} />
   <ServiceBlock locale={locale} id="voice-agent" />
-  <ServiceBlock locale={locale} id="custom-tools" isAlternate={true} />
-  <ServiceBlock locale={locale} id="clarity-sprint" />
 
   <HowIWork locale={locale} />
   


### PR DESCRIPTION
## Summary
- **Bundle-first pricing model** replacing à la carte: Growth Bundle $997/mo (US) / $8,497 MXN/mes (MX), Voice Agent $1,497/mo / $10,997 MXN/mes
- **Removed** Custom Automation and Strategy Session services from page (quoted on discovery calls only)
- **Renamed** chatbot to "Intelligent Customer Support AI Chatbot" (EN/ES)
- **ScenarioQualifier**: 4 pain-point cards with prices visible on every card
- **InvestmentOverview**: 2-card bundle showcase replacing 7-row à la carte table
- **Cleaned stale references** across Footer, ServicesSection, translations, FAQ, and FinalCTA
- All changes applied to both EN and ES

## Test plan
- [ ] Visual check `/services/` — 4 scenario cards, 3 service blocks, 2 pricing cards, FAQ, CTA
- [ ] Visual check `/es/services/` — same structure, MXN pricing, Spanish copy
- [ ] Verify all anchor links from scenario cards scroll to correct sections
- [ ] Verify mobile layout for pricing cards and scenario grid
- [ ] Confirm no references to `custom-tools`, `clarity-sprint`, `$1,500`, or `$25,500` remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)