### PR TITLE
Add Messenger privacy policy and data deletion page

### DIFF
--- a/src/pages/data-deletion.astro
+++ b/src/pages/data-deletion.astro
@@ -1,0 +1,127 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+---
+
+<BaseLayout
+  title="Data Deletion Instructions | CushLabs.ai"
+  description="How to request deletion of personal data collected by CushLabs AI Messenger Assistants. We respond within 30 days."
+>
+  <main class="min-h-screen bg-white dark:bg-gray-950">
+    <!-- Hero -->
+    <section class="relative pt-24 pb-12">
+      <div class="absolute inset-0 -z-10">
+        <div class="absolute top-20 left-1/4 w-96 h-96 bg-cush-orange/10 rounded-full blur-3xl"></div>
+      </div>
+      <div class="mx-auto max-w-3xl px-4 text-center">
+        <h1 class="font-display text-4xl font-bold text-gray-900 dark:text-white md:text-5xl">
+          Data Deletion Instructions
+        </h1>
+        <p class="mt-4 text-gray-500 dark:text-gray-400">Last updated: April 2026</p>
+      </div>
+    </section>
+
+    <!-- Content -->
+    <section class="pb-24">
+      <div class="mx-auto max-w-3xl px-4 space-y-10">
+
+        <div>
+          <p class="text-lg text-gray-600 dark:text-gray-400 leading-relaxed">
+            This page explains how to request deletion of any personal data held by CushLabs AI Services as a result of interacting with an AI Messenger Assistant powered by CushLabs.
+          </p>
+          <p class="mt-4 text-gray-600 dark:text-gray-400 leading-relaxed">
+            <strong class="text-gray-900 dark:text-white">Quick version:</strong> Email <a href="mailto:privacy@cushlabs.ai" class="text-cush-orange underline underline-offset-2">privacy@cushlabs.ai</a> with the subject line "Data Deletion Request", or send a WhatsApp message to +52 33 1559 0572 with the message "Please delete my data". We will confirm deletion within 30 days.
+          </p>
+        </div>
+
+        <div>
+          <h2 class="font-display text-xl font-semibold text-gray-900 dark:text-white mb-4">What Data We Hold</h2>
+          <p class="text-gray-600 dark:text-gray-400 leading-relaxed mb-4">
+            When you interact with a CushLabs-powered Messenger Assistant on Facebook, we temporarily store:
+          </p>
+          <ul class="space-y-2 text-gray-600 dark:text-gray-400">
+            {[
+              "Your Facebook-Scoped User ID (PSID)",
+              "Your public first and last name as shown on your Facebook profile",
+              "The content of your recent messages",
+              "Your language preference (English or Spanish)",
+              "Message timestamps and short-term conversation state",
+            ].map(item => (
+              <li class="flex gap-3">
+                <span class="text-cush-orange mt-1">—</span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+          <p class="mt-4 text-gray-600 dark:text-gray-400 leading-relaxed">
+            All data is stored in Cloudflare Workers KV and automatically deleted: conversation history and language preferences after 1 hour, handoff state after 30 minutes. In most cases your data has already expired before a request arrives.
+          </p>
+        </div>
+
+        <div>
+          <h2 class="font-display text-xl font-semibold text-gray-900 dark:text-white mb-6">How to Request Deletion</h2>
+
+          <div class="space-y-6">
+            <div class="bg-gray-50 dark:bg-gray-900 rounded-xl p-6">
+              <h3 class="font-display font-semibold text-gray-900 dark:text-white mb-2">Option A — Email</h3>
+              <p class="text-gray-600 dark:text-gray-400 text-sm leading-relaxed">
+                Send to <a href="mailto:privacy@cushlabs.ai" class="text-cush-orange underline underline-offset-2">privacy@cushlabs.ai</a> with subject "Data Deletion Request". Include the name you use on Facebook so we can locate the correct records.
+              </p>
+            </div>
+
+            <div class="bg-gray-50 dark:bg-gray-900 rounded-xl p-6">
+              <h3 class="font-display font-semibold text-gray-900 dark:text-white mb-2">Option B — WhatsApp</h3>
+              <p class="text-gray-600 dark:text-gray-400 text-sm leading-relaxed">
+                Message +52 33 1559 0572 with "Please delete my data". Include your Facebook display name.
+              </p>
+            </div>
+
+            <div class="bg-gray-50 dark:bg-gray-900 rounded-xl p-6">
+              <h3 class="font-display font-semibold text-gray-900 dark:text-white mb-2">Option C — Facebook Messenger</h3>
+              <p class="text-gray-600 dark:text-gray-400 text-sm leading-relaxed">
+                Send "Please delete my data" directly to the Facebook Page whose Messenger Assistant you interacted with. A human operator will process the request.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <h2 class="font-display text-xl font-semibold text-gray-900 dark:text-white mb-4">What We Will Do</h2>
+          <p class="text-gray-600 dark:text-gray-400 leading-relaxed mb-4">Within 30 days of receiving your request, we will:</p>
+          <ol class="space-y-2 text-gray-600 dark:text-gray-400 list-decimal list-inside">
+            <li>Locate any data currently held about you</li>
+            <li>Permanently delete all conversation history, language preferences, PSID-linked records, and any other personal data associated with your account</li>
+            <li>Send you a confirmation via the same channel you used to make the request</li>
+          </ol>
+        </div>
+
+        <div>
+          <h2 class="font-display text-xl font-semibold text-gray-900 dark:text-white mb-4">What We Cannot Delete</h2>
+          <p class="text-gray-600 dark:text-gray-400 leading-relaxed mb-3">We may retain the following because it cannot be tied back to your personal identity:</p>
+          <ul class="space-y-2 text-gray-600 dark:text-gray-400">
+            {[
+              "Aggregated, anonymized analytics — message counts with no personal identifiers",
+              "Anonymized error logs — technical reports with timestamps and stack traces, no message content or Facebook identity",
+              "Data held by Meta/Facebook — we cannot delete data Meta retains under its own policies. Use Facebook's data controls at facebook.com/settings.",
+            ].map(item => (
+              <li class="flex gap-3">
+                <span class="text-cush-orange mt-1">—</span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div class="pt-8 border-t border-gray-200 dark:border-gray-800">
+          <h2 class="font-display text-xl font-semibold text-gray-900 dark:text-white mb-4">Contact</h2>
+          <p class="text-gray-600 dark:text-gray-400 leading-relaxed">
+            For questions about this process, or to follow up on a request:<br />
+            Email: <a href="mailto:privacy@cushlabs.ai" class="text-cush-orange underline underline-offset-2">privacy@cushlabs.ai</a><br />
+            WhatsApp: +52 33 1559 0572<br />
+            Operator: Robert Cushman, CushLabs AI Services, Guadalajara, Mexico
+          </p>
+        </div>
+
+      </div>
+    </section>
+  </main>
+</BaseLayout>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -3,37 +3,57 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 
 const content = {
   title: "Privacy Policy | CushLabs.ai",
-  description: "Learn how CushLabs.ai collects, uses, and protects your personal information. We respect your privacy — no tracking cookies, no data sales, no surprises.",
+  description: "Learn how CushLabs.ai collects, uses, and protects your personal information, including data processed by our AI Messenger Assistant product.",
   heading: "Privacy Policy",
-  lastUpdated: "Last updated: February 2026",
+  lastUpdated: "Last updated: April 2026",
   sections: [
     {
+      title: "Overview",
+      content: "CushLabs AI Services is an AI consulting and software development company operated by Robert Cushman, based in Guadalajara, Mexico. This policy covers how we collect, use, and protect your personal information when you use our website (cushlabs.ai), contact us directly, or interact with AI Messenger Assistants deployed by CushLabs on behalf of our clients."
+    },
+    {
       title: "Information We Collect",
-      content: "We collect information you provide directly to us, such as when you fill out a contact form, book a consultation, or communicate with us via email. This may include your name, email address, phone number, company name, and any other information you choose to provide."
+      content: "Website: When you use cushlabs.ai, we may collect contact information you submit via forms (name, email, phone, company), technical information (IP address, browser type, device details), and usage information (pages visited, time on site). We do not collect payment information directly.\n\nAI Messenger Assistant (Facebook Messenger): When you message a Facebook Page that uses a CushLabs-powered Messenger Assistant, we receive and process: your Facebook-Scoped User ID (PSID) — an anonymous identifier unique to that Page; the content of your messages; your language preference (English or Spanish); and message timestamps. We do not collect your email address, phone number, friends list, or any other Facebook profile data beyond what is listed."
     },
     {
       title: "How We Use Your Information",
-      content: "We use the information we collect to respond to your inquiries, provide our consulting services, send you updates about our services (with your consent), and improve our website and services."
+      content: "We use your data to: provide and improve our services; respond to your inquiries; maintain short-term conversation context in Messenger Assistants; detect and respond in your preferred language; analyze site usage and performance; maintain security; and comply with legal obligations. We do not use Messenger data for advertising, profiling, or resale."
     },
     {
-      title: "Information Sharing",
-      content: "We do not sell, trade, or otherwise transfer your personal information to third parties without your consent, except as necessary to provide our services or as required by law."
+      title: "Data Retention",
+      content: "Website data: Retained as long as necessary to provide the services you requested, or as required by law.\n\nMessenger Assistant data: Stored temporarily in Cloudflare Workers KV and automatically deleted on a rolling schedule — conversation history: 1 hour; language preference: 1 hour; handoff state: 30 minutes. We do not maintain long-term storage of Messenger conversations."
     },
     {
-      title: "Data Security",
-      content: "We implement appropriate security measures to protect your personal information against unauthorized access, alteration, disclosure, or destruction."
-    },
-    {
-      title: "Cookies",
-      content: "Our website may use cookies to enhance your browsing experience. You can choose to disable cookies through your browser settings, though this may affect some website functionality."
+      title: "Third-Party Processors",
+      content: "We do not sell or rent your personal data. For the Messenger Assistant product, your messages are transmitted to the following processors: Meta Platforms, Inc. — delivers messages via the Messenger Platform; Anthropic, PBC — provides the Claude AI model that generates responses; Cloudflare, Inc. — hosts the Worker, provides KV storage, Vectorize vector database, and AI Gateway routing; Functional Software, Inc. (Sentry) — receives error reports for monitoring purposes. For general website operations, we may use analytics providers and email services."
     },
     {
       title: "Your Rights",
-      content: "You have the right to access, correct, or delete your personal information. To exercise these rights, please contact us at info@cushlabs.ai."
+      content: "Depending on your location, you may have the right to: access the personal data we hold about you; correct or update inaccurate information; request deletion of your personal data; object to or restrict how your data is processed; and withdraw previously given consent. To exercise any of these rights, contact us at privacy@cushlabs.ai."
+    },
+    {
+      title: "Data Deletion",
+      content: "You can request deletion of all data we hold about you at any time. Full instructions are at: https://www.cushlabs.ai/data-deletion/"
+    },
+    {
+      title: "Data Security",
+      content: "We use appropriate technical and organizational safeguards to protect your data, including encrypted transit (HTTPS/TLS) and encrypted secrets storage. No method of online transmission or storage is completely secure."
+    },
+    {
+      title: "Cookies",
+      content: "Our website may use cookies to enhance your browsing experience. You can manage cookie preferences in your browser settings. Messenger Assistants do not use cookies."
+    },
+    {
+      title: "Children's Privacy",
+      content: "Our services are intended for adults aged 18 and over. We do not knowingly collect data from anyone under 18. Contact us at privacy@cushlabs.ai if you believe this has occurred."
+    },
+    {
+      title: "Changes to This Policy",
+      content: "We may occasionally update this Privacy Policy. When changes occur, we will update the date at the top of this page."
     },
     {
       title: "Contact Us",
-      content: "If you have any questions about this Privacy Policy, please contact us at info@cushlabs.ai."
+      content: "For privacy-related questions, data access requests, or concerns: Email: privacy@cushlabs.ai | WhatsApp: +52 33 1559 0572 | Operator: Robert Cushman, CushLabs AI Services, Guadalajara, Mexico"
     }
   ]
 };
@@ -66,11 +86,14 @@ const content = {
               <h2 class="font-display text-xl font-semibold text-gray-900 dark:text-white mb-3">
                 {section.title}
               </h2>
-              <p class="text-gray-600 dark:text-gray-400 leading-relaxed">
+              <p class="text-gray-600 dark:text-gray-400 leading-relaxed whitespace-pre-line">
                 {section.content}
               </p>
             </div>
           ))}
+        </div>
+        <div class="mt-12 pt-8 border-t border-gray-200 dark:border-gray-800 text-sm text-gray-500 dark:text-gray-500">
+          <p>For data deletion requests, see our <a href="/data-deletion/" class="text-cush-orange underline underline-offset-2">Data Deletion Instructions</a>.</p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Updates `cushlabs.ai/privacy` with AI Messenger Assistant disclosures: PSIDs, Anthropic as AI processor, Cloudflare Vectorize, 1-hour KV retention TTL, data deletion link
- Creates `cushlabs.ai/data-deletion` with 3-channel deletion request process (email, WhatsApp, Messenger) and 30-day response SLA
- Required for Meta App Review submission for the CushLabs multi-client Messenger product

## Test plan
- [ ] Visit cushlabs.ai/privacy — verify Messenger section renders, data deletion link works
- [ ] Visit cushlabs.ai/data-deletion — verify all 3 request options render correctly
- [ ] Build passes clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)