### PR TITLE
fix(seo): exclude noindex OAuth pages from sitemap; resolve Ahrefs error cascade

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -57,10 +57,13 @@ export default defineConfig({
     }),
     sitemap({
       filter: (page) => {
-        // Exclude 404, old/backup pages, and internal routes
         const path = page.replace(SITE, '');
         if (path.includes('404')) return false;
         if (path.includes('_')) return false;
+        // Internal flow pages with noindex meta — must NOT appear in sitemap
+        // (Ahrefs flags "noindex page in sitemap" as a hard error).
+        if (/\/messenger-assistant\/connect(ed)?\/?$/.test(path)) return false;
+        if (/\/es\/messenger-assistant\/connect(ed)?\/?$/.test(path)) return false;
         return true;
       },
       serialize: (item) => {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,8 @@
 User-agent: *
 Allow: /
+Disallow: /messenger-assistant/connect/
+Disallow: /messenger-assistant/connected/
+Disallow: /es/messenger-assistant/connect/
+Disallow: /es/messenger-assistant/connected/
 
 Sitemap: https://www.cushlabs.ai/sitemap-index.xml

--- a/src/pages/es/messenger-assistant/connect.astro
+++ b/src/pages/es/messenger-assistant/connect.astro
@@ -22,7 +22,7 @@ const permissions = [
 
 <BaseLayout
   title="Conecta tu página de Facebook | Asistente Messenger CushLabs"
-  description="Conecta tu página de Facebook a tu Asistente IA de Messenger de CushLabs. Un clic, login seguro de Facebook, y listo."
+  description="Conecta tu página de Facebook a tu Asistente IA de Messenger de CushLabs. Login seguro, sin instalar nada — listo en menos de un minuto, control total."
   noindex={true}
 >
   <section class="relative pt-24 pb-16 md:pt-32 md:pb-20 overflow-hidden">

--- a/src/pages/es/messenger-assistant/connected.astro
+++ b/src/pages/es/messenger-assistant/connected.astro
@@ -82,9 +82,9 @@ import Container from "../../../components/layout/Container.astro";
           </svg>
         </div>
 
-        <h1 class="font-display text-fluid-3xl font-bold text-gray-900 dark:text-white mb-4 leading-tight tracking-tight">
+        <h2 class="font-display text-fluid-3xl font-bold text-gray-900 dark:text-white mb-4 leading-tight tracking-tight">
           La conexión no se completó
-        </h1>
+        </h2>
 
         <p class="text-fluid-lg text-gray-600 dark:text-gray-300 mb-8 leading-relaxed">
           <span id="error-message">No recibimos los datos de autorización de Facebook. Esto pasa a veces si se cancela la autorización o si la sesión expira.</span>

--- a/src/pages/messenger-assistant/connect.astro
+++ b/src/pages/messenger-assistant/connect.astro
@@ -25,7 +25,7 @@ const permissions = [
 
 <BaseLayout
   title="Connect your Facebook Page | CushLabs Messenger Assistant"
-  description="Connect your Facebook Page to your CushLabs AI Messenger Assistant. One click, secure Facebook Login, and you're set up."
+  description="Connect your Facebook Page to your CushLabs AI Messenger Assistant. Secure Facebook Login, no new software needed — done in under a minute, full control."
   noindex={true}
 >
   <section class="relative pt-24 pb-16 md:pt-32 md:pb-20 overflow-hidden">

--- a/src/pages/messenger-assistant/connected.astro
+++ b/src/pages/messenger-assistant/connected.astro
@@ -86,9 +86,9 @@ import Container from "../../components/layout/Container.astro";
             </svg>
         </div>
 
-        <h1 class="font-display text-fluid-3xl font-bold text-gray-900 dark:text-white mb-4 leading-tight tracking-tight">
+        <h2 class="font-display text-fluid-3xl font-bold text-gray-900 dark:text-white mb-4 leading-tight tracking-tight">
           Connection didn't complete
-        </h1>
+        </h2>
 
         <p class="text-fluid-lg text-gray-600 dark:text-gray-300 mb-8 leading-relaxed">
           <span id="error-message">We didn't receive the authorization details from Facebook. This sometimes happens if you cancel the authorization or if the session times out.</span>


### PR DESCRIPTION
## Summary
- Ahrefs flagged 4 Errors + 11 Warnings + 74 Notices on the latest crawl, all traceable to one root cause: the 4 Messenger OAuth callback pages (`/messenger-assistant/{connect,connected}/` EN+ES) are correctly `noindex` but were appearing in `sitemap-index.xml`.
- Excluding them from sitemap + robots.txt resolves the 4 hard errors and the dependent cascade (nofollow link mixes, page indexability flags).
- Bonus cleanup on the same surface: demoted duplicate H1 → H2 on `connected.astro` error state, lengthened `connect.astro` meta descriptions to the Ahrefs 150–160 sweet spot.

## What changed
- `astro.config.mjs` — sitemap `filter()` now skips `/messenger-assistant/connect(ed)/` for both EN and ES locales
- `public/robots.txt` — added explicit `Disallow:` rules for those 4 paths (belt + suspenders so crawlers don't waste budget)
- `src/pages/messenger-assistant/connected.astro` (EN + ES) — error-state heading demoted from `<h1>` to `<h2>` (only one state ever renders, but both H1s existed in the static HTML)
- `src/pages/messenger-assistant/connect.astro` (EN + ES) — meta descriptions expanded from ~115 chars to 153 (EN) and 151 (ES)

## Why these pages are noindex (don't change)
Both pages serve the Facebook OAuth flow and must NEVER appear in search results:
- `/connect/` — pre-OAuth landing where a user starts the Facebook auth dance
- `/connected/` — OAuth callback target (success/error states based on query params)

## Verification
- `npm run build` — 99 pages built, sitemap regenerated
- Post-build sitemap inspection: 94 `<loc>` entries, **zero** containing `connect` or `connected`
- `dist/messenger-assistant/connected/index.html` — exactly 1 `<h1>`, 2 `<h2>` (was 2 H1s)
- Meta description lengths: EN=153, ES=151 chars (Ahrefs target 150-160)
- `npm run audit:predeploy` — all checks pass (titles, descriptions, trailing slashes, orphan detection)

## Expected Ahrefs impact on next crawl
The 4 hard errors disappear immediately. The dependent issues (4× nofollow page, 4× noindex+nofollow page, 4× nofollow incoming-only, 4× nofollow outgoing, 24× mixed nofollow+dofollow incoming, 2× multiple H1, 2× meta-too-short) will resolve over the next 1–2 crawls as Ahrefs drops the OAuth pages entirely (no sitemap entry + robots Disallow + zero indexable inbound links = nothing to crawl).

## Test plan
- [ ] Vercel preview build succeeds
- [ ] Spot-check `/messenger-assistant/connect/` and `/connected/` still render correctly in preview (both EN and ES)
- [ ] Confirm `https://www.cushlabs.ai/sitemap-0.xml` after merge contains zero `connect` or `connected` URLs
- [ ] Re-run Ahrefs audit after deploy and confirm error count drops to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)