### PR TITLE
feat: add Facebook page link to footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -227,6 +227,18 @@ const t = content[locale];
         {t.copyrightPrefix} <a href="https://www.cushlabs.ai" class="hover:text-cush-orange transition-colors">CushLabs.ai</a> {t.copyrightSuffix}
       </p>
       <div class="flex items-center gap-4">
+        <!-- Facebook -->
+        <a
+          href="https://www.facebook.com/cushlabs"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-gray-400 hover:text-cush-orange transition-colors"
+          aria-label="Facebook"
+        >
+          <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
+          </svg>
+        </a>
         <!-- LinkedIn -->
         <a
           href="https://www.linkedin.com/in/robert-cushman3/"


### PR DESCRIPTION
## Summary
- Adds CushLabs Facebook page link (https://www.facebook.com/cushlabs) to the footer social icons
- Order: Facebook, LinkedIn, GitHub (business-first, professional, technical)
- Uses standard Facebook circle-f SVG, monochrome via currentColor to match existing icons

## Why now
1. **Brand coherence**: CushLabs sells Facebook Messenger automation as a flagship offering — having LinkedIn + GitHub but no FB link was a credibility gap
2. **Verification signal**: Creates a bidirectional cushlabs.ai ↔ Facebook Page connection that Meta's Business Verification crawler can corroborate against the Page already owned by the Business Portfolio

## Test plan
- [ ] Vercel preview deploys cleanly
- [ ] FB icon renders in footer between brand section and LinkedIn
- [ ] Click opens https://www.facebook.com/cushlabs in a new tab
- [ ] Hover state matches LinkedIn/GitHub (cush-orange)
- [ ] Mobile and desktop both render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)