### PR TITLE
fix: align <head> hreflang locale codes with sitemap (en-US / es-MX)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -70,9 +70,9 @@ const ogLocaleAlternate = locale === "es" ? "en_US" : "es_MX";
     <meta name="robots" content={noindex ? "noindex, nofollow" : "index, follow"} />
     <link rel="canonical" href={canonicalURL} />
 
-    <!-- Hreflang for bilingual SEO -->
-    <link rel="alternate" hreflang="en" href={enURL} />
-    <link rel="alternate" hreflang="es" href={esURL} />
+    <!-- Hreflang for bilingual SEO — locale codes match sitemap i18n config (en-US / es-MX) -->
+    <link rel="alternate" hreflang="en-US" href={enURL} />
+    <link rel="alternate" hreflang="es-MX" href={esURL} />
     <link rel="alternate" hreflang="x-default" href={enURL} />
 
     <!-- Open Graph -->


### PR DESCRIPTION
## Summary

- `BaseLayout.astro` was emitting `hreflang="en"` and `hreflang="es"` on every page
- The sitemap (`astro.config.mjs` i18n map) already correctly uses `en-US` and `es-MX`
- Google expects the locale codes to be **consistent** between `<head>` and sitemap signals
- Updated `<head>` to `hreflang="en-US"` / `hreflang="es-MX"` — now matches sitemap on all ~88 pages
- `x-default` unchanged, still points to the EN canonical URL

## Verification

- `npx astro check` — 0 errors
- Confirmed via live site fetch: old values were `en`/`es`; after deploy will be `en-US`/`es-MX`

🤖 Generated with [Claude Code](https://claude.com/claude-code)