### PR TITLE
feat: Facebook Login OAuth pages for Messenger Assistant

### DIFF
--- a/src/pages/es/messenger-assistant/connect.astro
+++ b/src/pages/es/messenger-assistant/connect.astro
@@ -1,0 +1,133 @@
+---
+import BaseLayout from "../../../layouts/BaseLayout.astro";
+import Container from "../../../components/layout/Container.astro";
+
+const OAUTH_START_URL = "https://ny-english-messenger-bot.rcushmaniii.workers.dev/oauth/start?lang=es";
+
+const steps = [
+  { n: 1, title: "Conecta tu página de Facebook", desc: "Autoriza a CushLabs para recibir y responder mensajes en la página de Facebook que elijas." },
+  { n: 2, title: "Configuramos tu negocio", desc: "Subimos tus servicios, precios y preguntas frecuentes y afinamos al asistente con tu voz. Tiempo típico: 5 días hábiles." },
+  { n: 3, title: "Prueba gratis de 2 semanas", desc: "Tu asistente entra en producción en tu página. Lo ves trabajar. Si no se gana su lugar, nos despedimos como amigos." },
+  { n: 4, title: "Ajuste mensual", desc: "Reportes semanales de desempeño. Ajuste mensual conforme tu negocio evoluciona." },
+];
+
+const permissions = [
+  { name: "Enviar y recibir mensajes de Messenger en tu página", why: "Para que el asistente pueda responder a tus clientes." },
+  { name: "Ver la lista de páginas que administras", why: "Para que puedas elegir en cuál instalar el asistente." },
+  { name: "Leer el nombre y datos básicos de tu página", why: "Para confirmarte cuál estás conectando." },
+  { name: "Suscribirse a los webhooks de mensajes de tu página", why: "Para que los mensajes nuevos lleguen al asistente en tiempo real." },
+  { name: "Leer el idioma preferido de cada cliente", why: "Para que el asistente responda en español o inglés automáticamente." },
+];
+---
+
+<BaseLayout
+  title="Conecta tu página de Facebook | Asistente Messenger CushLabs"
+  description="Conecta tu página de Facebook a tu Asistente IA de Messenger de CushLabs. Un clic, login seguro de Facebook, y listo."
+  noindex={true}
+>
+  <section class="relative pt-24 pb-16 md:pt-32 md:pb-20 overflow-hidden">
+    <div class="absolute inset-0 -z-10">
+      <div class="absolute top-1/4 left-1/4 w-[500px] h-[500px] bg-cush-orange/15 rounded-full blur-[120px]"></div>
+    </div>
+
+    <Container size="md">
+      <div class="text-center max-w-3xl mx-auto">
+        <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-green-500/10 border border-green-500/20 text-green-700 dark:text-green-400 text-sm font-semibold mb-8">
+          <span class="w-2 h-2 rounded-full bg-green-500 animate-pulse"></span>
+          Bienvenido — vamos a configurarte
+        </div>
+
+        <h1 class="font-display text-fluid-4xl font-bold text-gray-900 dark:text-white mb-6 leading-tight tracking-tight">
+          Conecta tu página de Facebook
+        </h1>
+
+        <p class="text-fluid-lg text-gray-600 dark:text-gray-300 mb-10 max-w-2xl mx-auto leading-relaxed">
+          Un clic. Login seguro de Facebook. Nosotros nos encargamos del resto. Regresas aquí en menos de un minuto.
+        </p>
+
+        <div class="flex flex-col items-center gap-4">
+          <a
+            href={OAUTH_START_URL}
+            class="group inline-flex items-center gap-3 px-8 py-4 bg-[#1877F2] hover:bg-[#166FE5] text-white font-display font-semibold rounded-lg transition-all duration-300 shadow-lg shadow-[#1877F2]/30 hover:shadow-xl text-lg"
+          >
+            <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
+            </svg>
+            Conectar con Facebook
+          </a>
+
+          <p class="text-sm text-gray-500 dark:text-gray-400 max-w-md">
+            Te llevaremos a Facebook para iniciar sesión y autorizar al Asistente Messenger de CushLabs en la página que elijas.
+          </p>
+        </div>
+      </div>
+    </Container>
+  </section>
+
+  <section class="py-16 md:py-24 bg-gray-50 dark:bg-gray-900/30 border-y border-gray-100 dark:border-gray-800">
+    <Container size="lg">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="font-display font-bold text-3xl md:text-4xl text-gray-900 dark:text-white mb-3 leading-tight tracking-tight text-center">
+          Lo que sigue
+        </h2>
+        <p class="text-center text-gray-600 dark:text-gray-400 mb-12 max-w-2xl mx-auto">
+          Vas en el paso 1. De aquí a una semana aproximadamente tu asistente estará en vivo en tu página.
+        </p>
+
+        <ol class="space-y-6">
+          {steps.map(s => (
+            <li class="flex gap-5 p-5 bg-white dark:bg-gray-800/50 rounded-xl border border-gray-100 dark:border-gray-800">
+              <div class="flex-shrink-0 w-10 h-10 rounded-full bg-cush-orange/10 text-cush-orange font-display font-bold flex items-center justify-center">
+                {s.n}
+              </div>
+              <div>
+                <h3 class="font-display font-semibold text-lg text-gray-900 dark:text-white mb-1">{s.title}</h3>
+                <p class="text-gray-600 dark:text-gray-400 leading-relaxed">{s.desc}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </Container>
+  </section>
+
+  <section class="py-16 md:py-24">
+    <Container size="lg">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="font-display font-bold text-2xl md:text-3xl text-gray-900 dark:text-white mb-3 leading-tight tracking-tight">
+          Lo que estarás autorizando
+        </h2>
+        <p class="text-gray-600 dark:text-gray-400 mb-8 leading-relaxed">
+          Cuando hagas clic en <em>Conectar con Facebook</em>, Facebook te preguntará si quieres otorgar al Asistente Messenger de CushLabs los siguientes permisos sobre la página que selecciones. Tú mantienes el control — puedes revocarlos cuando quieras desde la configuración de Facebook.
+        </p>
+
+        <ul class="space-y-4 mb-10">
+          {permissions.map(p => (
+            <li class="flex gap-4">
+              <svg class="w-5 h-5 text-green-500 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+              </svg>
+              <div>
+                <strong class="text-gray-900 dark:text-white font-semibold">{p.name}.</strong>
+                {" "}<span class="text-gray-600 dark:text-gray-400">{p.why}</span>
+              </div>
+            </li>
+          ))}
+        </ul>
+
+        <div class="bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-xl p-6 text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
+          <p class="mb-3">
+            <strong class="text-gray-900 dark:text-white">Privacidad:</strong> Nunca vendemos ni compartimos tus datos. Los mensajes de los clientes se envían a Anthropic Claude (nuestro proveedor de IA) únicamente para generar respuestas, y el historial de conversación se borra automáticamente de nuestra memoria a corto plazo después de una hora.
+          </p>
+          <p>
+            <a href="/es/privacy/" class="text-cush-orange hover:underline">Política de privacidad</a>
+            <span class="mx-2 text-gray-400">·</span>
+            <a href="/es/data-deletion/" class="text-cush-orange hover:underline">Eliminación de datos</a>
+            <span class="mx-2 text-gray-400">·</span>
+            <a href="/es/messenger-assistant/" class="text-cush-orange hover:underline">Volver a la descripción</a>
+          </p>
+        </div>
+      </div>
+    </Container>
+  </section>
+</BaseLayout>

--- a/src/pages/es/messenger-assistant/connected.astro
+++ b/src/pages/es/messenger-assistant/connected.astro
@@ -1,0 +1,143 @@
+---
+import BaseLayout from "../../../layouts/BaseLayout.astro";
+import Container from "../../../components/layout/Container.astro";
+
+// Static-rendered. Query params (page_name, page_id, error) leídos client-side.
+---
+
+<BaseLayout
+  title="Conectado | Asistente Messenger CushLabs"
+  description="Tu página de Facebook está conectada al Asistente Messenger de CushLabs."
+  noindex={true}
+>
+  <section class="relative pt-24 pb-16 md:pt-32 md:pb-24 overflow-hidden min-h-[60vh]">
+    <div class="absolute inset-0 -z-10">
+      <div id="bg-glow" class="absolute top-1/4 left-1/4 w-[500px] h-[500px] bg-green-500/10 rounded-full blur-[120px]"></div>
+    </div>
+
+    <Container size="md">
+      <div id="loading-state" class="text-center max-w-2xl mx-auto">
+        <div class="inline-flex items-center justify-center w-20 h-20 rounded-full bg-gray-200 dark:bg-gray-700 mb-8 animate-pulse">
+        </div>
+        <div class="h-10 bg-gray-200 dark:bg-gray-700 rounded animate-pulse max-w-md mx-auto mb-4"></div>
+        <div class="h-6 bg-gray-200 dark:bg-gray-700 rounded animate-pulse max-w-lg mx-auto"></div>
+      </div>
+
+      <div id="success-state" class="text-center max-w-2xl mx-auto" hidden>
+        <div class="inline-flex items-center justify-center w-20 h-20 rounded-full bg-green-500/15 border border-green-500/30 mb-8">
+          <svg class="w-10 h-10 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+
+        <h1 class="font-display text-fluid-4xl font-bold text-gray-900 dark:text-white mb-4 leading-tight tracking-tight">
+          ¡Listo, ya estás conectado!
+        </h1>
+
+        <p class="text-fluid-lg text-gray-600 dark:text-gray-300 mb-8 leading-relaxed">
+          Autorizamos al Asistente Messenger de CushLabs en
+          <strong id="page-name" class="text-gray-900 dark:text-white">tu página de Facebook</strong>.
+        </p>
+
+        <div class="bg-white dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-xl p-6 mb-10 text-left">
+          <h2 class="font-display font-semibold text-lg text-gray-900 dark:text-white mb-4">
+            Lo que sigue
+          </h2>
+          <ol class="space-y-3 text-gray-700 dark:text-gray-300">
+            <li class="flex gap-3">
+              <span class="text-cush-orange font-display font-bold">1.</span>
+              <span>Recibirás un correo de bienvenida en el siguiente día hábil para agendar tu llamada de levantamiento de contenido.</span>
+            </li>
+            <li class="flex gap-3">
+              <span class="text-cush-orange font-display font-bold">2.</span>
+              <span>Subimos tus servicios, precios, horarios y preguntas frecuentes y afinamos al asistente con tu voz.</span>
+            </li>
+            <li class="flex gap-3">
+              <span class="text-cush-orange font-display font-bold">3.</span>
+              <span>Tu asistente entra en producción en tu página en 5 días hábiles. Comienza la prueba gratis de 2 semanas.</span>
+            </li>
+          </ol>
+        </div>
+
+        <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
+          <a
+            href="/es/messenger-assistant/"
+            class="inline-flex items-center gap-2 px-6 py-3 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-all duration-300"
+          >
+            Volver a la descripción
+          </a>
+          <a
+            href="/es/contact/"
+            class="font-display font-medium text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white underline underline-offset-4 decoration-gray-300 hover:decoration-cush-orange transition-all"
+          >
+            ¿Preguntas? Contáctanos →
+          </a>
+        </div>
+      </div>
+
+      <div id="error-state" class="text-center max-w-2xl mx-auto" hidden>
+        <div class="inline-flex items-center justify-center w-20 h-20 rounded-full bg-amber-500/15 border border-amber-500/30 mb-8">
+          <svg class="w-10 h-10 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+          </svg>
+        </div>
+
+        <h1 class="font-display text-fluid-3xl font-bold text-gray-900 dark:text-white mb-4 leading-tight tracking-tight">
+          La conexión no se completó
+        </h1>
+
+        <p class="text-fluid-lg text-gray-600 dark:text-gray-300 mb-8 leading-relaxed">
+          <span id="error-message">No recibimos los datos de autorización de Facebook. Esto pasa a veces si se cancela la autorización o si la sesión expira.</span>
+        </p>
+
+        <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
+          <a
+            href="/es/messenger-assistant/connect/"
+            class="inline-flex items-center gap-2 px-6 py-3 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-all duration-300"
+          >
+            Intentar de nuevo
+          </a>
+          <a
+            href="/es/contact/"
+            class="font-display font-medium text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white underline underline-offset-4 decoration-gray-300 hover:decoration-cush-orange transition-all"
+          >
+            Contáctanos →
+          </a>
+        </div>
+      </div>
+    </Container>
+  </section>
+
+  <script is:inline>
+    (function () {
+      const params = new URLSearchParams(window.location.search);
+      const pageName = params.get("page_name");
+      const pageId = params.get("page_id");
+      const error = params.get("error");
+
+      const loading = document.getElementById("loading-state");
+      const success = document.getElementById("success-state");
+      const errorEl = document.getElementById("error-state");
+      const bgGlow = document.getElementById("bg-glow");
+
+      loading.hidden = true;
+
+      if (!error && (pageName || pageId)) {
+        if (pageName) {
+          document.getElementById("page-name").textContent = pageName;
+        }
+        success.hidden = false;
+      } else {
+        if (error) {
+          document.getElementById("error-message").textContent =
+            'Facebook respondió: "' + error + '". Esto pasa a veces si se cancela la autorización o si la sesión expira.';
+        }
+        if (bgGlow) {
+          bgGlow.classList.remove("bg-green-500/10");
+          bgGlow.classList.add("bg-amber-500/10");
+        }
+        errorEl.hidden = false;
+      }
+    })();
+  </script>
+</BaseLayout>

--- a/src/pages/messenger-assistant/connect.astro
+++ b/src/pages/messenger-assistant/connect.astro
@@ -1,0 +1,138 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import Container from "../../components/layout/Container.astro";
+
+// The OAuth flow is initiated server-side by the messenger bot Worker so
+// we can issue a CSRF state token tied to a short-lived KV key. The button
+// on this page is just a link; the Worker does the redirect dance.
+const OAUTH_START_URL = "https://ny-english-messenger-bot.rcushmaniii.workers.dev/oauth/start";
+
+const steps = [
+  { n: 1, title: "Connect your Facebook Page", desc: "Authorize CushLabs to receive and respond to messages on the Facebook Page you choose." },
+  { n: 2, title: "We onboard your business", desc: "We ingest your services, pricing, and FAQs and tune the assistant to your voice. Typical turnaround: 5 business days." },
+  { n: 3, title: "Free 2-week trial", desc: "Your assistant goes live on your Page. You watch it work. If it doesn't earn its keep, we part as friends." },
+  { n: 4, title: "We tune monthly", desc: "Weekly performance reports. Monthly tuning as your business evolves." },
+];
+
+const permissions = [
+  { name: "Send and receive Messenger messages on your Page", why: "So the assistant can reply to customers." },
+  { name: "See the list of Pages you manage", why: "So you can pick which Page to install the assistant on." },
+  { name: "Read your Page's name and basic info", why: "So we can show you which Page you're connecting." },
+  { name: "Subscribe to message webhooks on your Page", why: "So new messages reach the assistant in real time." },
+  { name: "Read each customer's preferred language", why: "So the assistant replies in English or Spanish automatically." },
+];
+---
+
+<BaseLayout
+  title="Connect your Facebook Page | CushLabs Messenger Assistant"
+  description="Connect your Facebook Page to your CushLabs AI Messenger Assistant. One click, secure Facebook Login, and you're set up."
+  noindex={true}
+>
+  <section class="relative pt-24 pb-16 md:pt-32 md:pb-20 overflow-hidden">
+    <div class="absolute inset-0 -z-10">
+      <div class="absolute top-1/4 left-1/4 w-[500px] h-[500px] bg-cush-orange/15 rounded-full blur-[120px]"></div>
+    </div>
+
+    <Container size="md">
+      <div class="text-center max-w-3xl mx-auto">
+        <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-green-500/10 border border-green-500/20 text-green-700 dark:text-green-400 text-sm font-semibold mb-8">
+          <span class="w-2 h-2 rounded-full bg-green-500 animate-pulse"></span>
+          Welcome aboard — let's get you set up
+        </div>
+
+        <h1 class="font-display text-fluid-4xl font-bold text-gray-900 dark:text-white mb-6 leading-tight tracking-tight">
+          Connect your Facebook Page
+        </h1>
+
+        <p class="text-fluid-lg text-gray-600 dark:text-gray-300 mb-10 max-w-2xl mx-auto leading-relaxed">
+          One click. Secure Facebook Login. We'll handle the rest. You'll be back here in less than a minute.
+        </p>
+
+        <div class="flex flex-col items-center gap-4">
+          <a
+            href={OAUTH_START_URL}
+            class="group inline-flex items-center gap-3 px-8 py-4 bg-[#1877F2] hover:bg-[#166FE5] text-white font-display font-semibold rounded-lg transition-all duration-300 shadow-lg shadow-[#1877F2]/30 hover:shadow-xl text-lg"
+          >
+            <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
+            </svg>
+            Connect with Facebook
+          </a>
+
+          <p class="text-sm text-gray-500 dark:text-gray-400 max-w-md">
+            You'll be redirected to Facebook to log in and authorize CushLabs Messenger Assistant on the Page you choose.
+          </p>
+        </div>
+      </div>
+    </Container>
+  </section>
+
+  <!-- The four steps -->
+  <section class="py-16 md:py-24 bg-gray-50 dark:bg-gray-900/30 border-y border-gray-100 dark:border-gray-800">
+    <Container size="lg">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="font-display font-bold text-3xl md:text-4xl text-gray-900 dark:text-white mb-3 leading-tight tracking-tight text-center">
+          What happens next
+        </h2>
+        <p class="text-center text-gray-600 dark:text-gray-400 mb-12 max-w-2xl mx-auto">
+          You're at step 1. From here it's about a week until your assistant is live on your Page.
+        </p>
+
+        <ol class="space-y-6">
+          {steps.map(s => (
+            <li class="flex gap-5 p-5 bg-white dark:bg-gray-800/50 rounded-xl border border-gray-100 dark:border-gray-800">
+              <div class="flex-shrink-0 w-10 h-10 rounded-full bg-cush-orange/10 text-cush-orange font-display font-bold flex items-center justify-center">
+                {s.n}
+              </div>
+              <div>
+                <h3 class="font-display font-semibold text-lg text-gray-900 dark:text-white mb-1">{s.title}</h3>
+                <p class="text-gray-600 dark:text-gray-400 leading-relaxed">{s.desc}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </Container>
+  </section>
+
+  <!-- What we'll request access to -->
+  <section class="py-16 md:py-24">
+    <Container size="lg">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="font-display font-bold text-2xl md:text-3xl text-gray-900 dark:text-white mb-3 leading-tight tracking-tight">
+          What you'll be authorizing
+        </h2>
+        <p class="text-gray-600 dark:text-gray-400 mb-8 leading-relaxed">
+          When you click <em>Connect with Facebook</em>, Facebook will ask whether you want to grant CushLabs Messenger Assistant the following access on the Page you select. You stay in control — you can revoke this at any time from your Facebook settings.
+        </p>
+
+        <ul class="space-y-4 mb-10">
+          {permissions.map(p => (
+            <li class="flex gap-4">
+              <svg class="w-5 h-5 text-green-500 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+              </svg>
+              <div>
+                <strong class="text-gray-900 dark:text-white font-semibold">{p.name}.</strong>
+                {" "}<span class="text-gray-600 dark:text-gray-400">{p.why}</span>
+              </div>
+            </li>
+          ))}
+        </ul>
+
+        <div class="bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-xl p-6 text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
+          <p class="mb-3">
+            <strong class="text-gray-900 dark:text-white">Privacy:</strong> We never sell or share your data. Customer messages are sent to Anthropic Claude (our AI provider) solely to generate replies, then conversation history auto-expires from our short-term memory after one hour.
+          </p>
+          <p>
+            <a href="/privacy/" class="text-cush-orange hover:underline">Privacy policy</a>
+            <span class="mx-2 text-gray-400">·</span>
+            <a href="/data-deletion/" class="text-cush-orange hover:underline">Data deletion</a>
+            <span class="mx-2 text-gray-400">·</span>
+            <a href="/messenger-assistant/" class="text-cush-orange hover:underline">Back to overview</a>
+          </p>
+        </div>
+      </div>
+    </Container>
+  </section>
+</BaseLayout>

--- a/src/pages/messenger-assistant/connected.astro
+++ b/src/pages/messenger-assistant/connected.astro
@@ -1,0 +1,147 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import Container from "../../components/layout/Container.astro";
+
+// Static-rendered. Query params (page_name, page_id, error) are read
+// client-side because the site has no server adapter.
+---
+
+<BaseLayout
+  title="Connected | CushLabs Messenger Assistant"
+  description="Your Facebook Page is connected to CushLabs Messenger Assistant."
+  noindex={true}
+>
+  <section class="relative pt-24 pb-16 md:pt-32 md:pb-24 overflow-hidden min-h-[60vh]">
+    <div class="absolute inset-0 -z-10">
+      <div id="bg-glow" class="absolute top-1/4 left-1/4 w-[500px] h-[500px] bg-green-500/10 rounded-full blur-[120px]"></div>
+    </div>
+
+    <Container size="md">
+      <!-- Loading placeholder (visible until JS runs) -->
+      <div id="loading-state" class="text-center max-w-2xl mx-auto">
+        <div class="inline-flex items-center justify-center w-20 h-20 rounded-full bg-gray-200 dark:bg-gray-700 mb-8 animate-pulse">
+        </div>
+        <div class="h-10 bg-gray-200 dark:bg-gray-700 rounded animate-pulse max-w-md mx-auto mb-4"></div>
+        <div class="h-6 bg-gray-200 dark:bg-gray-700 rounded animate-pulse max-w-lg mx-auto"></div>
+      </div>
+
+      <!-- Success state -->
+      <div id="success-state" class="text-center max-w-2xl mx-auto" hidden>
+        <div class="inline-flex items-center justify-center w-20 h-20 rounded-full bg-green-500/15 border border-green-500/30 mb-8">
+          <svg class="w-10 h-10 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+
+        <h1 class="font-display text-fluid-4xl font-bold text-gray-900 dark:text-white mb-4 leading-tight tracking-tight">
+          You're connected!
+        </h1>
+
+        <p class="text-fluid-lg text-gray-600 dark:text-gray-300 mb-8 leading-relaxed">
+          We've authorized CushLabs Messenger Assistant on
+          <strong id="page-name" class="text-gray-900 dark:text-white">your Facebook Page</strong>.
+        </p>
+
+        <div class="bg-white dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-xl p-6 mb-10 text-left">
+          <h2 class="font-display font-semibold text-lg text-gray-900 dark:text-white mb-4">
+            What happens next
+          </h2>
+          <ol class="space-y-3 text-gray-700 dark:text-gray-300">
+            <li class="flex gap-3">
+              <span class="text-cush-orange font-display font-bold">1.</span>
+              <span>You'll receive an onboarding email within 1 business day to schedule your content intake call.</span>
+            </li>
+            <li class="flex gap-3">
+              <span class="text-cush-orange font-display font-bold">2.</span>
+              <span>We'll ingest your services, pricing, hours, and FAQs and tune the assistant to your voice.</span>
+            </li>
+            <li class="flex gap-3">
+              <span class="text-cush-orange font-display font-bold">3.</span>
+              <span>Your assistant goes live on your Page within 5 business days. Free 2-week trial begins.</span>
+            </li>
+          </ol>
+        </div>
+
+        <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
+          <a
+            href="/messenger-assistant/"
+            class="inline-flex items-center gap-2 px-6 py-3 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-all duration-300"
+          >
+            Back to overview
+          </a>
+          <a
+            href="/contact/"
+            class="font-display font-medium text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white underline underline-offset-4 decoration-gray-300 hover:decoration-cush-orange transition-all"
+          >
+            Questions? Contact us →
+          </a>
+        </div>
+      </div>
+
+      <!-- Error state -->
+      <div id="error-state" class="text-center max-w-2xl mx-auto" hidden>
+        <div class="inline-flex items-center justify-center w-20 h-20 rounded-full bg-amber-500/15 border border-amber-500/30 mb-8">
+          <svg class="w-10 h-10 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
+        </div>
+
+        <h1 class="font-display text-fluid-3xl font-bold text-gray-900 dark:text-white mb-4 leading-tight tracking-tight">
+          Connection didn't complete
+        </h1>
+
+        <p class="text-fluid-lg text-gray-600 dark:text-gray-300 mb-8 leading-relaxed">
+          <span id="error-message">We didn't receive the authorization details from Facebook. This sometimes happens if you cancel the authorization or if the session times out.</span>
+        </p>
+
+        <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
+          <a
+            href="/messenger-assistant/connect/"
+            class="inline-flex items-center gap-2 px-6 py-3 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-all duration-300"
+          >
+            Try again
+          </a>
+          <a
+            href="/contact/"
+            class="font-display font-medium text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white underline underline-offset-4 decoration-gray-300 hover:decoration-cush-orange transition-all"
+          >
+            Contact us for help →
+          </a>
+        </div>
+      </div>
+    </Container>
+  </section>
+
+  <script is:inline>
+    (function () {
+      const params = new URLSearchParams(window.location.search);
+      const pageName = params.get("page_name");
+      const pageId = params.get("page_id");
+      const error = params.get("error");
+
+      const loading = document.getElementById("loading-state");
+      const success = document.getElementById("success-state");
+      const errorEl = document.getElementById("error-state");
+      const bgGlow = document.getElementById("bg-glow");
+
+      loading.hidden = true;
+
+      if (!error && (pageName || pageId)) {
+        if (pageName) {
+          document.getElementById("page-name").textContent = pageName;
+        }
+        success.hidden = false;
+      } else {
+        if (error) {
+          document.getElementById("error-message").textContent =
+            'Facebook returned: "' + error + '". This sometimes happens if you cancel the authorization or if the session times out.';
+        }
+        if (bgGlow) {
+          bgGlow.classList.remove("bg-green-500/10");
+          bgGlow.classList.add("bg-amber-500/10");
+        }
+        errorEl.hidden = false;
+      }
+    })();
+  </script>
+</BaseLayout>


### PR DESCRIPTION
## Summary
Adds the missing onboarding flow needed for Meta App Review's screencast requirement.

- \`/messenger-assistant/connect/\` — landing page with \"Connect with Facebook\" button (EN + ES)
- \`/messenger-assistant/connected/\` — post-OAuth confirmation page (EN + ES)

The button links to the ny-english-messenger-bot Cloudflare Worker's \`/oauth/start\` endpoint (separate PR), which handles the OAuth state machine and redirects users back here.

## Why this matters
Meta App Review requires the screencast to show \"the app user granting your app the permission you are demonstrating\" — i.e., the Facebook Login for Business OAuth consent screen. Without these pages, the screencast can't cover \`pages_show_list\`, \`business_management\`, etc., and those permissions get rejected.

## Test plan
- [ ] Cushlabs Vercel deploy succeeds
- [ ] /messenger-assistant/connect/ renders cleanly (light + dark modes)
- [ ] /es/messenger-assistant/connect/ renders cleanly
- [ ] Button navigates to ny-english-messenger-bot.rcushmaniii.workers.dev/oauth/start
- [ ] /messenger-assistant/connected/?page_name=Test shows success state
- [ ] /messenger-assistant/connected/?error=test shows error state

🤖 Generated with [Claude Code](https://claude.com/claude-code)