### PR TITLE
feat: Messenger Assistant portfolio page with bilingual hero slides

### DIFF
--- a/src/components/services2/ServiceBlock.astro
+++ b/src/components/services2/ServiceBlock.astro
@@ -72,8 +72,6 @@ const data = {
     }
   },
   'competitive-intelligence': {
-    liveUrl: 'https://marketsignal.cushlabs.ai',
-    liveLabel: { en: 'See the Live Platform →', es: 'Ver la Plataforma en Vivo →' },
     en: {
       heading: "AI Assistant on Your Facebook Page That Sells While You Sleep",
       subheading: "Every message answered in seconds. Every customer captured. Every question handled in their language — in your voice — 24 hours a day.",

--- a/src/data/projects.generated.json
+++ b/src/data/projects.generated.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-18T21:50:09.908Z",
+  "generatedAt": "2026-04-19T03:20:06.509Z",
   "count": 33,
   "projects": [
     {
@@ -312,14 +312,14 @@
       "status": "Production",
       "language": "HTML",
       "languages": {
-        "HTML": 434936,
-        "JavaScript": 117322,
-        "CSS": 7015,
+        "HTML": 518122,
+        "JavaScript": 118063,
+        "CSS": 8475,
         "Dockerfile": 358
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-04-14T21:11:53Z",
+      "lastPushed": "2026-04-18T23:09:17Z",
       "createdAt": "2026-02-23T01:31:09Z",
       "isFeatured": true,
       "isArchived": false,
@@ -468,7 +468,7 @@
       "status": null,
       "language": "TypeScript",
       "languages": {
-        "TypeScript": 681827,
+        "TypeScript": 716327,
         "HTML": 29745,
         "CSS": 3586,
         "Dockerfile": 1126,
@@ -476,7 +476,7 @@
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-04-17T06:45:51Z",
+      "lastPushed": "2026-04-18T22:59:45Z",
       "createdAt": "2026-03-30T19:46:00Z",
       "isFeatured": true,
       "isArchived": false,
@@ -605,7 +605,7 @@
         "Astro": 2065454,
         "TypeScript": 1957148,
         "HTML": 838639,
-        "JavaScript": 404654,
+        "JavaScript": 404739,
         "CSS": 40875,
         "Python": 30138,
         "MDX": 23172,
@@ -613,7 +613,7 @@
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-04-18T19:27:28Z",
+      "lastPushed": "2026-04-19T03:15:47Z",
       "createdAt": "2025-03-23T03:27:14Z",
       "isFeatured": true,
       "isArchived": false,
@@ -741,7 +741,7 @@
         "Cloudflare Workers",
         "TypeScript",
         "Claude API (Haiku + Sonnet)",
-        "Qdrant Cloud (vector search)",
+        "Cloudflare Vectorize (vector search)",
         "Cloudflare Workers AI (embeddings)",
         "Cloudflare KV (session state)",
         "Meta Messenger Platform",
@@ -750,20 +750,20 @@
       "status": null,
       "language": "TypeScript",
       "languages": {
-        "TypeScript": 130956,
+        "TypeScript": 134597,
         "PowerShell": 1415,
-        "HTML": 622,
+        "HTML": 686,
         "CSS": 323
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-04-17T06:38:20Z",
+      "lastPushed": "2026-04-19T03:18:48Z",
       "createdAt": "2026-04-06T23:20:56Z",
       "isFeatured": false,
       "isArchived": false,
       "isPrivate": true,
       "tagline": "Facebook Messenger chatbot that handles student inquiries with Claude AI, RAG-powered answers, and bilingual EN/ES support",
-      "thumbnail": null,
+      "thumbnail": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/thumb.webp",
       "problem": "Small business owners on Facebook spend hours answering the same customer\nquestions in Messenger — pricing, availability, services, location. For\nbilingual markets like Mexico, they need to handle inquiries in both English\nand Spanish. A human can't be online 24/7, and generic chatbots sound robotic\nand can't answer business-specific questions accurately.\n",
       "solution": null,
       "keyFeatures": [
@@ -776,7 +776,55 @@
       "metrics": [],
       "priority": 5,
       "dateCompleted": null,
-      "slides": [],
+      "slides": [
+        {
+          "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-01.webp",
+          "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-01.webp",
+          "altEn": "The 24/7 AI Sales Assistant for Facebook Messenger — Built from your content, trained on your business. Made by CushLabs.",
+          "altEs": "El asistente de ventas con IA 24/7 para Facebook Messenger — Creado a partir de tu contenido. Entrenado en tu negocio. Hecho por CushLabs."
+        },
+        {
+          "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-02.webp",
+          "altEn": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant",
+          "altEs": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant"
+        },
+        {
+          "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-03.webp",
+          "altEn": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant",
+          "altEs": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant"
+        },
+        {
+          "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-04.webp",
+          "altEn": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant",
+          "altEs": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant"
+        },
+        {
+          "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-05.webp",
+          "altEn": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant",
+          "altEs": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant"
+        },
+        {
+          "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-06.webp",
+          "altEn": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant",
+          "altEs": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant"
+        },
+        {
+          "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-07.webp",
+          "altEn": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant",
+          "altEs": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant"
+        },
+        {
+          "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-08.webp",
+          "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-08.webp",
+          "altEn": "The math is simple: it pays for itself the first time it converts a client you would have otherwise lost.",
+          "altEs": "La matemática es simple: Se paga solo la primera vez que convierte a un cliente que de otro modo habrías perdido."
+        },
+        {
+          "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-09.webp",
+          "altEn": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant",
+          "altEs": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant"
+        }
+      ],
       "videoUrl": null,
       "videoPoster": null
     },
@@ -1873,7 +1921,7 @@
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-04-06T02:12:11Z",
+      "lastPushed": "2026-04-18T23:40:36Z",
       "createdAt": "2026-03-08T19:31:57Z",
       "isFeatured": false,
       "isArchived": false,
@@ -2822,7 +2870,7 @@
       },
       "stars": 2,
       "forks": 0,
-      "lastPushed": "2026-04-18T19:32:10Z",
+      "lastPushed": "2026-04-18T23:09:27Z",
       "createdAt": "2026-01-08T03:52:43Z",
       "isFeatured": false,
       "isArchived": false,

--- a/src/data/projects.generated.json
+++ b/src/data/projects.generated.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-19T03:20:06.509Z",
+  "generatedAt": "2026-04-19T03:27:38.934Z",
   "count": 33,
   "projects": [
     {
@@ -602,7 +602,7 @@
       "status": "Production",
       "language": "Astro",
       "languages": {
-        "Astro": 2065454,
+        "Astro": 2065667,
         "TypeScript": 1957148,
         "HTML": 838639,
         "JavaScript": 404739,
@@ -613,7 +613,7 @@
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-04-19T03:15:47Z",
+      "lastPushed": "2026-04-19T03:23:37Z",
       "createdAt": "2025-03-23T03:27:14Z",
       "isFeatured": true,
       "isArchived": false,
@@ -757,7 +757,7 @@
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-04-19T03:18:48Z",
+      "lastPushed": "2026-04-19T03:27:18Z",
       "createdAt": "2026-04-06T23:20:56Z",
       "isFeatured": false,
       "isArchived": false,
@@ -785,44 +785,51 @@
         },
         {
           "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-02.webp",
-          "altEn": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant",
-          "altEs": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant"
+          "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-02.webp",
+          "altEn": "The problem every business owner knows — your Facebook page gets messages. You catch some. Most you don't.",
+          "altEs": "El problema que todo dueño de negocio conoce — tu página de Facebook recibe mensajes. Algunos los cachas. La mayoría no."
         },
         {
           "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-03.webp",
-          "altEn": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant",
-          "altEs": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant"
+          "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-03.webp",
+          "altEn": "Generic auto-replies are a polite way to lose a potential client — the lead decay curve.",
+          "altEs": "Las respuestas automáticas son una forma amable de perder un cliente potencial — la curva de decaimiento de un cliente potencial."
         },
         {
           "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-04.webp",
-          "altEn": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant",
-          "altEs": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant"
+          "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-04.webp",
+          "altEn": "What if your inbox answered itself? Introducing the CushLabs AI Messaging Assistant.",
+          "altEs": "¿Qué tal si tu bandeja de entrada se respondiera sola? Presentamos el Asistente de Mensajería AI CushLabs."
         },
         {
           "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-05.webp",
-          "altEn": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant",
-          "altEs": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant"
+          "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-05.webp",
+          "altEn": "Never lose a prospect while you sleep — qualified conversations at 8:30 PM, 11:15 PM, 2:00 AM.",
+          "altEs": "Nunca pierdas un prospecto mientras duermes — conversaciones calificadas a las 8:30 PM, 11:15 PM, 2:00 AM."
         },
         {
           "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-06.webp",
-          "altEn": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant",
-          "altEs": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant"
+          "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-06.webp",
+          "altEn": "Get your time back and stop repeating yourself — the bot handles FAQs so you only step in when a client is ready to buy.",
+          "altEs": "Recupera tu tiempo y deja de repetirte — el bot responde preguntas frecuentes para que solo intervengas cuando un cliente esté listo para comprar."
         },
         {
           "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-07.webp",
-          "altEn": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant",
-          "altEs": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant"
+          "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-07.webp",
+          "altEn": "Speaks their language perfectly and without interruption — native bilingual EN/ES with no manual switching.",
+          "altEs": "Habla su idioma a la perfección y sin interrupciones — bilingüe nativo EN/ES sin cambios manuales."
         },
         {
           "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-08.webp",
           "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-08.webp",
-          "altEn": "The math is simple: it pays for itself the first time it converts a client you would have otherwise lost.",
-          "altEs": "La matemática es simple: Se paga solo la primera vez que convierte a un cliente que de otro modo habrías perdido."
+          "altEn": "Sells like you, because it's built from you — your website, your FAQs, your methodology, your prices.",
+          "altEs": "Vende como tú, porque está hecho de ti — tu sitio web, tus preguntas frecuentes, tu metodología, tus precios."
         },
         {
           "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-09.webp",
-          "altEn": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant",
-          "altEs": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant"
+          "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-09.webp",
+          "altEn": "The math is simple: it pays for itself the first time it converts a client you would have otherwise lost.",
+          "altEs": "La matemática es simple: Se paga solo la primera vez que convierte a un cliente que de otro modo habrías perdido."
         }
       ],
       "videoUrl": null,

--- a/src/pages/es/messenger-assistant.astro
+++ b/src/pages/es/messenger-assistant.astro
@@ -1,0 +1,260 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import Container from "../../components/layout/Container.astro";
+import FinalCTA from "../../components/services2/FinalCTA.astro";
+
+const locale = "es" as const;
+
+const included = [
+  { title: "Entrenamiento personalizado", desc: "Productos, precios, horarios, políticas, tono — entrenado con lo que realmente vendes y cómo realmente hablas" },
+  { title: "Conversaciones bilingües (EN/ES)", desc: "Español e inglés con fluidez, cambia automáticamente según el idioma del cliente" },
+  { title: "Recomendaciones inteligentes de productos", desc: "Guía al cliente al producto o servicio correcto en vez de tirarle el catálogo encima" },
+  { title: "Agendado de citas y captura de leads", desc: "Recoge los datos que necesitas — nombre, contacto, intención — y los enruta donde corresponde" },
+  { title: "Transferencia a humano", desc: "Te pasa la conversación con todo el contexto cuando realmente se necesita una persona" },
+  { title: "Reporte semanal de desempeño", desc: "Qué te están preguntando los clientes, qué está convirtiendo, qué mejorar — cada lunes" },
+  { title: "Ajuste mensual", desc: "Refino el asistente conforme tu negocio evoluciona — nuevos productos, nuevos precios, nuevas temporadas" },
+];
+
+const notIncluded = [
+  "Configuraciones multi-página o de franquicia más allá de una sola página de Facebook (se cotiza aparte)",
+  "Generación de contenido nuevo de marketing — el asistente usa tu voz y tus productos",
+  "Gestión de anuncios de Facebook o publicaciones en redes sociales",
+];
+
+const bestFor = [
+  "Negocios locales perdiendo clientes por respuestas lentas",
+  "Dueños ahogados en preguntas repetitivas en Messenger",
+  "Negocios con clientes bilingües (español + inglés)",
+  "Cualquiera cuyos competidores están respondiendo más rápido",
+];
+---
+
+<BaseLayout
+  title="Asistente de IA en Facebook Messenger | CushLabs.ai"
+  description="Un asistente de ventas con IA disponible 24/7 en tu Facebook Messenger — entrenado con tu negocio, activo en semanas. Bilingüe EN/ES. Totalmente gestionado."
+  canonical="https://cushlabs.ai/es/messenger-assistant/"
+>
+
+  <!-- Hero -->
+  <section class="relative pt-24 pb-16 md:pt-32 md:pb-24 overflow-hidden">
+    <div class="absolute inset-0 -z-10">
+      <div class="absolute top-1/4 left-1/4 w-[500px] h-[500px] bg-cush-orange/15 rounded-full blur-[120px]"></div>
+      <div class="absolute bottom-1/4 right-1/4 w-[400px] h-[400px] bg-cush-orange/10 rounded-full blur-[100px]"></div>
+    </div>
+
+    <Container size="md">
+      <div class="text-center max-w-4xl mx-auto">
+        <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-cush-orange/10 border border-cush-orange/20 text-cush-orange text-sm font-semibold mb-8">
+          <span class="w-2 h-2 rounded-full bg-green-500 animate-pulse"></span>
+          Ya está activo con un cliente real — en producción ahora mismo
+        </div>
+
+        <h1 class="font-display text-fluid-4xl font-bold text-gray-900 dark:text-white mb-6 leading-tight tracking-tight">
+          Asistente de IA en tu Facebook Messenger que Vende Mientras Duermes
+        </h1>
+
+        <p class="text-fluid-lg text-gray-600 dark:text-gray-300 mb-4 max-w-3xl mx-auto leading-relaxed">
+          Un asistente de ventas con IA disponible 24/7 en tu Facebook Messenger — entrenado con tu negocio, activo en semanas.
+        </p>
+        <p class="text-fluid-base text-gray-500 dark:text-gray-400 mb-10 max-w-2xl mx-auto leading-relaxed">
+          Cada mensaje contestado en segundos. Cada cliente capturado. Cada pregunta resuelta en su idioma — con tu voz — las 24 horas del día.
+        </p>
+
+        <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
+          <a
+            href="/es/reservar/"
+            class="group inline-flex items-center gap-2 px-8 py-4 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-all duration-300 shadow-lg shadow-cush-orange/25 hover:shadow-xl hover:shadow-cush-orange/30 text-lg"
+          >
+            Agendar Llamada de Descubrimiento
+            <svg class="w-5 h-5 transition-transform group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+            </svg>
+          </a>
+          <a href="/es/services/" class="font-display font-medium text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white underline underline-offset-4 decoration-gray-300 hover:decoration-cush-orange transition-all">
+            Ver todos los servicios →
+          </a>
+        </div>
+      </div>
+    </Container>
+  </section>
+
+  <!-- Problem -->
+  <section class="py-20 md:py-28 bg-gray-50 dark:bg-gray-900/30 border-y border-gray-100 dark:border-gray-800">
+    <Container size="lg">
+      <div class="max-w-3xl">
+        <h2 class="font-display font-bold text-3xl md:text-4xl text-gray-900 dark:text-white mb-8 leading-tight tracking-tight">
+          El problema que todo dueño de negocio conoce
+        </h2>
+        <div class="space-y-6 text-lg text-gray-600 dark:text-gray-400 leading-relaxed">
+          <p>
+            Tu página de Facebook recibe mensajes. Algunos los ves. La mayoría no — no a tiempo. Y en mercados competitivos, el negocio que responde primero gana la conversación.
+          </p>
+          <p>
+            Ya conoces los autorespondedores genéricos. <em>"¡Gracias por escribirnos! Nos pondremos en contacto contigo pronto."</em> Eso no es una solución. Es una forma educada de perder un lead.
+          </p>
+          <p>
+            Facebook te quita la insignia de "responde rápido" si tardas más de 15 minutos en contestar. Con IA, tu tiempo de respuesta es menos de 5 segundos — siempre.
+          </p>
+        </div>
+      </div>
+    </Container>
+  </section>
+
+  <!-- Solution -->
+  <section class="py-20 md:py-32">
+    <Container size="lg">
+      <div class="grid lg:grid-cols-12 gap-12 lg:gap-16">
+
+        <!-- Left: Solution narrative -->
+        <div class="lg:col-span-7 space-y-12">
+          <div>
+            <h2 class="font-display font-bold text-3xl md:text-5xl text-gray-900 dark:text-white mb-4 leading-tight tracking-tight">
+              Lo que CushLabs construye en cambio
+            </h2>
+            <p class="text-xl md:text-2xl text-cush-orange font-medium leading-relaxed mb-8">
+              No una plantilla. No un chatbot que dice "No entendí eso."
+            </p>
+            <div class="prose prose-lg dark:prose-invert max-w-none">
+              <div class="text-gray-900 dark:text-gray-200 bg-cush-orange/5 border-l-4 border-cush-orange pl-6 py-4 rounded-r-lg space-y-3">
+                <p>Un asistente de IA a la medida que vive en tu Facebook Messenger y realmente conoce tu negocio. Un asistente entrenado con tus servicios, tus precios, tu voz — que contesta como lo harías tú, a cualquier hora, en el idioma que hablan tus clientes.</p>
+                <p>Recomienda el producto correcto. Agenda la cita. Contesta las preguntas frecuentes cien veces al día sin quejarse. Y cuando se necesita un humano de verdad, te pasa la conversación con todo el contexto ya levantado.</p>
+                <p>Ya lo desplegamos para un cliente real. Está activo, en producción, manejando consultas ahora mismo mientras el dueño del negocio duerme.</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- What it means -->
+          <div>
+            <h3 class="font-display font-semibold text-2xl text-gray-900 dark:text-white mb-6">
+              Lo que significa para tu negocio
+            </h3>
+            <div class="space-y-5">
+              {[
+                { title: "Dejas de perder leads fuera de horario.", body: "Los prospectos que escriben a las 10pm reciben una respuesta real — no un formulario, no silencio, no 'te contactamos pronto.'" },
+                { title: "Dejas de contestar las mismas preguntas.", body: "Precios, disponibilidad, servicios, cómo funciona — tu asistente lo maneja todo. Solo escuchas de clientes cuando están listos para comprar." },
+                { title: "Habla su idioma.", body: "¿Cliente en español? Responde en español. ¿En inglés? En inglés. Automático, natural, fluido." },
+                { title: "Sabe cuándo llamarte.", body: "Cuando una conversación realmente te necesita, se hace a un lado y te la pasa — con todo el contexto. Cuando terminas, el asistente retoma." },
+                { title: "Suena como tú — no como un robot.", body: "Porque está construido con tu contenido: tu sitio web, tus descripciones de servicios, tus FAQs. Cada respuesta viene de lo que ya dijiste sobre tu negocio." },
+              ].map(item => (
+                <div class="flex gap-4">
+                  <svg class="w-5 h-5 text-green-500 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                  </svg>
+                  <div>
+                    <strong class="text-gray-900 dark:text-white font-semibold">{item.title}</strong>
+                    {" "}<span class="text-gray-600 dark:text-gray-400">{item.body}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <!-- Best For -->
+          <div>
+            <h3 class="font-display font-semibold text-sm text-gray-900 dark:text-white mb-6 uppercase tracking-wider">
+              Ideal Para:
+            </h3>
+            <div class="grid sm:grid-cols-2 gap-4">
+              {bestFor.map(item => (
+                <div class="flex gap-3">
+                  <svg class="w-5 h-5 text-green-500 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                  </svg>
+                  <span class="text-gray-700 dark:text-gray-300 text-sm leading-relaxed">{item}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <!-- Right: Specs card -->
+        <div class="lg:col-span-5 space-y-8">
+
+          <!-- Pricing card -->
+          <div class="bg-gray-900 dark:bg-gray-800 rounded-2xl p-8 shadow-xl text-gray-300">
+            <div class="mb-6 pb-6 border-b border-gray-700">
+              <h4 class="font-display font-semibold text-white mb-2 uppercase text-xs tracking-wider">Línea de Tiempo</h4>
+              <div class="text-lg text-white font-medium">En vivo en 2 semanas. Llamada → entrenamiento → pruebas → lanzamiento.</div>
+            </div>
+            <div class="mb-4">
+              <h4 class="font-display font-semibold text-white mb-2 uppercase text-xs tracking-wider">Inversión</h4>
+              <div class="text-base leading-relaxed">
+                Incluido en el <span class="text-white font-bold">Paquete de Crecimiento con IA — $8,497 MXN/mes</span>. Una sola página, conversaciones ilimitadas, totalmente gestionado. Incluye configuración, entrenamiento, reportes semanales y ajuste mensual. Sin cuota de instalación. Sin contrato.
+              </div>
+            </div>
+            <p class="text-xs text-cush-orange font-medium mt-4 italic">Prueba gratis de 2 semanas. Cancela cuando quieras.</p>
+            <div class="mt-8">
+              <a href="/es/reservar/" class="block w-full text-center px-6 py-3 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-colors duration-300">
+                Agendar Llamada
+              </a>
+            </div>
+          </div>
+
+          <!-- Included -->
+          <div>
+            <h3 class="font-display font-semibold text-xl text-gray-900 dark:text-white mb-6">Qué Incluye</h3>
+            <ul class="space-y-4">
+              {included.map(item => (
+                <li class="flex gap-4">
+                  <div class="w-1.5 h-1.5 bg-cush-orange rounded-full mt-2.5 shrink-0"></div>
+                  <div>
+                    <strong class="text-gray-900 dark:text-white font-semibold">{item.title}</strong> — <span class="text-gray-600 dark:text-gray-400 text-sm">{item.desc}</span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <!-- Not included -->
+          <div class="pt-6 border-t border-gray-200 dark:border-gray-800">
+            <h3 class="font-display font-semibold text-base text-gray-900 dark:text-white mb-4">Lo Que NO Incluye</h3>
+            <ul class="space-y-2">
+              {notIncluded.map(item => (
+                <li class="flex gap-3 text-sm text-gray-500 dark:text-gray-500">
+                  <svg class="w-4 h-4 text-gray-400 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+      </div>
+    </Container>
+  </section>
+
+  <!-- Why CushLabs -->
+  <section class="py-20 md:py-28 bg-gray-50 dark:bg-gray-900/30 border-y border-gray-100 dark:border-gray-800">
+    <Container size="md">
+      <div class="max-w-3xl mx-auto text-center">
+        <h2 class="font-display font-bold text-3xl md:text-4xl text-gray-900 dark:text-white mb-8 leading-tight tracking-tight">
+          Por qué CushLabs y no una plataforma genérica de chatbots
+        </h2>
+        <div class="space-y-6 text-lg text-gray-600 dark:text-gray-400 leading-relaxed text-left">
+          <p>
+            Las plataformas genéricas te dan un constructor. CushLabs te da un asistente desplegado y listo para producción — construido, configurado, probado y monitoreado. Nosotros manejamos la configuración, la ingesta de contenido, la integración con Facebook y la confiabilidad continua. Tú obtienes los resultados.
+          </p>
+          <p>
+            Ya resolvimos los problemas difíciles: soporte bilingüe, respuestas precisas basadas en el contenido real de tu negocio, transferencia elegante a humanos, uptime 24/7 con monitoreo de errores. No nos pagas para que lo descubramos — ya lo descubrimos.
+          </p>
+        </div>
+        <div class="mt-10">
+          <a
+            href="/es/reservar/"
+            class="inline-flex items-center gap-2 px-8 py-4 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-all duration-300 shadow-lg shadow-cush-orange/25 hover:shadow-xl text-lg"
+          >
+            Empieza Tu Prueba Gratis de 2 Semanas
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+            </svg>
+          </a>
+        </div>
+      </div>
+    </Container>
+  </section>
+
+  <FinalCTA locale={locale} />
+
+</BaseLayout>

--- a/src/pages/messenger-assistant.astro
+++ b/src/pages/messenger-assistant.astro
@@ -1,0 +1,260 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import Container from "../components/layout/Container.astro";
+import FinalCTA from "../components/services2/FinalCTA.astro";
+
+const locale = "en" as const;
+
+const included = [
+  { title: "Custom training on your business", desc: "Products, prices, hours, policies, tone — trained on what you actually sell and how you actually talk" },
+  { title: "Bilingual conversations (EN/ES)", desc: "Fluent Spanish and English, switches automatically based on what the customer writes" },
+  { title: "Smart product & service recommendations", desc: "Guides customers toward the right purchase instead of dumping a catalog on them" },
+  { title: "Appointment booking & lead capture", desc: "Collects the details you need — name, contact, intent — and routes them where they belong" },
+  { title: "Human handoff", desc: "Escalates to you with full context when the conversation actually needs a human" },
+  { title: "Weekly performance report", desc: "What your customers are asking, what's converting, what to improve — delivered every Monday" },
+  { title: "Monthly tuning", desc: "I refine the assistant as your business evolves — new products, new pricing, new seasons" },
+];
+
+const notIncluded = [
+  "Multi-page or franchise setups beyond a single Facebook page (scoped separately)",
+  "Generating new marketing content — the assistant uses your voice and your products",
+  "Paid Facebook ad management or social posting",
+];
+
+const bestFor = [
+  "Local businesses losing leads to slow response times",
+  "Owners drowning in repeat questions on Messenger",
+  "Businesses with bilingual customers (Spanish + English)",
+  "Anyone whose competitors are responding faster than they are",
+];
+---
+
+<BaseLayout
+  title="AI Messenger Assistant for Facebook | CushLabs.ai"
+  description="A 24/7 AI sales assistant in your Facebook Messenger — built from your content, trained on your business, live in weeks. Bilingual EN/ES. Fully managed."
+  canonical="https://cushlabs.ai/messenger-assistant/"
+>
+
+  <!-- Hero -->
+  <section class="relative pt-24 pb-16 md:pt-32 md:pb-24 overflow-hidden">
+    <div class="absolute inset-0 -z-10">
+      <div class="absolute top-1/4 left-1/4 w-[500px] h-[500px] bg-cush-orange/15 rounded-full blur-[120px]"></div>
+      <div class="absolute bottom-1/4 right-1/4 w-[400px] h-[400px] bg-cush-orange/10 rounded-full blur-[100px]"></div>
+    </div>
+
+    <Container size="md">
+      <div class="text-center max-w-4xl mx-auto">
+        <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-cush-orange/10 border border-cush-orange/20 text-cush-orange text-sm font-semibold mb-8">
+          <span class="w-2 h-2 rounded-full bg-green-500 animate-pulse"></span>
+          Already live with a real client — in production now
+        </div>
+
+        <h1 class="font-display text-fluid-4xl font-bold text-gray-900 dark:text-white mb-6 leading-tight tracking-tight">
+          AI Messenger Assistant for Your Facebook Page
+        </h1>
+
+        <p class="text-fluid-lg text-gray-600 dark:text-gray-300 mb-4 max-w-3xl mx-auto leading-relaxed">
+          A 24/7 AI sales assistant in your Facebook Messenger — built from your content, trained on your business, live in weeks.
+        </p>
+        <p class="text-fluid-base text-gray-500 dark:text-gray-400 mb-10 max-w-2xl mx-auto leading-relaxed">
+          Every message answered in seconds. Every customer captured. Every question handled in their language — in your voice — 24 hours a day.
+        </p>
+
+        <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
+          <a
+            href="/consultation/"
+            class="group inline-flex items-center gap-2 px-8 py-4 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-all duration-300 shadow-lg shadow-cush-orange/25 hover:shadow-xl hover:shadow-cush-orange/30 text-lg"
+          >
+            Book a Discovery Call
+            <svg class="w-5 h-5 transition-transform group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+            </svg>
+          </a>
+          <a href="/services/" class="font-display font-medium text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white underline underline-offset-4 decoration-gray-300 hover:decoration-cush-orange transition-all">
+            See all services →
+          </a>
+        </div>
+      </div>
+    </Container>
+  </section>
+
+  <!-- Problem -->
+  <section class="py-20 md:py-28 bg-gray-50 dark:bg-gray-900/30 border-y border-gray-100 dark:border-gray-800">
+    <Container size="lg">
+      <div class="max-w-3xl">
+        <h2 class="font-display font-bold text-3xl md:text-4xl text-gray-900 dark:text-white mb-8 leading-tight tracking-tight">
+          The problem every business owner knows
+        </h2>
+        <div class="space-y-6 text-lg text-gray-600 dark:text-gray-400 leading-relaxed">
+          <p>
+            Your Facebook page gets messages. Some you catch. Most you don't — not fast enough, anyway. And in competitive markets, the business that responds first wins the conversation.
+          </p>
+          <p>
+            You've seen the generic autoresponders. <em>"Thanks for reaching out! We'll get back to you shortly."</em> That's not a solution. That's a polite way of losing a lead.
+          </p>
+          <p>
+            Facebook removes your "responds quickly" badge if you take more than 15 minutes to reply. With AI, your response time is under 5 seconds — always.
+          </p>
+        </div>
+      </div>
+    </Container>
+  </section>
+
+  <!-- Solution -->
+  <section class="py-20 md:py-32">
+    <Container size="lg">
+      <div class="grid lg:grid-cols-12 gap-12 lg:gap-16">
+
+        <!-- Left: Solution narrative -->
+        <div class="lg:col-span-7 space-y-12">
+          <div>
+            <h2 class="font-display font-bold text-3xl md:text-5xl text-gray-900 dark:text-white mb-4 leading-tight tracking-tight">
+              What CushLabs builds instead
+            </h2>
+            <p class="text-xl md:text-2xl text-cush-orange font-medium leading-relaxed mb-8">
+              Not a template. Not a chatbot that says "I didn't understand that."
+            </p>
+            <div class="prose prose-lg dark:prose-invert max-w-none">
+              <div class="text-gray-900 dark:text-gray-200 bg-cush-orange/5 border-l-4 border-cush-orange pl-6 py-4 rounded-r-lg space-y-3">
+                <p>A custom AI assistant that lives in your Facebook Messenger and actually knows your business. An assistant trained on your services, your pricing, your voice — that answers the way you would, at any hour, in any language your customers speak.</p>
+                <p>It recommends the right product. It books the appointment. It handles the FAQ a hundred times a day without complaining. And when a real human is needed, it hands the conversation off to you with the context already gathered.</p>
+                <p>We've already deployed this for a real client. It's live, it's in production, and it's handling inquiries right now while the business owner sleeps.</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- What it means -->
+          <div>
+            <h3 class="font-display font-semibold text-2xl text-gray-900 dark:text-white mb-6">
+              What it means for your business
+            </h3>
+            <div class="space-y-5">
+              {[
+                { title: "You stop losing leads after hours.", body: "Prospects who message at 10pm get a real answer — not a form, not silence, not 'we'll get back to you.'" },
+                { title: "You stop answering the same questions.", body: "Pricing, availability, services, how it works — your assistant handles all of it. You only hear from customers when they're ready to buy." },
+                { title: "It speaks their language.", body: "Spanish-speaking customer? They get Spanish. English? English. Automatic, natural, seamless." },
+                { title: "It knows when to get you.", body: "When a conversation genuinely needs you, it steps aside and hands it over — with full context. When you're done, it picks back up." },
+                { title: "It sounds like you — not a robot.", body: "Because it's built from your content: your website, your service descriptions, your FAQs. Every answer comes from what you've already said about your business." },
+              ].map(item => (
+                <div class="flex gap-4">
+                  <svg class="w-5 h-5 text-green-500 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                  </svg>
+                  <div>
+                    <strong class="text-gray-900 dark:text-white font-semibold">{item.title}</strong>
+                    {" "}<span class="text-gray-600 dark:text-gray-400">{item.body}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <!-- Best For -->
+          <div>
+            <h3 class="font-display font-semibold text-sm text-gray-900 dark:text-white mb-6 uppercase tracking-wider">
+              Best For:
+            </h3>
+            <div class="grid sm:grid-cols-2 gap-4">
+              {bestFor.map(item => (
+                <div class="flex gap-3">
+                  <svg class="w-5 h-5 text-green-500 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                  </svg>
+                  <span class="text-gray-700 dark:text-gray-300 text-sm leading-relaxed">{item}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <!-- Right: Specs card -->
+        <div class="lg:col-span-5 space-y-8">
+
+          <!-- Pricing card -->
+          <div class="bg-gray-900 dark:bg-gray-800 rounded-2xl p-8 shadow-xl text-gray-300">
+            <div class="mb-6 pb-6 border-b border-gray-700">
+              <h4 class="font-display font-semibold text-white mb-2 uppercase text-xs tracking-wider">Timeline</h4>
+              <div class="text-lg text-white font-medium">Live in 2 weeks. Discovery call → training → testing → launch.</div>
+            </div>
+            <div class="mb-4">
+              <h4 class="font-display font-semibold text-white mb-2 uppercase text-xs tracking-wider">Investment</h4>
+              <div class="text-base leading-relaxed">
+                Included in the <span class="text-white font-bold">AI Growth Bundle — $997/month</span>. Single page, unlimited conversations, fully managed. Includes setup, training, weekly reports, and monthly tuning. No setup fee. No long-term contract.
+              </div>
+            </div>
+            <p class="text-xs text-cush-orange font-medium mt-4 italic">Free 2-week trial. Cancel anytime.</p>
+            <div class="mt-8">
+              <a href="/consultation/" class="block w-full text-center px-6 py-3 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-colors duration-300">
+                Book a Discovery Call
+              </a>
+            </div>
+          </div>
+
+          <!-- Included -->
+          <div>
+            <h3 class="font-display font-semibold text-xl text-gray-900 dark:text-white mb-6">What's Included</h3>
+            <ul class="space-y-4">
+              {included.map(item => (
+                <li class="flex gap-4">
+                  <div class="w-1.5 h-1.5 bg-cush-orange rounded-full mt-2.5 shrink-0"></div>
+                  <div>
+                    <strong class="text-gray-900 dark:text-white font-semibold">{item.title}</strong> — <span class="text-gray-600 dark:text-gray-400 text-sm">{item.desc}</span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <!-- Not included -->
+          <div class="pt-6 border-t border-gray-200 dark:border-gray-800">
+            <h3 class="font-display font-semibold text-base text-gray-900 dark:text-white mb-4">What's NOT Included</h3>
+            <ul class="space-y-2">
+              {notIncluded.map(item => (
+                <li class="flex gap-3 text-sm text-gray-500 dark:text-gray-500">
+                  <svg class="w-4 h-4 text-gray-400 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+      </div>
+    </Container>
+  </section>
+
+  <!-- Why CushLabs -->
+  <section class="py-20 md:py-28 bg-gray-50 dark:bg-gray-900/30 border-y border-gray-100 dark:border-gray-800">
+    <Container size="md">
+      <div class="max-w-3xl mx-auto text-center">
+        <h2 class="font-display font-bold text-3xl md:text-4xl text-gray-900 dark:text-white mb-8 leading-tight tracking-tight">
+          Why CushLabs over a generic chatbot platform
+        </h2>
+        <div class="space-y-6 text-lg text-gray-600 dark:text-gray-400 leading-relaxed text-left">
+          <p>
+            Generic platforms give you a builder. CushLabs gives you a deployed, production-ready assistant — built, configured, tested, and monitored. We handle the setup, the content ingestion, the Facebook integration, and the ongoing reliability. You get the results.
+          </p>
+          <p>
+            We've already solved the hard problems: bilingual support, accurate answers grounded in your actual business content, graceful handover to humans, 24/7 uptime with error monitoring. You don't pay for us to figure it out — we've already figured it out.
+          </p>
+        </div>
+        <div class="mt-10">
+          <a
+            href="/consultation/"
+            class="inline-flex items-center gap-2 px-8 py-4 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-all duration-300 shadow-lg shadow-cush-orange/25 hover:shadow-xl text-lg"
+          >
+            Start Your Free 2-Week Trial
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+            </svg>
+          </a>
+        </div>
+      </div>
+    </Container>
+  </section>
+
+  <FinalCTA locale={locale} />
+
+</BaseLayout>


### PR DESCRIPTION
## Summary
- Adds portfolio page for ny-english-messenger-bot
- All 9 hero slides in EN + ES with full alt text
- projects.generated.json synced

🤖 Generated with [Claude Code](https://claude.com/claude-code)