### PR TITLE
fix(seo): resolve Ahrefs errors + add Learn More links to messenger page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,12 +35,41 @@
 - Custom Development (full-stack apps, dashboards)
 - AI Strategy & Consulting
 
-**Packaged Services (Productized Offerings):**
-- Onboarding Assistant Bot - RAG chatbot for new employee onboarding
-- Customer Service Voice Agent - Voicebots for tier-1 support
-- Internal Knowledge Base Bot - Company documentation Q&A
-- Sales Enablement Assistant - Product/competitive intel for reps
-- Document Q&A System - Upload docs and ask questions
+**Current Productized Offerings (what Robert actively sells and can deliver):**
+- **AI Messenger Assistant** — AI chatbot deployed to Facebook Messenger (or website). Live with real client in production. Standalone service page: `/messenger-assistant/`
+- **AI Voice Agent** — Inbound voice agent for missed calls. Live at `voice.cushlabs.ai`. No standalone service page yet (planned).
+- **AI Customer Support Chatbot** — Website chat widget. Same underlying tech as Messenger, different surface.
+
+**NOT offered yet (do not mention on site):**
+- Outbound auto-dialing / cold calling campaigns
+
+---
+
+## Messenger AI — Mexican Market Positioning (IMPORTANT)
+
+When working on copy or pages for the Facebook Messenger AI service, keep this framing in mind:
+
+**The key insight:** Many small Mexican businesses (family-owned, local) have NO website. Their entire business presence is their Facebook page. The Messenger AI is not "another channel" for them — it IS their storefront.
+
+**Strong pitch for this market:**
+> "Most of your competitors have no website. You don't need one either. We put your sales assistant where your customers already are — Facebook — and alert you on WhatsApp when someone's ready to talk."
+
+**Handover approach for non-tech clients:**
+- Business owner does NOT need Meta Business Suite or any new app
+- When the AI detects a human is needed, it captures the customer's phone number and sends the owner a **WhatsApp message**: "New lead from Facebook: [Name], [Number], wants [X]. Ready to book."
+- Owner calls or messages the customer directly — channel they already live in
+- This is a feature, not a workaround: faster than inbox monitoring, works on any phone
+
+**Robert's own preferred workflow (dog-fooding this):**
+- WhatsApp desktop (always open, taskbar notifications with blinking)
+- See the WhatsApp alert with conversation summary
+- Switch to Facebook Messenger desktop app (available in Microsoft Store) or browser tab
+- Handle the conversation directly
+
+**What the product lineup is NOT:**
+- Not a multi-channel inbox tool
+- Not a bot builder platform
+- Not anything that requires the client to learn new software
 
 ---
 

