### PR TITLE
docs: session log + tech debt tracker

### DIFF
--- a/docs/SESSION-LOG.md
+++ b/docs/SESSION-LOG.md
@@ -1,0 +1,113 @@
+# CushLabs.ai — Session Log & Tech Debt
+
+> Living document for the cushlabs.ai marketing site.
+> Captures shipped work, open technical debt, prioritized backlog, and recurring failure modes worth remembering.
+> Newest session at the bottom of "Session History" section. Update at the end of every working session.
+
+---
+
+## Active Technical Debt
+
+Things that shipped but have a known gap. These should be cleaned up before they compound.
+
+| # | Item | Severity | Notes |
+|---|------|----------|-------|
+| 1 | `src/pages/es/privacy.astro` is the old generic policy | **High (legal)** | PR #74 rewrote `src/pages/privacy.astro` with full Messenger Assistant disclosures (data collection, retention windows, third-party processors: Meta, Anthropic, Cloudflare, Sentry; GDPR-style rights). Spanish version was never updated — still reflects "Última actualización: Febrero 2026". Mexican LFPDPPP compliance hinges on the Spanish disclosure since CushLabs serves Mexican customers via Facebook Messenger. |
+| 2 | `BaseLayout.astro` canonical prop has a footgun | Medium | When a page passes an absolute URL to the `canonical` prop, `new URL(absolute, Astro.site)` short-circuits and the explicit URL wins — silently bypassing `Astro.site` config. Caused PR #80's "Non-canonical page in sitemap" Ahrefs errors when `/messenger-assistant/` shipped with `canonical="https://cushlabs.ai/..."` while sitemap used `https://www.cushlabs.ai/...`. Fix: in `BaseLayout.astro` strip protocol+host from any incoming `canonical` before joining with `Astro.site`. |
+| 3 | No standalone Voice Agent service page on main site | Medium (revenue) | AI Voice Agent is a productized offering ($1,497 US / $10,997 MXN) with a live subdomain at voice.cushlabs.ai. cushlabs.ai has no `/voice-agent/` page to drive deep links, capture SEO, or convert prospects. |
+| 4 | No HowTo schema | Low | Only outstanding "Known Issue" in CLAUDE.md. FAQPage schema is already implemented EN+ES. |
+| 5 | SEO automation only wired for cushlabs.ai | Low | Per memory `project_seo_automation`: GSC/Bing/IndexNow scripts work for cushlabs.ai. voice.cushlabs.ai, soyconverso, and other CushLabs domains still need the same automation replicated. |
+
+---
+
+## Backlog (Prioritized)
+
+Work that is planned but not yet started. Bundle related items into single PRs per CLAUDE.md guidance.
+
+### High priority
+
+- **ES privacy.astro Messenger-specific rewrite** — addresses tech-debt #1. Port PR #74's structure to Spanish: same sections, same disclosures, Spanish-native phrasing (not Google-translated). Update `lastUpdated` to current date.
+- **Voice Agent service page** (`/voice-agent/` + `/es/voice-agent/`) — addresses tech-debt #3. Slim intro page covering: what it is, pricing ($1,497 / $10,997 MXN), 3 industries it fits, ROI vs receptionist, primary CTA → `voice.cushlabs.ai` for live demo, secondary CTA → `/consultation`. Source content: `docs/voice-cushlabs-ai-briefing.md`.
+
+### Medium priority
+
+- **`BaseLayout` canonical guardrail** — addresses tech-debt #2. One-line fix in `src/layouts/BaseLayout.astro:24-26`. Strip protocol+host from `canonical` prop before passing to `new URL(canonicalPath, Astro.site)` so absolute URLs can't bypass site config.
+- **HowTo schema** — addresses tech-debt #4. Probably best-fit on `/messenger-assistant/` or `/voice-agent/` as "How to add an AI assistant to your business in 3 steps".
+
+### Low priority
+
+- **SEO automation replication for voice.cushlabs.ai** — addresses tech-debt #5. Port the GSC sitemap submission, Bing IndexNow script, and weekly cron from cushlabs.ai to the voice subdomain repo. Tracked in memory `project_seo_automation`.
+- **Title pixel-width audit on `/data-deletion/` and new `/es/data-deletion/`** — currently both end in `| CushLabs.ai`. Worth checking against Ahrefs's pixel threshold while we're already in the title-tightening mindset.
+
+---
+
+## Recurring Failure Modes
+
+Patterns that have bitten this project before. Re-read this section before shipping any change to the listed surfaces.
+
+### 1. Bilingual parity drift on new pages
+
+**What happened:** PR #74 shipped `/data-deletion/` (EN-only). `BaseLayout` auto-emits hreflang tags pointing at `/es/data-deletion/` — which 404'd. Ahrefs flagged 4 cascading errors on the next crawl ("Hreflang to redirect or broken page", "404 page", "4XX page", "Page links to broken page").
+
+**Rule:** Every new EN page MUST ship with its ES counterpart in the same PR. No "I'll add the Spanish version later." The hreflang machinery in `BaseLayout` makes the gap immediately visible to crawlers.
+
+### 2. Bare-domain canonical bypassing `Astro.site`
+
+**What happened:** PR #74 also passed `canonical="https://cushlabs.ai/messenger-assistant/"` (bare domain) to `BaseLayout`. Astro's `new URL(absolute, base)` ignores `base` when `absolute` is already absolute → canonical resolved to `cushlabs.ai` while sitemap used `www.cushlabs.ai`. Ahrefs flagged "Non-canonical page in sitemap" on the next crawl.
+
+**Rule:** Don't pass absolute URLs to `BaseLayout`'s `canonical` prop. Either omit it entirely (and let pathname-based default win) or pass a path-only string. See tech-debt #2 for the proposed permanent guardrail.
+
+### 3. PORTFOLIO.md silent YAML corruption
+
+Documented extensively in `CLAUDE.md` ("Recurring Failure: Silent YAML Corruption") and memory `feedback_portfolio_md_yaml_silent_corruption`. Summary: duplicate top-level YAML keys (most often `health_status:`) cause gray-matter to throw, the previous version of `tryLocalPortfolioMd()` silently caught it, and projects landed in `projects.generated.json` with `thumbnail: null`. Fix in place: `npm run validate:portfolio-md` runs before every sync and fails loudly. Don't relax that catch block.
+
+### 4. Tailwind 4 utility name collision
+
+Documented in CLAUDE.md ("Tailwind 4 Migration Gotchas") and memory `feedback_tailwind4_color_collision`. Custom `--color-base` defined in `@theme` silently overrode the built-in `text-base` font-size utility. Avoid color names matching `xs`, `sm`, `base`, `lg`, `xl`, `2xl`–`9xl`. Use `canvas`, `surface`, `page`, `app`.
+
+---
+
+## Session History
+
+### 2026-04-27 — Ahrefs SEO recovery (PR #80)
+
+**Trigger:** Ahrefs digest showed health score dropped 100 → 96 on the 25 April crawl. +4 errors, +2 warnings.
+
+**Diagnosis:** Three independent regressions all introduced by PR #74 (the Messenger Assistant launch a few days prior):
+
+1. `/data-deletion/` shipped EN-only → 4 cascading errors via BaseLayout's hreflang auto-emission to non-existent `/es/data-deletion/`.
+2. `/messenger-assistant/` (EN+ES) had explicit bare-domain canonical (`cushlabs.ai`) that bypassed `Astro.site = www.cushlabs.ai` → +2 "Non-canonical page in sitemap".
+3. Both messenger titles crossed Ahrefs's pixel-width threshold → +2 "Title too long".
+
+**Fix shipped — PR #80** (squash-merged 2026-04-27, commit `9c2de0c`):
+
+- Removed bare-domain canonical override from `src/pages/messenger-assistant.astro` and `src/pages/es/messenger-assistant.astro`. `BaseLayout` now resolves canonical from pathname against `Astro.site`.
+- Created `src/pages/es/data-deletion.astro` — full Spanish translation matching the EN structure (Hero, "Qué Datos Conservamos", three deletion options, "Qué Haremos", "Qué No Podemos Eliminar", Contact).
+- Added `/es/privacy/` → `/es/data-deletion/` link to `src/pages/es/privacy.astro` for parity with EN privacy page.
+- Tightened titles: EN messenger 49ch → 37ch, ES messenger 51ch → 37ch.
+
+**Verified post-build:**
+- `dist/sitemap-0.xml` pairs `/data-deletion/` and `/es/data-deletion/` with proper `xhtml:link` hreflang entries.
+- `messenger-assistant` canonical now matches sitemap loc (both `www.cushlabs.ai`).
+
+**Verification automation:** One-shot remote agent scheduled for 2026-05-01 09:00 America/Mexico_City (trigger `trig_01P4s9QfqPVBPxrnVUJ4kdUZ`). Reads next Ahrefs digest from Gmail; falls back to live URL fetches if no fresh email arrives.
+
+**Flagged but NOT addressed in this session** (now tracked in tech-debt #1): `src/pages/es/privacy.astro` is still the old generic policy — PR #74 only rewrote the EN version. Real legal/compliance gap.
+
+**Cross-references:**
+- PR #80: https://github.com/RCushmaniii/cushlabs/pull/80
+- Memory: `project_ahrefs_100_milestone.md` (note: 100 health score originally hit 2026-03-31 in a single session; tracking the recovery to that level)
+- Related docs: `docs/seo/HREFLANG-FIX-SUMMARY.md`, `docs/seo/SITEMAP-SEO-ANALYSIS.md`
+
+---
+
+## Cross-references to existing audit docs
+
+This log complements (does not replace) the deeper audit and lessons-learned docs already in `docs/`:
+
+- `docs/LESSONS-LEARNED.md` — broader project lessons
+- `docs/SITE-AUDIT-2026-03-03.md` — earlier full-site audit
+- `docs/seo/SEO-FIXES-2025-11-29.md` — earlier SEO fix log
+- `docs/seo/SEO-TECHNICAL-CHECKLIST.md` — pre-deploy SEO checklist
+- `docs/architecture/BILINGUAL-PARITY-CHECKLIST.md` — EN/ES sync rules
+- `docs/voice-cushlabs-ai-briefing.md` — voice.cushlabs.ai product spec (driver for backlog item: Voice Agent service page)

--- a/docs/voice-cushlabs-ai-briefing.md
+++ b/docs/voice-cushlabs-ai-briefing.md
@@ -1,0 +1,201 @@
+# voice.cushlabs.ai — Site Audit & Rebuild Briefing
+
+> This document is a briefing for an AI assistant working on the voice.cushlabs.ai repo.
+> Written by Robert Cushman with context from the cushlabs.ai pricing overhaul completed 2026-04-13.
+> Read this entire document before touching any code.
+
+---
+
+## Who This Site Is For
+
+**voice.cushlabs.ai** is a product showcase site for CushLabs AI Voice Agents — the premium $1,497/mo (US) / $10,997 MXN/mes (MX) standalone product. It is NOT a general CushLabs company site. The main company site is cushlabs.ai.
+
+**Robert Cushman** is the sole operator. He lives in Mexico, serves US and Mexico/LATAM markets, and does bilingual (EN/ES) delivery. He builds AI-powered voice agents for small-to-medium businesses.
+
+---
+
+## Current State of the Site (audited 2026-04-13)
+
+### What exists and is working well
+- **Homepage** — Strong hero: "Stop Losing Leads to Voicemail." Good pain-first framing. Describes 4 capabilities (Lead Qualification, Appointment Booking, Customer Support, AI Front Desk). Has a "How It Works" 4-step process.
+- **Live Demo pages** — 5 demo agents: Clara (lead qual), James (exec coaching scheduler), Sophia (med spa front desk), Mike (home services dispatcher), David (real estate setter). These are the strongest asset on the site — they let prospects actually talk to the AI.
+- **Portfolio page** — Exists (not yet audited in detail)
+- **Contact page** — Exists
+- **Consultation booking** — Exists (`/consultation`)
+- **Bilingual toggle** — ES button exists in nav
+
+### What is MISSING
+1. **No Services/Pricing page** — The biggest gap. A prospect who wants to know what it costs and what they get has nowhere to go. They either leave or have to book a call just to find out the price. This is the #1 thing to build.
+2. **No FAQ page** — Common objections (does it sound robotic? what if I go over minutes? do I need a developer?) are unanswered.
+3. **"New York, NY" in the footer** — WRONG. Robert is based in Mexico and serves US + Mexico. This needs to be removed or changed to "Serving US & Mexico."
+
+### Messaging issues to fix
+- Footer says `"Built by Robert Cushman — powered by AI and voice."` — fine, keep it.
+- The `/nyc-coaching` demo page says **"NEW YORK ENGLISH"** as a brand — this is a different client brand (possibly the ny-english-teacher client). Make sure this isn't creating confusion about CushLabs' location/identity.
+- Homepage process step says **"Clara lives inside your CRM and Calendar"** — this hardcodes the demo agent name into generic copy. Should say "Your agent lives inside your CRM..." since every client gets a custom agent, not Clara.
+- No pricing anywhere on the site. A prospect landing here has no idea what this costs. This creates friction and may filter out exactly the qualified buyers you want (who are ready to pay but need a number to evaluate).
+
+---
+
+## The Services/Pricing Page to Build
+
+### URL
+`/services` (and `/es/services` for Spanish)
+
+### What it should communicate
+
+This page should answer: **"What do I get, what does it cost, and how does this work?"**
+
+#### Price
+- **US:** $1,497/mo
+- **Mexico/LATAM:** $10,997 MXN/mes
+- 500 minutes included per month
+- Overage: $0.50/min (US) / $8.50 MXN/min (MX)
+- Free 2-week trial
+- No setup fee. No long-term contract. Cancel anytime.
+
+#### What's included (feature list)
+- Natural-sounding AI voice matched to your brand
+- Answers every call on the first ring, 24/7
+- 500 minutes/mo included
+- Appointment booking directly into your calendar (Google Calendar, Calendly, etc.)
+- Lead capture — name, number, intent texted to you instantly
+- Call transfer with context when a human is needed
+- Bilingual EN/ES (automatic language detection)
+- Monthly call reports and ongoing optimization
+- Custom voice, persona, and script tuned for your business
+- No IT team needed — fully managed setup and maintenance
+
+#### Pain-first framing (use this, don't lead with features)
+Lead with the cost of inaction. The buyer's real problem is missed calls = missed revenue. Frame it like this:
+
+- You miss 3–5 calls a day while you're with clients, driving, or at lunch.
+- Each one could be a $500–$1,500 customer.
+- That's $7,500–$37,500/month walking away to a competitor who picked up.
+- A full-time receptionist costs $3,000–$4,500/mo and works 8 hours.
+- Your AI voice agent works 24/7 for $1,497/mo and never calls in sick.
+
+#### Who it's for (use these as "scenario cards" or bullet points)
+- **Home services companies** (plumbing, HVAC, roofing) — every missed call is a $1,200 job
+- **Med spas and clinics** — front desk that never puts callers on hold
+- **Real estate teams** — outbound follow-up and inbound lead qualification
+- **Law firms and professional services** — intake without a receptionist
+- **Any business that misses calls** — if your phone rings and nobody picks up, this is for you
+
+#### How it works (keep it to 3–4 steps)
+1. **Discovery call (free)** — We learn your call flow, customer questions, and business rules
+2. **We build your agent** — Custom voice, persona, and scripts in days, not months
+3. **Connect your systems** — Calendar, CRM, text notifications
+4. **Go live + monthly optimization** — Launch, then we tune it based on real call data
+
+#### CTA
+Primary: "Start Free Trial" → `/consultation`
+Secondary: "Talk to Clara first" → demo embed or `/` anchor
+
+#### ROI block
+Include this comparison:
+
+| | Full-time receptionist | AI Voice Agent |
+|---|---|---|
+| Cost | $3,000–$4,500/mo | $1,497/mo |
+| Hours | 8/day, 5 days/week | 24/7, 365 days/year |
+| Sick days | Yes | Never |
+| Bilingual | Rarely | Always |
+| Appointment booking | Manual | Automatic |
+
+---
+
+## FAQ Page to Build
+
+Common objections to address:
+
+**Does it sound like a robot?**
+No. Modern AI voices are natural and conversational. You can hear it yourself — talk to Clara on the homepage.
+
+**What if a caller gets frustrated and wants a human?**
+The agent detects frustration and transfers the call to you or a team member, with full context of the conversation so far.
+
+**What if I go over 500 minutes?**
+Overage is billed at $0.50/min (US) / $8.50 MXN/min (MX). Most clients use 200–400 minutes per month. You'll be alerted before you hit the cap.
+
+**How long does setup take?**
+Most agents are live within 3–5 business days after the discovery call.
+
+**Do I need a developer or IT team?**
+No. CushLabs handles everything — setup, integration, maintenance, and monthly optimization.
+
+**How does the free 2-week trial work?**
+The agent is built and deployed during the trial — you see it working with real callers before you pay. If you're not happy, walk away. No invoice.
+
+**Can it speak Spanish?**
+Yes. Every agent is bilingual EN/ES with automatic language detection.
+
+**What systems does it connect to?**
+Google Calendar, Calendly, most CRMs via webhook/Zapier/Make. Ask about your specific stack on the discovery call.
+
+**Do you sign NDAs?**
+Yes. Happy to sign a mutual NDA before any sensitive business information is shared.
+
+---
+
+## Cross-Site Consistency Checklist
+
+Before shipping the services page, verify these match cushlabs.ai exactly:
+
+| Element | cushlabs.ai | voice.cushlabs.ai |
+|---|---|---|
+| US Voice Agent price | $1,497/mo | Must match |
+| MX Voice Agent price | $10,997 MXN/mes | Must match |
+| Minutes included | 500 | Must match |
+| Overage rate | $0.50/min US / $8.50 MXN | Must match |
+| Free trial length | 2 weeks | Must match |
+| CTA text | "Start Free Trial" | Should match |
+| Consultation URL | /consultation/ | Already matches |
+| Location | "Serving US & Mexico" | Fix footer — remove "New York, NY" |
+| Free trial messaging | "No setup fee. No contract. Cancel anytime." | Add this |
+
+---
+
+## Navigation Changes Needed
+
+Current nav: DEMOS → Portfolio → Contact → Book a Free Call
+
+Recommended nav after adding services page:
+`DEMOS | SERVICES | PORTFOLIO | CONTACT | [Start Free Trial CTA button]`
+
+Add "SERVICES" as a primary nav link. This is the most important missing piece — a prospect who sees "Services" in the nav knows there's a page that tells them what they'll pay.
+
+---
+
+## What NOT to change
+
+- The live demo pages (James, Sophia, Mike, David) — these are the strongest sales tool on the site. Don't touch the functionality.
+- The homepage hero copy — "Stop Losing Leads to Voicemail" is strong.
+- Clara demo embed on homepage — good.
+- The "How It Works" 4-step section — solid.
+
+---
+
+## Tone and Voice Guidelines
+
+Match the tone of cushlabs.ai:
+- **Direct, not corporate.** Write like a smart person talking to a business owner, not like a SaaS marketing team.
+- **Pain-first, not feature-first.** Lead with what it costs them NOT to have this.
+- **Confident without bragging.** Let the live demos do the selling — your job is to get them to try one.
+- **No jargon.** "AI voice agent" is fine. "Large language model orchestration" is not.
+- **Bilingual matters.** When you build the Spanish version, translate for the Mexican market — not Google Translate word-for-word. The MXN pricing is different from USD pricing. Never auto-convert. $10,997 MXN is the correct Mexico price. Do not calculate it as a currency conversion.
+
+---
+
+## Files Likely Needing Updates (confirm against actual repo structure)
+
+- `src/pages/services.astro` — CREATE THIS
+- `src/pages/es/services.astro` — CREATE THIS (Spanish version)
+- `src/components/` — New pricing card component, FAQ accordion
+- `src/layouts/` or navigation component — Add "Services" link to nav
+- Footer component — Remove "New York, NY", update to "Serving US & Mexico"
+- Homepage (if needed) — Fix "Clara lives inside your CRM" → "Your agent lives inside your CRM"
+
+---
+
+*Briefing written 2026-04-13 based on cushlabs.ai pricing overhaul (PR #66) and live site audit of voice.cushlabs.ai.*


### PR DESCRIPTION
## Summary

- Adds `docs/SESSION-LOG.md` as a living document for the cushlabs.ai marketing site — captures session accomplishments, active technical debt, prioritized backlog, and recurring failure modes worth remembering across sessions.
- Initial entry documents PR #80 (Ahrefs SEO recovery, 2026-04-27) and flags 5 active tech-debt items (highest: ES privacy parity gap from PR #74).
- Also adds previously-untracked `docs/voice-cushlabs-ai-briefing.md` (Robert wrote 2026-04-13) since SESSION-LOG.md references it as the source spec for the Voice Agent service page backlog item.

## Why now

Session-by-session work was surfacing recurring patterns (PORTFOLIO.md silent YAML corruption, bilingual parity drift, bare-domain canonical leaks) that lived only in chat history. This makes them durable across context windows.

## Test plan

- [x] No deployed-page changes — pure docs files under `docs/`, not in build bundle
- [x] Markdown renders cleanly on GitHub
- [x] No links to verify — internal cross-refs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)