### PR TITLE
fix: remove muted from click-to-play video

### DIFF
--- a/src/pages/es/projects/[slug].astro
+++ b/src/pages/es/projects/[slug].astro
@@ -549,8 +549,6 @@ const relatedProjects = scored.slice(0, 3).map(s => s.project);
           if (!src) return;
           const video = document.createElement('video');
           video.controls = true;
-          video.autoplay = true;
-          video.muted = true;
           video.playsInline = true;
           video.preload = 'auto';
           video.className = 'w-full rounded-xl';

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -544,8 +544,6 @@ const relatedProjects = scored.slice(0, 3).map(s => s.project);
           if (!src) return;
           const video = document.createElement('video');
           video.controls = true;
-          video.autoplay = true;
-          video.muted = true;
           video.playsInline = true;
           video.preload = 'auto';
           video.className = 'w-full rounded-xl';


### PR DESCRIPTION
## Summary

- Removes `muted` and `autoplay` attributes from programmatically-created video elements
- `play()` is called inside a click handler, so the user gesture gives the browser permission to play with sound — `muted` is not needed
- Fixes all 30 project detail pages (EN + ES)

🤖 Generated with [Claude Code](https://claude.com/claude-code)