### PR TITLE
feat(seo): GSC submitter wired via env-decoded service account

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,9 @@ PUBLIC_SENTRY_DSN=              # Same as SENTRY_DSN — exposed to client for e
 SENTRY_ORG=cushlabsai
 SENTRY_PROJECT=cushlabs
 SENTRY_AUTH_TOKEN=
+
+# Google Search Console API — for sitemap/URL submission via npm run seo:gsc
+# Base64-encoded service-account JSON. Generate via:
+#   [Convert]::ToBase64String([IO.File]::ReadAllBytes("path\to\sa-key.json"))
+# Service account must be added as Owner on the GSC property (sc-domain:cushlabs.ai).
+GOOGLE_SA_KEY_BASE64=

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -4,6 +4,35 @@ Entries are newest-first. Each entry documents one Claude Code working session.
 
 ---
 
+## Session: 2026-05-10
+
+### Accomplished
+- PR #92 merged: defaulted site theme to `light` (removed time-of-day logic in `ThemeScript.astro`); fixed 3 reported Tailwind v4 warnings (`bg-gradient-to-b` → `bg-linear-to-b`, `focus:z-[9999]` → `focus:z-9999`, `flex-shrink-0` → `shrink-0`); swept 35 files for the same legacy v3 patterns (17× `flex-shrink-*`, 17× `bg-gradient-*`, 2× arbitrary `-z-[5]`).
+- PR #93 merged: Dependabot fix via `package.json` overrides (`fast-xml-parser ≥5.7.0`, `yaml ≥2.8.3`); `npm audit fix` cleared incidental postcss XSS; canonical guardrail added to `BaseLayout.astro` (strips protocol+host before `new URL(p, Astro.site)`, closes recurring failure mode #2 from PR #80).
+- SEO: tightened 7 over-length titles/descriptions on `/services/` (EN+ES) and `/voice-agent/` (EN+ES); added `ny-english-messenger-bot` to `metaTitles` overrides on `[slug].astro` (EN+ES). Replaced `&` with comma in services title to avoid `&amp;` (5ch) pushing rendered length past 60.
+- Fixed regex bug in `scripts/audit-predeploy.ts`: alternation `["']` was truncating descriptions at apostrophes (e.g. "Driver's License"); switched to backreference `(["'])(.*?)\1`.
+
+### Decisions Made
+- Deferred `shadow-sm` → `shadow-xs` migration (83 occurrences, 43 files): semantic shift, every shadow gets one tier larger; needs side-by-side visual review before flipping.
+- Deferred `outline-none` migration (18 occurrences, 6 files): in v4 it actually removes outlines (was no-op in v3); accessibility risk for keyboard users, needs per-case decision (`outline-hidden` vs `focus-visible:ring-*`).
+- Discarded `projects.generated.json` from both PR commits per CLAUDE.md "stage explicitly" rule — it regenerates on every build with timestamp drift.
+
+### Immediate Next Steps
+- [ ] `shadow-sm` → `shadow-xs` migration with side-by-side visual review (83 sites).
+- [ ] `outline-none` accessibility audit per-case across 6 files.
+- [ ] HowTo schema on `/messenger-assistant/` or `/voice-agent/` ("How to add an AI assistant in 3 steps") — Low-priority tech debt #4.
+- [ ] Port GSC/IndexNow scripts to voice.cushlabs.ai repo.
+
+### Technical Debt
+- `shadow-sm` semantic drift not yet addressed (deferred from PR #92).
+- `outline-none` accessibility risk not yet addressed (deferred from PR #92).
+- HowTo schema still missing site-wide.
+
+### Open Questions / Blockers
+- None.
+
+---
+
 ## Session: 2026-05-09
 
 ### Accomplished

--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     "audit:predeploy": "tsx scripts/audit-predeploy.ts",
     "audit:portfolio": "tsx scripts/audit-portfolio.ts",
     "generate:skills": "tsx scripts/generate-skills.ts",
-    "seo:indexnow": "node scripts/seo/indexnow-submit.mjs"
+    "seo:indexnow": "node scripts/seo/indexnow-submit.mjs",
+    "seo:gsc": "node scripts/seo/gsc-submit-urls.mjs --sitemap",
+    "seo:gsc:url": "node scripts/seo/gsc-submit-urls.mjs --url",
+    "seo:submit": "npm run seo:indexnow && npm run seo:gsc"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.8",

--- a/scripts/seo/gsc-client.mjs
+++ b/scripts/seo/gsc-client.mjs
@@ -1,0 +1,98 @@
+/**
+ * Google Search Console API Client — CushLabs
+ *
+ * Authenticated access to GSC for:
+ * - Submitting sitemaps
+ * - Inspecting URL index status
+ * - Pulling search performance data
+ *
+ * Credentials: GOOGLE_SA_KEY_BASE64 in .env.local (base64-encoded service-account JSON).
+ * Service account: seo-api-access@cushlabs-seo.iam.gserviceaccount.com
+ *
+ * The service account must be added as Owner on the GSC property
+ * (sc-domain:cushlabs.ai) via Search Console → Settings → Users and permissions.
+ */
+
+import { google } from 'googleapis';
+import { config as loadEnv } from 'dotenv';
+
+// Load .env.local first (overrides), then .env (fallback). Mirrors how the
+// rest of the build pipeline reads secrets.
+loadEnv({ path: '.env.local', override: true });
+loadEnv({ path: '.env' });
+
+export const SITE_URL = 'https://www.cushlabs.ai';
+export const SITE_PROPERTY = 'sc-domain:cushlabs.ai';
+export const SITE_PROPERTY_URL = 'https://www.cushlabs.ai/';
+
+function decodeCredentials() {
+  const b64 = process.env.GOOGLE_SA_KEY_BASE64;
+  if (!b64) {
+    throw new Error(
+      'GOOGLE_SA_KEY_BASE64 is not set. Add the base64-encoded service-account JSON to .env.local.'
+    );
+  }
+  try {
+    return JSON.parse(Buffer.from(b64, 'base64').toString('utf-8'));
+  } catch (err) {
+    throw new Error(
+      `Failed to decode GOOGLE_SA_KEY_BASE64: ${err.message}. ` +
+      `Verify the value is a single-line base64 of a valid service-account JSON.`
+    );
+  }
+}
+
+let _authClient = null;
+
+export async function getAuthClient() {
+  if (_authClient) return _authClient;
+
+  const credentials = decodeCredentials();
+  const auth = new google.auth.GoogleAuth({
+    credentials,
+    scopes: [
+      'https://www.googleapis.com/auth/webmasters',
+      'https://www.googleapis.com/auth/webmasters.readonly',
+      'https://www.googleapis.com/auth/indexing',
+    ],
+  });
+  _authClient = await auth.getClient();
+  return _authClient;
+}
+
+export async function getSearchConsole() {
+  const auth = await getAuthClient();
+  return google.searchconsole({ version: 'v1', auth });
+}
+
+export async function getWebmasters() {
+  const auth = await getAuthClient();
+  return google.webmasters({ version: 'v3', auth });
+}
+
+export async function detectSiteProperty() {
+  const webmasters = await getWebmasters();
+  try {
+    const res = await webmasters.sites.list();
+    const sites = res.data.siteEntry || [];
+    console.log('Available GSC properties:');
+    sites.forEach((s) => console.log(`  - ${s.siteUrl} (${s.permissionLevel})`));
+
+    const match = sites.find(
+      (s) => s.siteUrl === SITE_PROPERTY || s.siteUrl === SITE_PROPERTY_URL
+    );
+    if (match) {
+      console.log(`\nUsing property: ${match.siteUrl}`);
+      return match.siteUrl;
+    }
+    console.log(
+      `\n${SITE_PROPERTY} not found. ` +
+      `The service account must be added as Owner on the GSC property ` +
+      `via Search Console → Settings → Users and permissions.`
+    );
+    return null;
+  } catch (err) {
+    console.error('Error listing sites:', err.message);
+    return null;
+  }
+}

--- a/scripts/seo/gsc-submit-urls.mjs
+++ b/scripts/seo/gsc-submit-urls.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * Submit URLs / sitemap to Google for indexing — CushLabs
+ *
+ * Usage:
+ *   node scripts/seo/gsc-submit-urls.mjs --sitemap             # Submit sitemap
+ *   node scripts/seo/gsc-submit-urls.mjs --url https://...     # Submit single URL
+ *   node scripts/seo/gsc-submit-urls.mjs --url https://... --removed  # Notify URL removed
+ *   node scripts/seo/gsc-submit-urls.mjs --all                 # Submit all pages from sitemap XML
+ */
+
+import { google } from 'googleapis';
+import { getAuthClient, getWebmasters, detectSiteProperty, SITE_URL } from './gsc-client.mjs';
+
+const args = process.argv.slice(2);
+const singleUrl = args.includes('--url') ? args[args.indexOf('--url') + 1] : null;
+const submitSitemap = args.includes('--sitemap');
+const submitAll = args.includes('--all');
+const isRemoved = args.includes('--removed');
+
+async function submitToIndexingAPI(url, type = 'URL_UPDATED') {
+  const auth = await getAuthClient();
+  const indexing = google.indexing({ version: 'v3', auth });
+
+  try {
+    const res = await indexing.urlNotifications.publish({
+      requestBody: { url, type },
+    });
+    console.log(`  ✓ ${url} → ${res.data.urlNotificationMetadata?.latestUpdate?.type || 'submitted'}`);
+    return true;
+  } catch (err) {
+    const msg = err.response?.data?.error?.message || err.message;
+    console.log(`  ✗ ${url} → ${msg}`);
+    return false;
+  }
+}
+
+async function submitSitemapToGSC() {
+  const siteUrl = await detectSiteProperty();
+  if (!siteUrl) return;
+
+  const webmasters = await getWebmasters();
+  const sitemapUrl = `${SITE_URL}/sitemap-index.xml`;
+
+  try {
+    await webmasters.sitemaps.submit({ siteUrl, feedpath: sitemapUrl });
+    console.log(`✓ Sitemap submitted: ${sitemapUrl}`);
+  } catch (err) {
+    console.error(`✗ Sitemap submission failed: ${err.message}`);
+  }
+
+  try {
+    const res = await webmasters.sitemaps.list({ siteUrl });
+    const sitemaps = res.data.sitemap || [];
+    if (sitemaps.length) {
+      console.log('\nRegistered sitemaps:');
+      for (const sm of sitemaps) {
+        console.log(`  - ${sm.path} (${sm.lastSubmitted || 'never'}) errors: ${sm.errors || 0}`);
+      }
+    }
+  } catch (err) {
+    console.error('Could not list sitemaps:', err.message);
+  }
+}
+
+async function getAllSitemapUrls() {
+  // Fetch sitemap index, then each child sitemap
+  const indexUrl = `${SITE_URL}/sitemap-index.xml`;
+  const urls = [];
+
+  try {
+    const indexRes = await fetch(indexUrl);
+    const indexXml = await indexRes.text();
+
+    // Extract sitemap URLs from index
+    const sitemapUrls = [...indexXml.matchAll(/<loc>([^<]+)<\/loc>/g)].map(m => m[1]);
+
+    for (const smUrl of sitemapUrls) {
+      const smRes = await fetch(smUrl);
+      const smXml = await smRes.text();
+      const pageUrls = [...smXml.matchAll(/<loc>([^<]+)<\/loc>/g)].map(m => m[1]);
+      urls.push(...pageUrls);
+    }
+  } catch (err) {
+    console.error(`Failed to fetch sitemap: ${err.message}`);
+  }
+
+  return urls;
+}
+
+async function main() {
+  console.log('Google URL Submission Tool — CushLabs\n');
+
+  if (submitSitemap) {
+    await submitSitemapToGSC();
+    return;
+  }
+
+  if (singleUrl) {
+    const type = isRemoved ? 'URL_DELETED' : 'URL_UPDATED';
+    console.log(`Submitting ${singleUrl} (${type})...`);
+    await submitToIndexingAPI(singleUrl, type);
+    return;
+  }
+
+  if (submitAll) {
+    const urls = await getAllSitemapUrls();
+    console.log(`Found ${urls.length} URLs in sitemap.\n`);
+
+    let success = 0, failed = 0;
+    for (const url of urls) {
+      const ok = await submitToIndexingAPI(url);
+      if (ok) success++;
+      else failed++;
+      await new Promise(r => setTimeout(r, 100));
+    }
+    console.log(`\nDone: ${success} submitted, ${failed} failed`);
+    return;
+  }
+
+  console.log('Usage:');
+  console.log('  --sitemap        Submit sitemap to GSC');
+  console.log('  --url <url>      Submit single URL');
+  console.log('  --all            Submit all URLs from sitemap');
+  console.log('  --removed        (with --url) Notify URL removed');
+}
+
+main();


### PR DESCRIPTION
## Summary
- Restores GSC sitemap/URL submission scripts (deleted in d865f97 with the incorrect rationale that IndexNow handles Bing passively).
- Replaces the previous file-on-disk credentials approach with the project-standard dotenv pattern: a single base64-encoded env var (`GOOGLE_SA_KEY_BASE64`) in `.env.local`.
- Adds npm scripts so submission is one command: `npm run seo:gsc` (sitemap), `npm run seo:gsc:url <url>` (single URL), `npm run seo:submit` (IndexNow + GSC together).

## Why env-decoded over a JSON file
- Mirrors how every other secret in this repo lives (Brevo, Cloudflare DNS, Sentry, etc.).
- Avoids credential files cluttering the repo root and the failure mode of accidentally committing the JSON.
- Single base64 round-trip sidesteps the `private_key` newline-escaping footgun that breaks the separate-fields dotenv layout.

## Verified
- `GOOGLE_SA_KEY_BASE64` decodes cleanly (3144 chars on disk).
- `GoogleAuth` instantiates without error.
- `webmasters.sites.list()` returns 200 (auth confirmed end-to-end).
- The list is currently empty only because the service account hasn't been granted Owner on `sc-domain:cushlabs.ai` yet (manual Search Console step, blocked on Google's user-lookup propagation lag after service account creation).

## Manual follow-up (already in flight)
Add `seo-api-access@cushlabs-seo.iam.gserviceaccount.com` as Owner on the cushlabs.ai property in Search Console. Retry in 5–10 min if "email not found" persists.

Once granted, run `npm run seo:gsc` to submit the sitemap; the script will log the available properties, submit the sitemap, and report success/last-submitted timestamp.

## Test plan
- [ ] Merge → service account permission propagates → `npm run seo:gsc` returns 200 OK and sitemap shows in Search Console
- [ ] Confirm `https://www.cushlabs.ai/sitemap-index.xml` appears in GSC Sitemaps panel with submitted timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)