### PR TITLE
chore: point Connect button at messenger.cushlabs.ai

### DIFF
--- a/src/pages/es/messenger-assistant/connect.astro
+++ b/src/pages/es/messenger-assistant/connect.astro
@@ -2,7 +2,7 @@
 import BaseLayout from "../../../layouts/BaseLayout.astro";
 import Container from "../../../components/layout/Container.astro";
 
-const OAUTH_START_URL = "https://ny-english-messenger-bot.rcushmaniii.workers.dev/oauth/start?lang=es";
+const OAUTH_START_URL = "https://messenger.cushlabs.ai/oauth/start?lang=es";
 
 const steps = [
   { n: 1, title: "Conecta tu página de Facebook", desc: "Autoriza a CushLabs para recibir y responder mensajes en la página de Facebook que elijas." },

--- a/src/pages/messenger-assistant/connect.astro
+++ b/src/pages/messenger-assistant/connect.astro
@@ -5,7 +5,7 @@ import Container from "../../components/layout/Container.astro";
 // The OAuth flow is initiated server-side by the messenger bot Worker so
 // we can issue a CSRF state token tied to a short-lived KV key. The button
 // on this page is just a link; the Worker does the redirect dance.
-const OAUTH_START_URL = "https://ny-english-messenger-bot.rcushmaniii.workers.dev/oauth/start";
+const OAUTH_START_URL = "https://messenger.cushlabs.ai/oauth/start";
 
 const steps = [
   { n: 1, title: "Connect your Facebook Page", desc: "Authorize CushLabs to receive and respond to messages on the Facebook Page you choose." },


### PR DESCRIPTION
Cleaner branded URL during OAuth flow than the workers.dev domain. Worker mapped to messenger.cushlabs.ai via Cloudflare custom domain. Both URLs still route to the same Worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)