### PR TITLE
feat: add bilingual Aviso Legal / Legal Notice to footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -43,6 +43,12 @@ const content = {
         { label: "Terms of Service", href: "/terms/" },
       ],
     },
+    legalNotice: {
+      heading: "Legal Notice",
+      body: "CushLabs.ai is a trade name operated by ROBERT FRANCIS CUSHMAN III, registered as a Persona Física con Actividad Empresarial y Profesional under Mexican tax law.",
+      addressLabel: "Registered Address",
+      contactLabel: "Contact",
+    },
     copyrightPrefix: `© ${new Date().getFullYear()}`,
     copyrightSuffix: "All rights reserved.",
   },
@@ -80,6 +86,12 @@ const content = {
         { label: "Política de Privacidad", href: "/es/privacy/" },
         { label: "Términos de Servicio", href: "/es/terms/" },
       ],
+    },
+    legalNotice: {
+      heading: "Aviso Legal",
+      body: "CushLabs.ai es un nombre comercial operado por ROBERT FRANCIS CUSHMAN III, registrado bajo el régimen fiscal de Persona Física con Actividad Empresarial y Profesional.",
+      addressLabel: "Domicilio Fiscal",
+      contactLabel: "Contacto",
     },
     copyrightPrefix: `© ${new Date().getFullYear()}`,
     copyrightSuffix: "Todos los derechos reservados.",
@@ -240,6 +252,15 @@ const t = content[locale];
           </svg>
         </a>
       </div>
+    </div>
+
+    <!-- Legal Notice / Aviso Legal -->
+    <div class="mt-6 pt-6 border-t border-gray-200 dark:border-gray-800 text-xs text-gray-500 dark:text-gray-500 leading-relaxed space-y-1">
+      <p class="font-semibold text-gray-700 dark:text-gray-300">{t.legalNotice.heading}</p>
+      <p>{t.legalNotice.body}</p>
+      <p><span class="font-medium">RFC:</span> CURO670609L86</p>
+      <p><span class="font-medium">{t.legalNotice.addressLabel}:</span> CALLE GARIBALDI 119, BARRANQUITAS, GUADALAJARA, JALISCO, C.P. 44270, México</p>
+      <p><span class="font-medium">{t.legalNotice.contactLabel}:</span> info@cushlabs.ai</p>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- Adds bilingual (EN/ES) operator disclosure to the global Footer.astro
- Surfaces legal entity name, RFC, registered address, and contact email as plain text on every page
- Two purposes: (1) Mexican PROFECO consumer protection compliance for any commercial site operating under a *nombre comercial*, (2) trade-name-to-legal-entity bridge text that Meta Business Verification's website crawler scans for during the verification process

## Why this matters
The CushLabs Business Portfolio's Meta verification was rejected on 2026-04-23. Research across Meta's docs, developer forums, and BSP guides identified the missing site-level operator disclosure as a documented bridge requirement when a Mexican *persona física* operates under a trade name. This change provides the exact-match strings (legal name, RFC, address) that align with the Meta Business Info fields and the SAT Constancia.

## Test plan
- [ ] Vercel preview deploys successfully
- [ ] Legal Notice renders on the EN homepage with `ROBERT FRANCIS CUSHMAN III`, `CURO670609L86`, `CALLE GARIBALDI 119, BARRANQUITAS, GUADALAJARA, JALISCO, C.P. 44270, México`, `info@cushlabs.ai` as plain text
- [ ] Aviso Legal renders on the ES homepage (`/es/`) with the same strings + Spanish labels
- [ ] Disclosure appears in the footer on Contact and Privacy Policy pages (it's in the global Footer component, so this should be automatic)
- [ ] Mobile and desktop layouts render the disclosure cleanly below the copyright/social icons row

🤖 Generated with [Claude Code](https://claude.com/claude-code)