### PR TITLE
chore: tech debt sweep — Dependabot CVE + canonical guardrail + SEO

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2700,6 +2700,19 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -8232,9 +8245,9 @@
       }
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.9.tgz",
+      "integrity": "sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==",
       "dev": true,
       "funding": [
         {
@@ -8248,9 +8261,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
       "dev": true,
       "funding": [
         {
@@ -8260,9 +8273,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -11615,9 +11629,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.1.tgz",
-      "integrity": "sha512-d7gQQmLvAKXKXE2GeP9apIGbMYKz88zWdsn/BN2HRWVQsDFdUY36WSLTY0Jvd4HWi7Fb30gQ62oAOzdgJA6fZw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "dev": true,
       "funding": [
         {
@@ -11738,9 +11752,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -12908,9 +12922,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "tailwindcss": "^4.2.2"
   },
   "overrides": {
-    "yaml": ">=2.8.3"
+    "yaml": ">=2.8.3",
+    "fast-xml-parser": ">=5.7.0"
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.1008.0",

--- a/scripts/audit-predeploy.ts
+++ b/scripts/audit-predeploy.ts
@@ -383,10 +383,12 @@ function extractTag(html: string, tag: string): string | null {
     return m ? m[1].trim() : null;
   }
   // <meta name="description" content="...">
+  // Use a backreference for the closing quote so apostrophes inside the content
+  // (e.g. "Driver's License") don't truncate the match early.
   if (tag === "description") {
-    const m = html.match(/<meta\s[^>]*name=["']description["'][^>]*content=["'](.*?)["'][^>]*\/?>/is)
-           || html.match(/<meta\s[^>]*content=["'](.*?)["'][^>]*name=["']description["'][^>]*\/?>/is);
-    return m ? m[1].trim() : null;
+    const m = html.match(/<meta\s[^>]*name=["']description["'][^>]*content=(["'])(.*?)\1[^>]*\/?>/is)
+           || html.match(/<meta\s[^>]*content=(["'])(.*?)\1[^>]*name=["']description["'][^>]*\/?>/is);
+    return m ? m[2].trim() : null;
   }
   return null;
 }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -21,9 +21,14 @@ const locale =
   (Astro.currentLocale as Locale | undefined) ??
   getLocaleFromPathname(pathname);
 
-// Ensure trailing slash for canonical URL consistency
+// Ensure trailing slash for canonical URL consistency.
+// Strip protocol+host from any incoming `canonical` so absolute URLs can't
+// bypass `Astro.site` (footgun: `new URL(absolute, base)` ignores `base`
+// when `absolute` is already absolute, which caused PR #80's "non-canonical
+// page in sitemap" Ahrefs errors).
+const stripOrigin = (p: string) => p.replace(/^https?:\/\/[^/]+/, '') || '/';
 const ensureTrailingSlash = (p: string) => p === '/' || p.endsWith('/') ? p : `${p}/`;
-const canonicalPath = ensureTrailingSlash(canonical || pathname);
+const canonicalPath = ensureTrailingSlash(stripOrigin(canonical || pathname));
 const canonicalURL = new URL(canonicalPath, Astro.site);
 
 // getLocalizedPath already returns trailing slashes

--- a/src/pages/es/projects/[slug].astro
+++ b/src/pages/es/projects/[slug].astro
@@ -25,6 +25,7 @@ const detail = override?.es ?? null;
 const metaTitles: Record<string, string> = {
   'ai-chatbot-saas': 'Converso AI — Chatbot Bilingüe SaaS',
   'ny-ai-chatbot': 'Chatbot IA para Sitios Web de PYMES',
+  'ny-english-messenger-bot': 'NY English Messenger — Asistente Bilingüe IA',
   'biojalisco-pitch': 'BioJalisco — Atlas de Biodiversidad',
   'expat-driver-license-prep': 'ExpatDrive — Examen de Licencia Bilingüe',
   'cushlabs-marketsignal': 'MarketSignal — Inteligencia Competitiva Local',

--- a/src/pages/es/services.astro
+++ b/src/pages/es/services.astro
@@ -11,8 +11,8 @@ import FinalCTA from "../../components/services2/FinalCTA.astro";
 
 const locale = "es" as const;
 
-const title = "Servicios de IA — Messenger, Inteligencia Competitiva y Voz | CushLabs.ai";
-const description = "Asistente de IA para Facebook Messenger, inteligencia competitiva en Google Maps con plan de acción semanal, chatbots para sitios web y agentes de voz con IA. Bilingüe. Prueba gratis 2 semanas.";
+const title = "Servicios de IA — Messenger, Voz y Automatización | CushLabs";
+const description = "Asistente de IA para Facebook Messenger, inteligencia competitiva en Google Maps, chatbots web y agentes de voz. Bilingüe. Prueba gratis 2 semanas.";
 ---
 
 <BaseLayout title={title} description={description}>

--- a/src/pages/es/voice-agent.astro
+++ b/src/pages/es/voice-agent.astro
@@ -32,7 +32,7 @@ const bestFor = [
 
 <BaseLayout
   title="Agente de Voz con IA | CushLabs.ai"
-  description="Un agente de voz con IA disponible 24/7 que contesta el teléfono de tu negocio, agenda citas y captura leads — bilingüe EN/ES, totalmente gestionado. Demos en vivo en voice.cushlabs.ai."
+  description="Agente de voz con IA disponible 24/7 — contesta tu teléfono, agenda citas y captura leads. Bilingüe EN/ES. Demos en vivo en voice.cushlabs.ai."
 >
 
   <!-- Hero -->

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -25,6 +25,7 @@ const detail = override?.en ?? null;
 const metaTitles: Record<string, string> = {
   'ai-chatbot-saas': 'Converso AI — Bilingual AI Chatbot SaaS',
   'ny-ai-chatbot': 'AI Chatbot Widget for Small Business Websites',
+  'ny-english-messenger-bot': 'NY English Messenger — Bilingual AI Assistant',
   'biojalisco-pitch': 'BioJalisco — Biodiversity Atlas',
   'expat-driver-license-prep': 'ExpatDrive — Bilingual License Exam Prep',
   'cushlabs-marketsignal': 'MarketSignal — Local Competitive Intelligence',

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -13,12 +13,12 @@ const locale = (Astro.currentLocale === "es" ? "es" : "en") as "en" | "es";
 
 const meta = {
   en: {
-    title: "AI Services — Messenger AI, Competitive Intelligence & Voice | CushLabs.ai",
-    description: "Facebook Messenger AI assistant, Google Maps competitive intelligence with weekly action plans, website chatbots, and AI voice agents. Bilingual EN/ES. Free 2-week trial.",
+    title: "AI Services — Messenger, Voice, Automation | CushLabs.ai",
+    description: "Facebook Messenger AI assistant, Google Maps competitive intelligence, website chatbots, and AI voice agents. Bilingual EN/ES. Free 2-week trial.",
   },
   es: {
-    title: "Servicios de IA — Messenger, Inteligencia Competitiva y Voz | CushLabs.ai",
-    description: "Asistente de IA para Facebook Messenger, inteligencia competitiva en Google Maps con plan de acción semanal, chatbots para sitios web y agentes de voz con IA. Bilingüe. Prueba gratis 2 semanas.",
+    title: "Servicios de IA — Messenger, Voz y Automatización | CushLabs",
+    description: "Asistente de IA para Facebook Messenger, inteligencia competitiva en Google Maps, chatbots web y agentes de voz. Bilingüe. Prueba gratis 2 semanas.",
   },
 };
 ---

--- a/src/pages/voice-agent.astro
+++ b/src/pages/voice-agent.astro
@@ -32,7 +32,7 @@ const bestFor = [
 
 <BaseLayout
   title="AI Voice Agent | CushLabs.ai"
-  description="A 24/7 AI voice agent that answers your business phone, books appointments, and captures leads — bilingual EN/ES, fully managed. Hear live demos at voice.cushlabs.ai."
+  description="A 24/7 AI voice agent that answers your business phone, books appointments, and captures leads — bilingual EN/ES. Hear live demos at voice.cushlabs.ai."
 >
 
   <!-- Hero -->


### PR DESCRIPTION
## Summary

Bundles three small tech-debt items identified after PR #92 (Tailwind canonical migration):

### 1. Dependabot CVE — `fast-xml-parser` (alert #15, moderate)
- Added `fast-xml-parser: ">=5.7.0"` to `package.json` overrides.
- Transitive via `@aws-sdk/client-s3` (used only by the R2 upload script — build-time, never ships to production).
- `npm audit fix` also bumped `postcss` past an unrelated XSS advisory.
- `npm audit` now reports **0 vulnerabilities**.

### 2. BaseLayout canonical guardrail (SESSION-LOG tech-debt #2)
- Strip protocol+host from any incoming `canonical` prop before joining with `Astro.site`.
- Permanent fix for **Recurring Failure Mode #2** — absolute URLs bypassing `Astro.site` produced "non-canonical page in sitemap" Ahrefs errors that drove PR #80.

### 3. SEO title/description tightening (audit:predeploy was failing)
| Page | Before | After |
|------|--------|-------|
| `/services/` title | 78ch | 56ch |
| `/services/` desc | 170ch | 147ch |
| `/es/services/` title | 73ch | 59ch |
| `/es/services/` desc | 193ch | 148ch |
| `/voice-agent/` desc | 166ch | 154ch |
| `/es/voice-agent/` desc | 185ch | 144ch |
| `/projects/ny-english-messenger-bot/` title (EN+ES) | 80ch | 60ch |

### Bonus: audit script regex bug fix
- The meta-description extractor's `(.*?)["']` truncated at the first single quote, so any description containing `Driver's` was reported as 29 chars. Fixed to use a backreference `(["'])(.*?)\1`.

## Verification
- ✅ `npm run audit:predeploy` — all checks OK
- ✅ `npm audit` — 0 vulnerabilities
- ✅ Build clean, 97 pages

## Test plan
- [ ] Vercel preview renders services + voice-agent + ny-english-messenger-bot pages with new meta tags
- [ ] Confirm Dependabot alert #15 closes after merge
- [ ] Next Ahrefs crawl: no new title-too-long / description-too-long warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)