### PR TITLE
chore: Tailwind 4 canonical class migration + light theme default

### DIFF
--- a/src/components/PageHero.astro
+++ b/src/components/PageHero.astro
@@ -28,7 +28,7 @@ const { title, subtitle, imageSrc, imageAlt = "Hero image", badge, backLink } = 
   </div>
 
   <!-- Gradient Overlay - darker for text readability -->
-  <div class="absolute inset-0 -z-10 bg-gradient-to-b from-black/50 via-black/60 to-background"></div>
+  <div class="absolute inset-0 -z-10 bg-linear-to-b from-black/50 via-black/60 to-background"></div>
 
   <!-- Aurora Effect -->
   <div class="absolute inset-0 -z-10 opacity-25">

--- a/src/components/ThemeScript.astro
+++ b/src/components/ThemeScript.astro
@@ -1,42 +1,13 @@
 ---
 // Inline script to apply theme before paint (prevents flash)
-// Defaults to light during daytime (7am-7pm Mexico City time), dark at night
+// Defaults to light; respects user's explicit preference if stored.
 ---
 
 <script is:inline>
   (function () {
     try {
       const stored = localStorage.getItem("theme");
-
-      // If user has explicitly set a theme, respect it
-      if (stored === "light" || stored === "dark") {
-        if (stored === "dark") {
-          document.documentElement.classList.add("dark");
-        } else {
-          document.documentElement.classList.remove("dark");
-        }
-        return;
-      }
-
-      // No stored preference - use time-based default (Mexico City timezone)
-      // Mexico City is America/Mexico_City (UTC-6 standard, UTC-5 DST)
-      function isDaytimeInMexicoCity() {
-        try {
-          const now = new Date();
-          const mexicoTime = new Date(now.toLocaleString("en-US", { timeZone: "America/Mexico_City" }));
-          const hour = mexicoTime.getHours();
-          // Daytime: 7am (7) to 7pm (19)
-          return hour >= 7 && hour < 19;
-        } catch (e) {
-          // Fallback: assume daytime if timezone API fails
-          return true;
-        }
-      }
-
-      const isDaytime = isDaytimeInMexicoCity();
-      const theme = isDaytime ? "light" : "dark";
-
-      if (theme === "dark") {
+      if (stored === "dark") {
         document.documentElement.classList.add("dark");
       } else {
         document.documentElement.classList.remove("dark");

--- a/src/components/booking/BookingFormSteps.astro
+++ b/src/components/booking/BookingFormSteps.astro
@@ -20,19 +20,19 @@ const b = dict.booking;
     </h3>
     <div class="space-y-3">
       <div class="flex items-start gap-3">
-        <svg class="w-6 h-6 text-cush-orange flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg class="w-6 h-6 text-cush-orange shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
         </svg>
         <p class="text-muted">{b.sessionDuration}</p>
       </div>
       <div class="flex items-start gap-3">
-        <svg class="w-6 h-6 text-cush-orange flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg class="w-6 h-6 text-cush-orange shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
         </svg>
         <p class="text-muted">{b.sessionMeet}</p>
       </div>
       <div class="flex items-start gap-3">
-        <svg class="w-6 h-6 text-cush-orange flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg class="w-6 h-6 text-cush-orange shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
         </svg>
         <p class="text-muted" id="timezone-info-text">{b.sessionTimezone}</p>
@@ -198,10 +198,10 @@ const b = dict.booking;
 
       <div class="max-w-lg mx-auto space-y-6">
         <!-- Summary Card -->
-        <div class="bg-gradient-to-br from-cush-orange/10 to-cush-orange/5 rounded-xl p-6 space-y-4 border border-cush-orange/20">
+        <div class="bg-linear-to-br from-cush-orange/10 to-cush-orange/5 rounded-xl p-6 space-y-4 border border-cush-orange/20">
           <!-- Date & Time -->
           <div class="flex items-start gap-3">
-            <svg class="w-5 h-5 text-cush-orange flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg class="w-5 h-5 text-cush-orange shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
             </svg>
             <div class="flex-1">
@@ -215,7 +215,7 @@ const b = dict.booking;
 
           <!-- Contact Info -->
           <div class="flex items-start gap-3">
-            <svg class="w-5 h-5 text-cush-orange flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg class="w-5 h-5 text-cush-orange shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"></path>
             </svg>
             <div class="flex-1">
@@ -230,7 +230,7 @@ const b = dict.booking;
 
           <!-- Meeting Type -->
           <div class="flex items-start gap-3">
-            <svg class="w-5 h-5 text-cush-orange flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg class="w-5 h-5 text-cush-orange shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
             </svg>
             <div class="flex-1">

--- a/src/components/home/FAQ.astro
+++ b/src/components/home/FAQ.astro
@@ -84,7 +84,7 @@ const t = content[locale];
               {faq.question}
             </h3>
             <svg
-              class="w-5 h-5 text-gray-500 transform transition-transform group-open:rotate-180 flex-shrink-0"
+              class="w-5 h-5 text-gray-500 transform transition-transform group-open:rotate-180 shrink-0"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"

--- a/src/components/home/Hero.astro
+++ b/src/components/home/Hero.astro
@@ -40,7 +40,7 @@ const t = content[locale];
       class="w-full h-full object-cover opacity-20 dark:opacity-10"
     />
     <!-- Multi-stop gradient overlay for smooth fade -->
-    <div class="absolute inset-0 bg-gradient-to-b from-white/80 via-white/60 to-white/30 dark:from-black/70 dark:via-black/55 dark:to-black/20"></div>
+    <div class="absolute inset-0 bg-linear-to-b from-white/80 via-white/60 to-white/30 dark:from-black/70 dark:via-black/55 dark:to-black/20"></div>
   </div>
   <!-- Subtle Gradient Orbs -->
   <div class="absolute inset-0 -z-10">
@@ -48,7 +48,7 @@ const t = content[locale];
     <div class="absolute bottom-1/4 right-1/4 w-[400px] h-[400px] bg-cush-orange/5 rounded-full blur-[100px] animate-pulse" style="animation-delay: 1s;"></div>
   </div>
   <!-- Bottom fade strip — dissolves hero into next section -->
-  <div class="absolute bottom-0 left-0 right-0 h-24 md:h-32 bg-gradient-to-b from-transparent to-white dark:to-black -z-[5]"></div>
+  <div class="absolute bottom-0 left-0 right-0 h-24 md:h-32 bg-linear-to-b from-transparent to-white dark:to-black -z-5"></div>
 
   <Container size="lg">
     <div class="text-center max-w-4xl mx-auto">

--- a/src/components/home/ProblemSolution.astro
+++ b/src/components/home/ProblemSolution.astro
@@ -106,7 +106,7 @@ const t = content[locale];
         {t.problems.map((problem) => (
           <div class="p-5 rounded-xl bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-800">
             <div class="flex items-start gap-3">
-              <div class="flex-shrink-0 mt-1">
+              <div class="shrink-0 mt-1">
                 <svg class="w-5 h-5 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                 </svg>
@@ -144,7 +144,7 @@ const t = content[locale];
       <div class="flex flex-wrap justify-center gap-3 mb-8">
         {t.solutionBullets.map((bullet) => (
           <div class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800">
-            <svg class="w-4 h-4 text-green-600 dark:text-green-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg class="w-4 h-4 text-green-600 dark:text-green-500 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
             </svg>
             <span class="text-sm text-green-800 dark:text-green-300">{bullet}</span>

--- a/src/components/home/ServicesOverview.astro
+++ b/src/components/home/ServicesOverview.astro
@@ -100,7 +100,7 @@ const t = content[locale];
 
         <div class="flex items-start gap-6">
           <!-- Icon -->
-          <div class="hidden sm:flex w-16 h-16 rounded-xl bg-cush-orange/10 items-center justify-center text-cush-orange flex-shrink-0">
+          <div class="hidden sm:flex w-16 h-16 rounded-xl bg-cush-orange/10 items-center justify-center text-cush-orange shrink-0">
             <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
             </svg>
@@ -112,13 +112,13 @@ const t = content[locale];
             </h3>
             <ul class="space-y-2 mb-4">
               <li class="flex items-center gap-2 text-gray-600 dark:text-gray-300">
-                <svg class="w-5 h-5 text-green-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-5 h-5 text-green-500 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
                 </svg>
                 {t.featured.benefit1}
               </li>
               <li class="flex items-center gap-2 text-gray-600 dark:text-gray-300">
-                <svg class="w-5 h-5 text-green-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-5 h-5 text-green-500 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
                 </svg>
                 {t.featured.benefit2}

--- a/src/components/home/WhyCushLabs.astro
+++ b/src/components/home/WhyCushLabs.astro
@@ -99,7 +99,7 @@ const icons: Record<string, string> = {
     <div class="mb-8">
       <div class="p-8 rounded-2xl border-2 border-cush-orange/30 bg-white dark:bg-gray-900 shadow-lg">
         <div class="flex flex-col md:flex-row md:items-start gap-6">
-          <div class="flex-shrink-0">
+          <div class="shrink-0">
             <div class="w-16 h-16 rounded-xl bg-cush-orange/10 flex items-center justify-center text-cush-orange">
               <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" set:html={icons[t.differentiators[0].icon]} />
             </div>

--- a/src/components/home2/FAQ.astro
+++ b/src/components/home2/FAQ.astro
@@ -106,7 +106,7 @@ const faqSchema = {
             <h3 class="font-display font-semibold text-lg text-gray-900 dark:text-white group-open:text-cush-orange transition-colors">
               {faq.q}
             </h3>
-            <span aria-hidden="true" class="flex-shrink-0 ml-1.5 w-6 h-6 rounded-full border border-gray-300 dark:border-gray-700 flex items-center justify-center text-gray-500 group-open:rotate-180 transition-transform duration-300">
+            <span aria-hidden="true" class="shrink-0 ml-1.5 w-6 h-6 rounded-full border border-gray-300 dark:border-gray-700 flex items-center justify-center text-gray-500 group-open:rotate-180 transition-transform duration-300">
               <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
               </svg>

--- a/src/components/home2/Guarantee.astro
+++ b/src/components/home2/Guarantee.astro
@@ -103,7 +103,7 @@ const t = content[locale];
         {t.points.map((point) => (
           <div class="flex gap-5 px-6 md:px-8 py-6 md:py-7">
             <!-- Number badge -->
-            <div class="flex-shrink-0 w-9 h-9 rounded-full bg-cush-orange/10 border border-cush-orange/20 flex items-center justify-center mt-0.5">
+            <div class="shrink-0 w-9 h-9 rounded-full bg-cush-orange/10 border border-cush-orange/20 flex items-center justify-center mt-0.5">
               <span class="font-display text-sm font-bold text-cush-orange">{point.number}</span>
             </div>
             <div>

--- a/src/components/home2/Hero.astro
+++ b/src/components/home2/Hero.astro
@@ -55,7 +55,7 @@ const t = content[locale];
       class="w-full h-full object-cover opacity-20 dark:opacity-10"
     />
     <!-- Multi-stop gradient overlay for smooth fade -->
-    <div class="absolute inset-0 bg-gradient-to-b from-white/80 via-white/60 to-white/30 dark:from-black/70 dark:via-black/55 dark:to-black/20"></div>
+    <div class="absolute inset-0 bg-linear-to-b from-white/80 via-white/60 to-white/30 dark:from-black/70 dark:via-black/55 dark:to-black/20"></div>
   </div>
   <!-- Subtle Gradient Orbs -->
   <div class="absolute inset-0 -z-10">
@@ -63,7 +63,7 @@ const t = content[locale];
     <div class="absolute bottom-1/4 right-1/4 w-[400px] h-[400px] bg-cush-orange/5 rounded-full blur-[100px] animate-pulse" style="animation-delay: 1s;"></div>
   </div>
   <!-- Bottom fade strip — dissolves hero into next section -->
-  <div class="absolute bottom-0 left-0 right-0 h-24 md:h-32 bg-gradient-to-b from-transparent to-white dark:to-black -z-[5]"></div>
+  <div class="absolute bottom-0 left-0 right-0 h-24 md:h-32 bg-linear-to-b from-transparent to-white dark:to-black -z-5"></div>
 
   <Container size="lg">
     <div class="text-center max-w-4xl mx-auto">

--- a/src/components/home2/HowItWorks.astro
+++ b/src/components/home2/HowItWorks.astro
@@ -58,7 +58,7 @@ const t = content[locale];
     </div>
 
     <!-- Timeline/Steps Layout -->
-    <div class="relative space-y-12 before:absolute before:inset-0 before:ml-5 md:before:ml-[50%] before:-translate-x-px md:before:translate-x-0 before:h-full before:w-0.5 before:bg-gradient-to-b before:from-transparent before:via-gray-200 dark:before:via-gray-800 before:to-transparent">
+    <div class="relative space-y-12 before:absolute before:inset-0 before:ml-5 md:before:ml-[50%] before:-translate-x-px md:before:translate-x-0 before:h-full before:w-0.5 before:bg-linear-to-b before:from-transparent before:via-gray-200 dark:before:via-gray-800 before:to-transparent">
       {t.steps.map((step, index) => (
         <div class={`relative flex items-center justify-between md:justify-normal md:odd:flex-row-reverse group border md:border-none border-gray-100 dark:border-gray-800 rounded-xl p-6 md:p-0 ${index % 2 === 0 ? 'md:pr-[50%]' : 'md:pl-[50%]'}`}>
           <!-- Marker -->

--- a/src/components/home2/PainPoints.astro
+++ b/src/components/home2/PainPoints.astro
@@ -99,7 +99,7 @@ const t = content[locale];
       ))}
     </div>
 
-    <div class="max-w-4xl mx-auto text-center p-8 rounded-xl bg-gradient-to-br from-cush-orange/5 to-transparent border border-cush-orange/20">
+    <div class="max-w-4xl mx-auto text-center p-8 rounded-xl bg-linear-to-br from-cush-orange/5 to-transparent border border-cush-orange/20">
       <p class="font-display font-semibold text-xl md:text-2xl text-gray-900 dark:text-white leading-relaxed mb-6">
         {t.closing}
       </p>

--- a/src/components/home2/SocialProof.astro
+++ b/src/components/home2/SocialProof.astro
@@ -107,7 +107,7 @@ const t = content[locale];
         <ul class="space-y-2 mb-5">
           {t.testimonial.highlights.map((h) => (
             <li class="flex items-start gap-2 text-sm text-gray-600 dark:text-gray-400">
-              <svg class="w-4 h-4 text-cush-orange mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-4 h-4 text-cush-orange mt-0.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
               </svg>
               <span>{h}</span>
@@ -121,7 +121,7 @@ const t = content[locale];
 
         <div class="flex items-center gap-3 pt-5 border-t border-gray-100 dark:border-gray-800">
           <!-- LinkedIn icon as avatar placeholder -->
-          <div class="w-10 h-10 rounded-full bg-[#0A66C2] flex items-center justify-center flex-shrink-0">
+          <div class="w-10 h-10 rounded-full bg-[#0A66C2] flex items-center justify-center shrink-0">
             <svg class="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
               <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
             </svg>

--- a/src/components/home2/SolutionOverview.astro
+++ b/src/components/home2/SolutionOverview.astro
@@ -94,7 +94,7 @@ const t = content[locale];
         
         {t.pillars.map((pillar, _i) => (
           <div class="flex gap-5 group">
-            <div class="flex-shrink-0 w-12 h-12 rounded-full bg-cush-orange/10 flex items-center justify-center group-hover:bg-cush-orange group-hover:text-white dark:text-white text-gray-900 transition-colors duration-300">
+            <div class="shrink-0 w-12 h-12 rounded-full bg-cush-orange/10 flex items-center justify-center group-hover:bg-cush-orange group-hover:text-white dark:text-white text-gray-900 transition-colors duration-300">
               <svg class="w-6 h-6 text-cush-orange group-hover:text-white transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d={pillar.icon} />
               </svg>

--- a/src/components/home2/WhyMe.astro
+++ b/src/components/home2/WhyMe.astro
@@ -74,7 +74,7 @@ const t = content[locale];
     <div class="space-y-6 max-w-4xl mx-auto">
       {t.differentiators.map((diff) => (
         <div class="group p-6 md:p-8 rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 flex flex-col md:flex-row gap-6 hover:border-cush-orange/50 hover:shadow-lg hover:shadow-cush-orange/5 transition-all duration-300">
-          <div class="flex-shrink-0 w-14 h-14 rounded-xl bg-cush-orange/10 flex items-center justify-center group-hover:bg-cush-orange group-hover:text-white dark:text-white text-gray-900 transition-colors duration-300">
+          <div class="shrink-0 w-14 h-14 rounded-xl bg-cush-orange/10 flex items-center justify-center group-hover:bg-cush-orange group-hover:text-white dark:text-white text-gray-900 transition-colors duration-300">
             <svg class="w-7 h-7 text-cush-orange group-hover:text-white transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d={diff.icon} />
             </svg>

--- a/src/components/services2/FAQ.astro
+++ b/src/components/services2/FAQ.astro
@@ -100,7 +100,7 @@ const t = content[locale];
         <details class="group bg-gray-50 dark:bg-gray-900/50 rounded-xl border border-gray-200 dark:border-gray-800 [&_summary::-webkit-details-marker]:hidden">
           <summary class="flex items-center justify-between cursor-pointer p-6 md:p-8 font-display font-semibold text-lg text-gray-900 dark:text-white mb-0">
             {faq.q}
-            <span class="ml-6 flex-shrink-0 bg-white dark:bg-black p-2 rounded-full shadow-sm text-cush-orange transition-transform duration-300 group-open:rotate-180">
+            <span class="ml-6 shrink-0 bg-white dark:bg-black p-2 rounded-full shadow-sm text-cush-orange transition-transform duration-300 group-open:rotate-180">
               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
               </svg>

--- a/src/components/services2/Hero.astro
+++ b/src/components/services2/Hero.astro
@@ -37,7 +37,7 @@ const t = content[locale];
       height="1080"
       class="w-full h-full object-cover opacity-[0.05] dark:opacity-[0.03]"
     />
-    <div class="absolute inset-0 bg-gradient-to-b from-white/50 via-transparent to-white dark:from-gray-950/50 dark:via-transparent dark:to-gray-950"></div>
+    <div class="absolute inset-0 bg-linear-to-b from-white/50 via-transparent to-white dark:from-gray-950/50 dark:via-transparent dark:to-gray-950"></div>
   </div>
   <!-- Gradient Orbs -->
   <div class="absolute inset-0 -z-10">

--- a/src/components/services2/HowIWork.astro
+++ b/src/components/services2/HowIWork.astro
@@ -89,7 +89,7 @@ const t = content[locale];
     </div>
 
     <!-- Optional Retainer Box -->
-    <div class="max-w-4xl mx-auto bg-gradient-to-br from-cush-orange/10 to-transparent border border-cush-orange/20 rounded-xl p-8 flex flex-col md:flex-row items-start md:items-center gap-6">
+    <div class="max-w-4xl mx-auto bg-linear-to-br from-cush-orange/10 to-transparent border border-cush-orange/20 rounded-xl p-8 flex flex-col md:flex-row items-start md:items-center gap-6">
       <div class="shrink-0 w-12 h-12 bg-cush-orange/20 rounded-full flex items-center justify-center">
         <svg class="w-6 h-6 text-cush-orange" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -181,7 +181,7 @@ const ogLocaleAlternate = locale === "es" ? "en_US" : "es_MX";
   </head>
   <body>
     <div
-      class="fixed inset-0 -z-20 bg-gradient-to-b from-black/5 via-transparent to-transparent dark:from-cush-gray-800/50"
+      class="fixed inset-0 -z-20 bg-linear-to-b from-black/5 via-transparent to-transparent dark:from-cush-gray-800/50"
     >
     </div>
     <div
@@ -193,7 +193,7 @@ const ogLocaleAlternate = locale === "es" ? "en_US" : "es_MX";
     <!-- Skip navigation for keyboard/screen reader users (WCAG 2.4.1) -->
     <a
       href="#main-content"
-      class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[9999] focus:bg-cush-orange focus:text-black focus:px-4 focus:py-2 focus:rounded-lg focus:font-display focus:font-semibold focus:shadow-lg"
+      class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-9999 focus:bg-cush-orange focus:text-black focus:px-4 focus:py-2 focus:rounded-lg focus:font-display focus:font-semibold focus:shadow-lg"
     >
       {locale === "es" ? "Ir al contenido principal" : "Skip to main content"}
     </a>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -182,7 +182,7 @@ const t = content[locale];
         height="1080"
         class="w-full h-full object-cover opacity-[0.05] dark:opacity-[0.03]"
       />
-      <div class="absolute inset-0 bg-gradient-to-b from-white/50 via-transparent to-white dark:from-gray-950/50 dark:via-transparent dark:to-gray-950"></div>
+      <div class="absolute inset-0 bg-linear-to-b from-white/50 via-transparent to-white dark:from-gray-950/50 dark:via-transparent dark:to-gray-950"></div>
     </div>
     <!-- Gradient Orbs -->
     <div class="absolute inset-0 -z-10">
@@ -258,7 +258,7 @@ const t = content[locale];
         <ul class="space-y-4 mb-8">
           {t.problem.items.map((item) => (
             <li class="flex items-start gap-3">
-              <svg class="w-6 h-6 text-red-500 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-6 h-6 text-red-500 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
               <span class="text-gray-700 dark:text-gray-300">{item}</span>
@@ -282,7 +282,7 @@ const t = content[locale];
         {t.approach.items.map((item, index) => (
           <div class="p-6 md:p-8 rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800/50">
             <div class="flex items-center gap-3 mb-4">
-              <div class="w-10 h-10 rounded-lg bg-cush-orange/10 flex items-center justify-center flex-shrink-0">
+              <div class="w-10 h-10 rounded-lg bg-cush-orange/10 flex items-center justify-center shrink-0">
                 <span class="font-display font-bold text-cush-orange">{String(index + 1).padStart(2, '0')}</span>
               </div>
               <h3 class="font-display text-xl font-bold text-gray-900 dark:text-white">
@@ -359,7 +359,7 @@ const t = content[locale];
         <ul class="space-y-4 mb-8">
           {t.clients.items.map((item) => (
             <li class="flex items-start gap-3">
-              <svg class="w-6 h-6 text-green-500 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-6 h-6 text-green-500 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
               </svg>
               <span class="text-gray-700 dark:text-gray-300">{item}</span>

--- a/src/pages/consultation.astro
+++ b/src/pages/consultation.astro
@@ -15,7 +15,7 @@ const dict = t(locale);
     <section class="relative overflow-hidden border-b border-border">
       <div class="absolute inset-0 -z-10">
         <div
-          class="absolute inset-0 bg-gradient-to-br from-cush-orange/15 via-transparent to-transparent"
+          class="absolute inset-0 bg-linear-to-br from-cush-orange/15 via-transparent to-transparent"
         >
         </div>
         <div

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -56,7 +56,7 @@ const hero = content[locale];
         height="1080"
         class="w-full h-full object-cover opacity-[0.05] dark:opacity-[0.03]"
       />
-      <div class="absolute inset-0 bg-gradient-to-b from-white/50 via-transparent to-white dark:from-gray-950/50 dark:via-transparent dark:to-gray-950"></div>
+      <div class="absolute inset-0 bg-linear-to-b from-white/50 via-transparent to-white dark:from-gray-950/50 dark:via-transparent dark:to-gray-950"></div>
     </div>
     <!-- Gradient Orbs -->
     <div class="absolute inset-0 -z-10">

--- a/src/pages/es/about.astro
+++ b/src/pages/es/about.astro
@@ -80,7 +80,7 @@ const t = content;
   <section class="relative pt-24 pb-16 overflow-hidden">
     <div class="absolute inset-0 -z-20">
       <img src="/images/hero/about-hero.webp" alt="CushLabs founder and AI consultant background" width="1920" height="1080" class="w-full h-full object-cover opacity-[0.05] dark:opacity-[0.03]" />
-      <div class="absolute inset-0 bg-gradient-to-b from-white/50 via-transparent to-white dark:from-gray-950/50 dark:via-transparent dark:to-gray-950"></div>
+      <div class="absolute inset-0 bg-linear-to-b from-white/50 via-transparent to-white dark:from-gray-950/50 dark:via-transparent dark:to-gray-950"></div>
     </div>
     <div class="absolute inset-0 -z-10">
       <div class="absolute top-1/4 left-1/4 w-[500px] h-[500px] bg-cush-orange/15 rounded-full blur-[120px]"></div>
@@ -129,7 +129,7 @@ const t = content;
         <ul class="space-y-4 mb-8">
           {t.problem.items.map((item) => (
             <li class="flex items-start gap-3">
-              <svg class="w-6 h-6 text-red-500 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+              <svg class="w-6 h-6 text-red-500 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
               <span class="text-gray-700 dark:text-gray-300">{item}</span>
             </li>
           ))}
@@ -146,7 +146,7 @@ const t = content;
         {t.approach.items.map((item, index) => (
           <div class="p-6 md:p-8 rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800/50">
             <div class="flex items-center gap-3 mb-4">
-              <div class="w-10 h-10 rounded-lg bg-cush-orange/10 flex items-center justify-center flex-shrink-0">
+              <div class="w-10 h-10 rounded-lg bg-cush-orange/10 flex items-center justify-center shrink-0">
                 <span class="font-display font-bold text-cush-orange">{String(index + 1).padStart(2, '0')}</span>
               </div>
               <h3 class="font-display text-xl font-bold text-gray-900 dark:text-white">{item.title}</h3>
@@ -190,7 +190,7 @@ const t = content;
         <ul class="space-y-4 mb-8">
           {t.clients.items.map((item) => (
             <li class="flex items-start gap-3">
-              <svg class="w-6 h-6 text-green-500 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
+              <svg class="w-6 h-6 text-green-500 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
               <span class="text-gray-700 dark:text-gray-300">{item}</span>
             </li>
           ))}

--- a/src/pages/es/contact.astro
+++ b/src/pages/es/contact.astro
@@ -30,7 +30,7 @@ const hero = {
   <section class="relative pt-24 pb-16 overflow-hidden">
     <div class="absolute inset-0 -z-20">
       <img src="/images/hero/contact-hero.webp" alt="Contact CushLabs for AI consulting and development services" width="1920" height="1080" class="w-full h-full object-cover opacity-[0.05] dark:opacity-[0.03]" />
-      <div class="absolute inset-0 bg-gradient-to-b from-white/50 via-transparent to-white dark:from-gray-950/50 dark:via-transparent dark:to-gray-950"></div>
+      <div class="absolute inset-0 bg-linear-to-b from-white/50 via-transparent to-white dark:from-gray-950/50 dark:via-transparent dark:to-gray-950"></div>
     </div>
     <div class="absolute inset-0 -z-10">
       <div class="absolute top-1/4 left-1/4 w-[500px] h-[500px] bg-cush-orange/15 rounded-full blur-[120px]"></div>

--- a/src/pages/es/faq.astro
+++ b/src/pages/es/faq.astro
@@ -133,7 +133,7 @@ const content = {
                       {faq.question}
                     </h3>
                     <svg
-                      class="w-5 h-5 text-gray-500 transform transition-transform group-open:rotate-180 flex-shrink-0"
+                      class="w-5 h-5 text-gray-500 transform transition-transform group-open:rotate-180 shrink-0"
                       fill="none"
                       stroke="currentColor"
                       viewBox="0 0 24 24"

--- a/src/pages/es/messenger-assistant/connect.astro
+++ b/src/pages/es/messenger-assistant/connect.astro
@@ -77,7 +77,7 @@ const permissions = [
         <ol class="space-y-6">
           {steps.map(s => (
             <li class="flex gap-5 p-5 bg-white dark:bg-gray-800/50 rounded-xl border border-gray-100 dark:border-gray-800">
-              <div class="flex-shrink-0 w-10 h-10 rounded-full bg-cush-orange/10 text-cush-orange font-display font-bold flex items-center justify-center">
+              <div class="shrink-0 w-10 h-10 rounded-full bg-cush-orange/10 text-cush-orange font-display font-bold flex items-center justify-center">
                 {s.n}
               </div>
               <div>

--- a/src/pages/es/portfolio.astro
+++ b/src/pages/es/portfolio.astro
@@ -53,7 +53,7 @@ const t = {
   <section class="relative pt-24 pb-16 overflow-hidden">
     <div class="absolute inset-0 -z-20">
       <img src="/images/hero/solutuions-hero.webp" alt="CushLabs portfolio of AI and software development projects" loading="eager" fetchpriority="high" width="1920" height="1080" class="w-full h-full object-cover opacity-[0.05] dark:opacity-[0.03]" />
-      <div class="absolute inset-0 bg-gradient-to-b from-white/50 via-transparent to-white dark:from-gray-950/50 dark:via-transparent dark:to-gray-950"></div>
+      <div class="absolute inset-0 bg-linear-to-b from-white/50 via-transparent to-white dark:from-gray-950/50 dark:via-transparent dark:to-gray-950"></div>
     </div>
     <div class="absolute inset-0 -z-10">
       <div class="absolute top-1/4 left-1/4 w-[500px] h-[500px] bg-cush-orange/15 rounded-full blur-[120px]"></div>

--- a/src/pages/es/projects/[slug].astro
+++ b/src/pages/es/projects/[slug].astro
@@ -285,7 +285,7 @@ const relatedProjects = scored.slice(0, 3).map(s => s.project);
                 <div id="slider" class="overflow-hidden">
                   <div id="slider-track" class="flex transition-transform duration-300 ease-in-out">
                     {images.map((img, i) => (
-                      <div class="w-full flex-shrink-0 p-4 md:p-6">
+                      <div class="w-full shrink-0 p-4 md:p-6">
                         <figure class="rounded-xl border border-border bg-canvas/40 overflow-hidden">
                           <img
                             src={i === 0 ? img.src : undefined}
@@ -384,7 +384,7 @@ const relatedProjects = scored.slice(0, 3).map(s => s.project);
               <ul class="mt-4 space-y-3">
                 {results.map((item) => (
                   <li class="flex items-start gap-3 text-muted">
-                    <svg class="w-5 h-5 text-cush-orange flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg class="w-5 h-5 text-cush-orange shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
                     </svg>
                     <span>{item}</span>

--- a/src/pages/es/reservar.astro
+++ b/src/pages/es/reservar.astro
@@ -14,7 +14,7 @@ const dict = t(locale);
   <main class="pb-24">
     <section class="relative overflow-hidden border-b border-border">
       <div class="absolute inset-0 -z-10">
-        <div class="absolute inset-0 bg-gradient-to-br from-cush-orange/15 via-transparent to-transparent"></div>
+        <div class="absolute inset-0 bg-linear-to-br from-cush-orange/15 via-transparent to-transparent"></div>
         <div class="absolute -left-24 top-16 h-64 w-64 rounded-full bg-cush-orange/10 blur-3xl"></div>
       </div>
 

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -130,7 +130,7 @@ const content = {
                       {faq.question}
                     </h3>
                     <svg
-                      class="w-5 h-5 text-gray-500 transform transition-transform group-open:rotate-180 flex-shrink-0"
+                      class="w-5 h-5 text-gray-500 transform transition-transform group-open:rotate-180 shrink-0"
                       fill="none"
                       stroke="currentColor"
                       viewBox="0 0 24 24"

--- a/src/pages/messenger-assistant/connect.astro
+++ b/src/pages/messenger-assistant/connect.astro
@@ -81,7 +81,7 @@ const permissions = [
         <ol class="space-y-6">
           {steps.map(s => (
             <li class="flex gap-5 p-5 bg-white dark:bg-gray-800/50 rounded-xl border border-gray-100 dark:border-gray-800">
-              <div class="flex-shrink-0 w-10 h-10 rounded-full bg-cush-orange/10 text-cush-orange font-display font-bold flex items-center justify-center">
+              <div class="shrink-0 w-10 h-10 rounded-full bg-cush-orange/10 text-cush-orange font-display font-bold flex items-center justify-center">
                 {s.n}
               </div>
               <div>

--- a/src/pages/portfolio.astro
+++ b/src/pages/portfolio.astro
@@ -122,7 +122,7 @@ const t = content[locale];
         height="1080"
         class="w-full h-full object-cover opacity-[0.05] dark:opacity-[0.03]"
       />
-      <div class="absolute inset-0 bg-gradient-to-b from-white/50 via-transparent to-white dark:from-gray-950/50 dark:via-transparent dark:to-gray-950"></div>
+      <div class="absolute inset-0 bg-linear-to-b from-white/50 via-transparent to-white dark:from-gray-950/50 dark:via-transparent dark:to-gray-950"></div>
     </div>
     <!-- Gradient Orbs -->
     <div class="absolute inset-0 -z-10">

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -280,7 +280,7 @@ const relatedProjects = scored.slice(0, 3).map(s => s.project);
                 <div id="slider" class="overflow-hidden">
                   <div id="slider-track" class="flex transition-transform duration-300 ease-in-out">
                     {images.map((img, i) => (
-                      <div class="w-full flex-shrink-0 p-4 md:p-6">
+                      <div class="w-full shrink-0 p-4 md:p-6">
                         <figure class="rounded-xl border border-border bg-canvas/40 overflow-hidden">
                           <img
                             src={i === 0 ? img.src : undefined}
@@ -379,7 +379,7 @@ const relatedProjects = scored.slice(0, 3).map(s => s.project);
               <ul class="mt-4 space-y-3">
                 {results.map((item) => (
                   <li class="flex items-start gap-3 text-muted">
-                    <svg class="w-5 h-5 text-cush-orange flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg class="w-5 h-5 text-cush-orange shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
                     </svg>
                     <span>{item}</span>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -101,7 +101,7 @@ body {
 
 /* ── Custom utilities ── */
 @utility text-gradient {
-  @apply bg-gradient-to-r from-foreground to-muted bg-clip-text text-transparent;
+  @apply bg-linear-to-r from-foreground to-muted bg-clip-text text-transparent;
 }
 
 @utility glow-orange {


### PR DESCRIPTION
## Summary

- **Default theme:** Site now defaults to **light** for first-time visitors. Dropped the time-of-day-based default in `ThemeScript`. User's stored `localStorage.theme` preference is still respected (toggle in Header continues to work).
- **Canonical Tailwind 4 class migration** — replaces v3 legacy names that IntelliSense flags via `suggestCanonicalClasses`:
  - `bg-gradient-to-*` → `bg-linear-to-*` (19 occurrences, 17 files + `global.css`)
  - `flex-shrink-0` → `shrink-0` (32 occurrences, 17 files)
  - `-z-[5]` → `-z-5` (2 occurrences in Hero components)
  - `focus:z-[9999]` → `focus:z-9999` (BaseLayout skip-nav link)

No visual changes — these are pure naming aliases that Tailwind 4 prefers. Build verified clean (97 pages, 3.46s).

## What was deliberately NOT migrated

Two patterns turned up in the audit but were skipped because they would change visuals and need case-by-case review, not a sweep:

1. **`shadow-sm`** (83 occurrences across 43 files) — Tailwind 4 renamed the old `shadow-sm` to `shadow-xs`, and the old default `shadow` became `shadow-sm`. Auto-renaming would shrink every shadow on the site by one tier.
2. **`outline-none`** (18 occurrences across 6 files) — semantic change in v4 (the new `outline-none` removes outlines entirely; old behavior is `outline-hidden`). Most existing usages probably need to stay; needs accessibility review per case.

Both are flagged in the SESSION-LOG follow-up as deliberate tech-debt entries for a separate visual-review pass.

## Test plan

- [x] Build passes (`npm run build`) — 97 pages, no errors
- [x] Zero remaining occurrences of `flex-shrink-`, `bg-gradient-to-`, `-z-[5]` in `src/`
- [ ] Visual smoke check on dev server (light theme default + gradients render correctly)
- [ ] Verify Vercel preview deployment renders identically to current production

🤖 Generated with [Claude Code](https://claude.com/claude-code)