### PR TITLE
fix(cors): allow *.cushlabs.ai subdomains on booking worker

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -9,7 +9,7 @@ enabled = true
 enabled = true
 
 [vars]
-ALLOWED_ORIGINS = "https://cushlabs.ai,https://www.cushlabs.ai,http://localhost:4321,http://localhost:4322,*.vercel.app"
+ALLOWED_ORIGINS = "https://cushlabs.ai,https://www.cushlabs.ai,*.cushlabs.ai,http://localhost:4321,http://localhost:4322,*.vercel.app"
 GOOGLE_CALENDAR_ID = "rcushmaniii@gmail.com"
 GOOGLE_CLIENT_ID = "169028283355-vev32b3a1fnaiqb63uus2fbrupa7hj0j.apps.googleusercontent.com"
 PERSONAL_CALENDAR_ID = "9lg6pj8ht2blt3ob4v1rtddsts@group.calendar.google.com"


### PR DESCRIPTION
## Summary
- Booking worker was rejecting CORS requests from `scrollytelling.cushlabs.ai` (and any other cushlabs.ai subdomain).
- The browser dropped responses for missing `Access-Control-Allow-Origin`, so the consultation page on scrollytelling.cushlabs.ai showed no available times for any selected date — even though the API was returning slots.
- Adding the `*.cushlabs.ai` suffix pattern (already supported by the worker's CORS handler — same pattern as `*.vercel.app`) covers all current and future cushlabs.ai subdomains.

## Verification
Deployed via wrangler from the branch. Confirmed with:
- `curl -H "Origin: https://scrollytelling.cushlabs.ai" .../slots/2026-04-30` → returns `Access-Control-Allow-Origin: https://scrollytelling.cushlabs.ai` and slots payload.
- `cushlabs.ai` origin still works.

## Test plan
- [x] Worker deployed and CORS verified via curl
- [ ] Open https://scrollytelling.cushlabs.ai/consultation, pick a date, confirm time slots appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)