--- a/src/components/services2/ServiceBlock.astro
+++ b/src/components/services2/ServiceBlock.astro
@@ -72,6 +72,8 @@ const data = {
     }
   },
   'competitive-intelligence': {
+    learnMoreUrl: { en: '/messenger-assistant/', es: '/es/messenger-assistant/' },
+    learnMoreLabel: { en: 'Full service details →', es: 'Ver detalles completos →' },
     en: {
       heading: "AI Assistant on Your Facebook Page That Sells While You Sleep",
       subheading: "Every message answered in seconds. Every customer captured. Every question handled in their language — in your voice — 24 hours a day.",
@@ -199,10 +201,13 @@ const data = {
 
 const block = data[id as keyof typeof data][locale];
 if (!block) throw new Error(`Block ${id} not found for locale ${locale}`);
-// liveUrl / liveLabel are optional top-level fields on select service blocks
-type ServiceEntry = { liveUrl?: string; liveLabel?: Record<string, string> };
-const liveUrl = (data[id as keyof typeof data] as ServiceEntry).liveUrl;
-const liveLabel = (data[id as keyof typeof data] as ServiceEntry).liveLabel?.[locale];
+// liveUrl / liveLabel / learnMoreUrl / learnMoreLabel are optional top-level fields on select service blocks
+type ServiceEntry = { liveUrl?: string; liveLabel?: Record<string, string>; learnMoreUrl?: Record<string, string>; learnMoreLabel?: Record<string, string> };
+const entry = data[id as keyof typeof data] as ServiceEntry;
+const liveUrl = entry.liveUrl;
+const liveLabel = entry.liveLabel?.[locale];
+const learnMoreUrl = entry.learnMoreUrl?.[locale];
+const learnMoreLabel = entry.learnMoreLabel?.[locale];
 
 const bgClass = isAlternate ? 'bg-gray-50 dark:bg-gray-900/30' : 'bg-white dark:bg-black';
 
@@ -285,6 +290,11 @@ const bgClass = isAlternate ? 'bg-gray-50 dark:bg-gray-900/30' : 'bg-white dark:
             {liveUrl && liveLabel && (
               <a href={liveUrl} target="_blank" rel="noopener noreferrer" class="block w-full text-center px-6 py-3 border border-gray-600 text-gray-300 font-display font-semibold rounded-lg hover:border-cush-orange hover:text-cush-orange transition-colors duration-300">
                 {liveLabel}
+              </a>
+            )}
+            {learnMoreUrl && learnMoreLabel && (
+              <a href={learnMoreUrl} class="block w-full text-center px-6 py-3 text-gray-400 font-display font-medium text-sm hover:text-cush-orange transition-colors duration-300 underline underline-offset-4 decoration-gray-600 hover:decoration-cush-orange">
+                {learnMoreLabel}
               </a>
             )}
           </div>

--- a/src/pages/es/data-deletion.astro
+++ b/src/pages/es/data-deletion.astro
@@ -1,0 +1,127 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+---
+
+<BaseLayout
+  title="Instrucciones de Eliminación de Datos | CushLabs.ai"
+  description="Cómo solicitar la eliminación de los datos personales recopilados por los Asistentes de IA en Messenger de CushLabs. Respondemos en un plazo de 30 días."
+>
+  <main class="min-h-screen bg-white dark:bg-gray-950">
+    <!-- Hero -->
+    <section class="relative pt-24 pb-12">
+      <div class="absolute inset-0 -z-10">
+        <div class="absolute top-20 left-1/4 w-96 h-96 bg-cush-orange/10 rounded-full blur-3xl"></div>
+      </div>
+      <div class="mx-auto max-w-3xl px-4 text-center">
+        <h1 class="font-display text-4xl font-bold text-gray-900 dark:text-white md:text-5xl">
+          Instrucciones de Eliminación de Datos
+        </h1>
+        <p class="mt-4 text-gray-500 dark:text-gray-400">Última actualización: abril de 2026</p>
+      </div>
+    </section>
+
+    <!-- Content -->
+    <section class="pb-24">
+      <div class="mx-auto max-w-3xl px-4 space-y-10">
+
+        <div>
+          <p class="text-lg text-gray-600 dark:text-gray-400 leading-relaxed">
+            Esta página explica cómo solicitar la eliminación de cualquier dato personal en posesión de CushLabs AI Services como resultado de interactuar con un Asistente de IA en Messenger creado por CushLabs.
+          </p>
+          <p class="mt-4 text-gray-600 dark:text-gray-400 leading-relaxed">
+            <strong class="text-gray-900 dark:text-white">Versión rápida:</strong> Envía un correo a <a href="mailto:privacy@cushlabs.ai" class="text-cush-orange underline underline-offset-2">privacy@cushlabs.ai</a> con el asunto "Solicitud de Eliminación de Datos", o un mensaje de WhatsApp al +52 33 1559 0572 con el texto "Por favor eliminen mis datos". Confirmaremos la eliminación en un plazo de 30 días.
+          </p>
+        </div>
+
+        <div>
+          <h2 class="font-display text-xl font-semibold text-gray-900 dark:text-white mb-4">Qué Datos Conservamos</h2>
+          <p class="text-gray-600 dark:text-gray-400 leading-relaxed mb-4">
+            Cuando interactúas con un Asistente de Messenger en Facebook desarrollado por CushLabs, almacenamos temporalmente:
+          </p>
+          <ul class="space-y-2 text-gray-600 dark:text-gray-400">
+            {[
+              "Tu ID de Usuario de Facebook (PSID)",
+              "Tu nombre y apellido públicos tal como aparecen en tu perfil de Facebook",
+              "El contenido de tus mensajes recientes",
+              "Tu preferencia de idioma (inglés o español)",
+              "Marcas de tiempo de los mensajes y estado de conversación a corto plazo",
+            ].map(item => (
+              <li class="flex gap-3">
+                <span class="text-cush-orange mt-1">—</span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+          <p class="mt-4 text-gray-600 dark:text-gray-400 leading-relaxed">
+            Todos los datos se almacenan en Cloudflare Workers KV y se eliminan automáticamente: el historial de conversación y la preferencia de idioma después de 1 hora; el estado de transferencia después de 30 minutos. En la mayoría de los casos, tus datos ya han expirado antes de que llegue una solicitud.
+          </p>
+        </div>
+
+        <div>
+          <h2 class="font-display text-xl font-semibold text-gray-900 dark:text-white mb-6">Cómo Solicitar la Eliminación</h2>
+
+          <div class="space-y-6">
+            <div class="bg-gray-50 dark:bg-gray-900 rounded-xl p-6">
+              <h3 class="font-display font-semibold text-gray-900 dark:text-white mb-2">Opción A — Correo Electrónico</h3>
+              <p class="text-gray-600 dark:text-gray-400 text-sm leading-relaxed">
+                Envía un correo a <a href="mailto:privacy@cushlabs.ai" class="text-cush-orange underline underline-offset-2">privacy@cushlabs.ai</a> con el asunto "Solicitud de Eliminación de Datos". Incluye el nombre que usas en Facebook para que podamos localizar los registros correctos.
+              </p>
+            </div>
+
+            <div class="bg-gray-50 dark:bg-gray-900 rounded-xl p-6">
+              <h3 class="font-display font-semibold text-gray-900 dark:text-white mb-2">Opción B — WhatsApp</h3>
+              <p class="text-gray-600 dark:text-gray-400 text-sm leading-relaxed">
+                Envía un mensaje al +52 33 1559 0572 con el texto "Por favor eliminen mis datos". Incluye el nombre con el que apareces en Facebook.
+              </p>
+            </div>
+
+            <div class="bg-gray-50 dark:bg-gray-900 rounded-xl p-6">
+              <h3 class="font-display font-semibold text-gray-900 dark:text-white mb-2">Opción C — Facebook Messenger</h3>
+              <p class="text-gray-600 dark:text-gray-400 text-sm leading-relaxed">
+                Envía "Por favor eliminen mis datos" directamente a la Página de Facebook cuyo Asistente de Messenger usaste. Un operador humano procesará la solicitud.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <h2 class="font-display text-xl font-semibold text-gray-900 dark:text-white mb-4">Qué Haremos</h2>
+          <p class="text-gray-600 dark:text-gray-400 leading-relaxed mb-4">En un plazo de 30 días desde la recepción de tu solicitud, haremos lo siguiente:</p>
+          <ol class="space-y-2 text-gray-600 dark:text-gray-400 list-decimal list-inside">
+            <li>Localizaremos los datos que tengamos sobre ti</li>
+            <li>Eliminaremos permanentemente todo el historial de conversación, las preferencias de idioma, los registros vinculados a tu PSID y cualquier otro dato personal asociado con tu cuenta</li>
+            <li>Te enviaremos una confirmación por el mismo canal que usaste para hacer la solicitud</li>
+          </ol>
+        </div>
+
+        <div>
+          <h2 class="font-display text-xl font-semibold text-gray-900 dark:text-white mb-4">Qué No Podemos Eliminar</h2>
+          <p class="text-gray-600 dark:text-gray-400 leading-relaxed mb-3">Es posible que conservemos lo siguiente porque no puede vincularse a tu identidad personal:</p>
+          <ul class="space-y-2 text-gray-600 dark:text-gray-400">
+            {[
+              "Analíticas agregadas y anónimas — conteos de mensajes sin identificadores personales",
+              "Registros de errores anónimos — informes técnicos con marcas de tiempo y trazas, sin contenido de mensajes ni identidad de Facebook",
+              "Datos en posesión de Meta/Facebook — no podemos eliminar los datos que Meta retiene bajo sus propias políticas. Usa los controles de datos de Facebook en facebook.com/settings.",
+            ].map(item => (
+              <li class="flex gap-3">
+                <span class="text-cush-orange mt-1">—</span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div class="pt-8 border-t border-gray-200 dark:border-gray-800">
+          <h2 class="font-display text-xl font-semibold text-gray-900 dark:text-white mb-4">Contacto</h2>
+          <p class="text-gray-600 dark:text-gray-400 leading-relaxed">
+            Para preguntas sobre este proceso o para dar seguimiento a una solicitud:<br />
+            Correo: <a href="mailto:privacy@cushlabs.ai" class="text-cush-orange underline underline-offset-2">privacy@cushlabs.ai</a><br />
+            WhatsApp: +52 33 1559 0572<br />
+            Operador: Robert Cushman, CushLabs AI Services, Guadalajara, México
+          </p>
+        </div>
+
+      </div>
+    </section>
+  </main>
+</BaseLayout>

--- a/src/pages/es/messenger-assistant.astro
+++ b/src/pages/es/messenger-assistant.astro
@@ -30,9 +30,8 @@ const bestFor = [
 ---
 
 <BaseLayout
-  title="Asistente de IA en Facebook Messenger | CushLabs.ai"
+  title="Asistente IA Messenger | CushLabs.ai"
   description="Un asistente de ventas con IA disponible 24/7 en tu Facebook Messenger — entrenado con tu negocio, activo en semanas. Bilingüe EN/ES. Totalmente gestionado."
-  canonical="https://cushlabs.ai/es/messenger-assistant/"
 >
 
   <!-- Hero -->

--- a/src/pages/es/privacy.astro
+++ b/src/pages/es/privacy.astro
@@ -75,6 +75,9 @@ const content = {
             </div>
           ))}
         </div>
+        <div class="mt-12 pt-8 border-t border-gray-200 dark:border-gray-800 text-sm text-gray-500 dark:text-gray-500">
+          <p>Para solicitudes de eliminación de datos, consulta nuestras <a href="/es/data-deletion/" class="text-cush-orange underline underline-offset-2">Instrucciones de Eliminación de Datos</a>.</p>
+        </div>
       </div>
     </section>
   </main>

--- a/src/pages/messenger-assistant.astro
+++ b/src/pages/messenger-assistant.astro
@@ -30,9 +30,8 @@ const bestFor = [
 ---
 
 <BaseLayout
-  title="AI Messenger Assistant for Facebook | CushLabs.ai"
+  title="AI Messenger Assistant | CushLabs.ai"
   description="A 24/7 AI sales assistant in your Facebook Messenger — built from your content, trained on your business, live in weeks. Bilingual EN/ES. Fully managed."
-  canonical="https://cushlabs.ai/messenger-assistant/"
 >
 
   <!-- Hero -->


### PR DESCRIPTION
## Summary

The 25 April Ahrefs crawl dropped health score 100 → 96 after PR #74. This PR resolves the regression and bundles the Learn More link work that originated this branch.

**Root causes identified:**
1. **`/messenger-assistant/` (EN+ES) canonicals pointed at the bare domain** (`https://cushlabs.ai/...`) while the rest of the site uses `www.cushlabs.ai`. → +2 "Non-canonical page in sitemap" errors.
2. **`/data-deletion/` shipped EN-only in #74.** `BaseLayout` auto-emits hreflang to `/es/data-deletion/` which 404'd, cascading into +4 errors (hreflang-broken, 404, 4XX, page-links-to-broken).
3. **Messenger titles too long** by Ahrefs's pixel threshold. → +2 warnings.

**Fixes:**
- Removed the absolute bare-domain `canonical` prop on both messenger pages; `BaseLayout` now resolves canonical from `Astro.site` (`www.cushlabs.ai`).
- Added `src/pages/es/data-deletion.astro` — full Spanish translation. Sitemap pairs the two pages with proper hreflang.
- Linked `/es/privacy/` to `/es/data-deletion/` for parity with `/privacy/`.
- Tightened messenger titles: EN 49ch → 37ch, ES 51ch → 37ch.
- Original branch work: Learn More links from services page to the standalone messenger page (commit a94e858).

Verified post-build:
- All four pages emit canonicals on `www.cushlabs.ai`.
- `/data-deletion/` and `/es/data-deletion/` appear paired in `dist/sitemap-0.xml` with `hreflang="en-US"` and `hreflang="es-MX"`.
- New ES page emits hreflang `<link>` tags pointing to live URLs in both directions.

## Heads-up — separate gap (not in this PR)

`src/pages/es/privacy.astro` is still the *old* generic privacy policy. PR #74 rewrote `src/pages/privacy.astro` with full Messenger-specific disclosures (data collection, retention, third-party processors) but the Spanish version was never updated. The ES legal page does not currently reflect actual product disclosures. Suggest a separate PR after this lands.

## Test plan

- [ ] After merge, request a fresh Ahrefs crawl
- [ ] Confirm health score returns to 100
- [ ] Verify the +4 error categories disappear from "What's new"
- [ ] Verify "Title too long" warnings drop on next crawl
- [ ] Spot-check `/messenger-assistant/`, `/es/messenger-assistant/`, `/data-deletion/`, `/es/data-deletion/` on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)