### PR TITLE
chore: codify SESSION-LOG.md maintenance + add Roadmap section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -493,6 +493,55 @@ The `docs/` folder contains lessons learned from the New York English repo:
 - `docs/seo/HREFLANG-FIX-SUMMARY.md` - Hreflang implementation
 - `docs/seo/SITEMAP-SEO-ANALYSIS.md` - Sitemap best practices
 - `docs/seo/SEO-TECHNICAL-CHECKLIST.md` - SEO validation checklist
+- `docs/SESSION-LOG.md` - **Living session log + tech debt + roadmap. READ THIS FIRST when starting work; update at the end of every substantive session.**
+
+---
+
+## Session Log Maintenance (REQUIRED)
+
+`docs/SESSION-LOG.md` is the durable memory across AI sessions for this repo. It captures what shipped, what's broken, what's planned. Treat it like the project's source-of-truth changelog — not a dumping ground.
+
+### Read it FIRST when starting a session
+
+Before proposing or implementing anything, read `docs/SESSION-LOG.md`. It tells you:
+
+- **Active Technical Debt** — known gaps in already-shipped work. If you're touching one of these surfaces, address the debt or note why you didn't.
+- **Backlog (Prioritized)** — concrete next work, sized and scoped. Pull from here when Robert says "what's next?"
+- **Roadmap** — directional ideas with longer horizon. Reference these when an opportunity emerges that fits the existing direction.
+- **Recurring Failure Modes** — patterns that have bitten this project before. Re-read before shipping any change to a surface called out here. Failing to do this is how regressions ship.
+- **Session History** — what shipped recently, in chronological order, with PR numbers and commit hashes.
+
+### Update it at the END of every substantive session
+
+If the session shipped code, fixed a bug, identified new tech debt, or surfaced a strategic idea, update SESSION-LOG.md before declaring the session done. Specifically:
+
+1. **Add a Session History entry** — date-stamped header, PR numbers, commit hashes, what shipped, what got resolved, what got flagged. Newest at the top of "Session History" (entries are chronological, newest first).
+2. **Update the Active Technical Debt table** — mark resolved items with strikethrough + resolution note (don't delete — keep the trail). Add new tech-debt rows for anything that shipped with a known gap.
+3. **Update the Backlog** — remove items that shipped, add new items the session identified as concrete next work.
+4. **Update the Roadmap** — add directional ideas the session surfaced. These are themes, not tickets — promote to Backlog only when the spec is concrete.
+5. **Add to Recurring Failure Modes** — if the session ran into a repeatable footgun (silent failure, parity drift, regression pattern), document it. Future-you will thank present-you.
+
+### Section structure (don't drift from this)
+
+The doc has six top-level sections in this exact order:
+
+1. **Active Technical Debt** — table format: `# | Item | Severity | Notes`
+2. **Backlog (Prioritized)** — bulleted, grouped by High / Medium / Low priority
+3. **Roadmap** — directional ideas grouped by theme (Product expansion, Distribution & growth, Internal tooling, Compliance & legal, etc.). Themes can be added/removed as the project evolves.
+4. **Recurring Failure Modes** — numbered patterns with "What happened" + "Rule" sections
+5. **Session History** — newest first, date-stamped headers
+6. **Cross-references to existing audit docs** — pointers to deeper docs in `docs/`
+
+### What does NOT belong in SESSION-LOG.md
+
+- Routine session work that doesn't change the project's known state (linting passes, ad-hoc bug investigations that found nothing, etc.). Only log substantive shipping or substantive learning.
+- Code patterns or conventions — those belong in dedicated `docs/architecture/` files.
+- Secrets, tokens, environment variables — never. The Secrets & Sensitive Data rules in the global CLAUDE.md apply to this file too.
+- Long debugging narratives — link to the PR or commit where the work happened; don't recap the journey here.
+
+### Commit cadence
+
+SESSION-LOG.md updates can ride along with the session's main feature PR (one branch, one PR), OR ship as a separate `docs:` commit if the session also touches deployed code and you want a clean separation. CLAUDE.md and memory file updates do NOT need a feature branch (per the global CLAUDE.md exemption); SESSION-LOG.md follows the same spirit since it's pure internal docs that don't change deployed pages — but bundling it into a related feature PR is also fine.
 
 ---
 
@@ -504,3 +553,4 @@ Before ending any session, verify:
 - [ ] No TypeScript errors (`npm run check`)
 - [ ] Dev server runs without errors
 - [ ] Language switcher works on modified pages
+- [ ] **`docs/SESSION-LOG.md` updated** with this session's accomplishments, new tech debt, new backlog/roadmap items, and any new recurring failure modes

--- a/docs/SESSION-LOG.md
+++ b/docs/SESSION-LOG.md
@@ -41,6 +41,34 @@ _(no high-priority items currently open — both prior items shipped 2026-05-02 
 
 ---
 
+## Roadmap
+
+Directional ideas with a longer horizon than the Backlog. Themes, not tickets — Backlog items are sized work; Roadmap items are "what could this become" before the spec exists. Promote a Roadmap entry to Backlog once the scope is concrete.
+
+### Product expansion
+
+- **WhatsApp Business as a third channel** — Messenger Assistant tech is reusable. Many Mexican SMBs live on WhatsApp first, Facebook second. Spec'ing a WhatsApp variant would broaden TAM without rebuilding the AI core. Validate demand via 2–3 prospects before committing.
+- **Outbound voice product** — currently disclaimed on the voice page ("Outbound calling campaigns — available as a separate engagement"). If a real prospect asks for it, productize it. Until then, keep it custom-quoted.
+- **Multi-page / franchise Messenger setups** — disclaimed on `/messenger-assistant/` ("scoped separately"). Same logic: productize once a real client justifies it.
+- **AI Customer Support Chatbot dedicated page** — already exists as a service block on `/services` (`support-assistants` ID) but no standalone landing like `/messenger-assistant/` or `/voice-agent/`. Could be the third standalone product page once content is ready.
+
+### Distribution & growth
+
+- **Bilingual SEO automation as a productized offering** — the GSC/Bing/IndexNow weekly cron + structured-data audit pattern that lives on cushlabs.ai is itself a consultable service. Sell to bilingual local businesses ("we'll set up the same SEO discipline that ranks our own site").
+- **Insurance-vertical landing page** — per memory `project_outreach_pipeline`, insurance is the active beachhead. A vertical-specific landing page with insurance copy + pricing + case studies would compound outbound efforts.
+
+### Internal tooling
+
+- **Pre-deploy SEO audit script: extend to FAQ schema and HowTo schema validation** — the script currently catches title/description/trailing-slash issues. Adding schema validation closes the loop on the structured-data side.
+- **Automated Ahrefs digest parser** — the verification routine that fires after big SEO PRs (e.g., trigger `trig_01P4s9QfqPVBPxrnVUJ4kdUZ`) is currently one-off. A general parser that extracts errors/warnings from any Ahrefs digest email and posts a structured summary would standardize SEO regression detection.
+
+### Compliance & legal
+
+- **EN privacy LFPDPPP framing review** — tracked as tech-debt #6. The ES privacy explicitly names LFPDPPP / derechos ARCO; EN says generic "depending on your location." A lawyer review could clarify whether the EN should mirror the Mexican-specific framing for English-speaking Mexican residents.
+- **Terms of Service freshness audit** — `src/pages/terms.astro` and `src/pages/es/terms.astro` exist but haven't been touched since the Messenger Assistant launched. Should be audited the same way privacy was: do the terms reflect actual product behavior?
+
+---
+
 ## Recurring Failure Modes
 
 Patterns that have bitten this project before. Re-read this section before shipping any change to the listed surfaces.


### PR DESCRIPTION
## Summary

Makes the SESSION-LOG.md pattern durable across AI sessions. Two paired changes:

### 1. `CLAUDE.md` — adds "Session Log Maintenance (REQUIRED)" section

Tells future AI assistants to:
- **Read `docs/SESSION-LOG.md` FIRST** when starting any session (Active Tech Debt, Backlog, Roadmap, Recurring Failure Modes, Session History)
- **Update it at the END** of every substantive session — Session History entry, Active Tech Debt updates, Backlog/Roadmap adjustments, new Recurring Failure Modes if applicable

Spells out the exact six-section structure, what does NOT belong in the file (routine work, code conventions, secrets, debugging narratives), and commit cadence rules. Adds a checkbox to the existing Session Checklist so the maintenance step can't be silently skipped.

### 2. `docs/SESSION-LOG.md` — adds "Roadmap" section

Between Backlog and Recurring Failure Modes. Roadmap = directional ideas with longer horizon than Backlog. Backlog items are sized work; Roadmap items are themes. Promote a Roadmap entry to Backlog once scope is concrete.

Initial Roadmap covers four themes:
- **Product expansion** — WhatsApp channel, outbound voice, multi-page Messenger, AI Customer Support standalone page
- **Distribution & growth** — bilingual SEO automation as a productized offering, insurance vertical landing page
- **Internal tooling** — pre-deploy SEO audit schema validation, automated Ahrefs digest parser
- **Compliance & legal** — EN privacy LFPDPPP review, terms of service freshness audit

## Why this matters

Without a CLAUDE.md instruction telling future sessions to maintain SESSION-LOG.md, the doc rots. Without the Roadmap section, strategic ideas get lost between sessions and end up living only in chat history. Both gaps closed.

## Test plan

- [x] No deployed-code changes — pure docs + CLAUDE.md instruction
- [x] Markdown renders cleanly on GitHub
- [x] Session Checklist now includes the SESSION-LOG.md update step

🤖 Generated with [Claude Code](https://claude.com/claude-code)