### PR TITLE
chore(tw4): shadow-xs, outline-hidden, Dependabot CVE sweep

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"6c51259f-5b1c-425c-81cf-cc5b379927b5","pid":36920,"procStart":"639139499952398730","acquiredAt":1778602992537}

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,12 +63,12 @@
       "license": "MIT"
     },
     "node_modules/@astrojs/internal-helpers": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.8.0.tgz",
-      "integrity": "sha512-J56GrhEiV+4dmrGLPNOl2pZjpHXAndWVyiVDYGDuw6MWKpBSEMLdFxHzeM/6sqaknw9M+HFfHZAcvi3OfT3D/w==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.9.1.tgz",
+      "integrity": "sha512-1pWuARqYom/TzuU3+0ZugsTrKlUydWKuULmDqSMTuonY+9IRDUEGKX/8PXQ1nBxRq3w85uGtd9q9SXfqEldMIQ==",
       "license": "MIT",
       "dependencies": {
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       }
     },
     "node_modules/@astrojs/language-server": {
@@ -113,13 +113,13 @@
       }
     },
     "node_modules/@astrojs/markdown-remark": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.1.0.tgz",
-      "integrity": "sha512-P+HnCsu2js3BoTc8kFmu+E9gOcFeMdPris75g+Zl4sY8+bBRbSQV6xzcBDbZ27eE7yBGEGQoqjpChx+KJYIPYQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.1.2.tgz",
+      "integrity": "sha512-caXZ4Dc2St2dW8luEg22GlP0gupLdztCTQE4EzZOxW1pqWXz9mbeJEuHUkgDYcKWW8tjIHkydYDhWLVoxJ327Q==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.8.0",
-        "@astrojs/prism": "4.0.1",
+        "@astrojs/internal-helpers": "0.9.1",
+        "@astrojs/prism": "4.0.2",
         "github-slugger": "^2.0.0",
         "hast-util-from-html": "^2.0.3",
         "hast-util-to-text": "^4.0.2",
@@ -142,9 +142,9 @@
       }
     },
     "node_modules/@astrojs/prism": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-4.0.1.tgz",
-      "integrity": "sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-4.0.2.tgz",
+      "integrity": "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==",
       "license": "MIT",
       "dependencies": {
         "prismjs": "^1.30.0"
@@ -165,13 +165,12 @@
       }
     },
     "node_modules/@astrojs/telemetry": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.1.tgz",
-      "integrity": "sha512-7fcIxXS9J4ls5tr8b3ww9rbAIz2+HrhNJYZdkAhhB4za/I5IZ/60g+Bs8q7zwG0tOIZfNB4JWhVJ1Qkl/OrNCw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.2.tgz",
+      "integrity": "sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ==",
       "license": "MIT",
       "dependencies": {
         "ci-info": "^4.4.0",
-        "dlv": "^1.1.3",
         "dset": "^3.1.4",
         "is-docker": "^4.0.0",
         "is-wsl": "^3.1.1",
@@ -6286,15 +6285,15 @@
       "license": "MIT"
     },
     "node_modules/astro": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.8.tgz",
-      "integrity": "sha512-6fT9M12U3fpi13DiPavNKDIoBflASTSxmKTEe+zXhWtlebQuOqfOnIrMWyRmlXp+mgDsojmw+fVFG9LUTzKSog==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.3.5.tgz",
+      "integrity": "sha512-gU+4KedkbTuVgz7YoVAN+9Ftnq0GaYwejxK2NbqDzB0M9dWd0f3kXZBuaM9hzbchRFoRAJfJjFtdX9LK6Ir7ZA==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/compiler": "^3.0.1",
-        "@astrojs/internal-helpers": "0.8.0",
-        "@astrojs/markdown-remark": "7.1.0",
-        "@astrojs/telemetry": "3.3.1",
+        "@astrojs/compiler": "^4.0.0",
+        "@astrojs/internal-helpers": "0.9.1",
+        "@astrojs/markdown-remark": "7.1.2",
+        "@astrojs/telemetry": "3.3.2",
         "@capsizecss/unpack": "^4.0.0",
         "@clack/prompts": "^1.1.0",
         "@oslojs/encoding": "^1.1.0",
@@ -6312,10 +6311,12 @@
         "esbuild": "^0.27.3",
         "flattie": "^1.1.1",
         "fontace": "~0.4.1",
+        "get-tsconfig": "5.0.0-beta.4",
         "github-slugger": "^2.0.0",
         "html-escaper": "3.0.3",
         "http-cache-semantics": "^4.2.0",
         "js-yaml": "^4.1.1",
+        "jsonc-parser": "^3.3.1",
         "magic-string": "^0.30.21",
         "magicast": "^0.5.2",
         "mrmime": "^2.0.1",
@@ -6325,7 +6326,7 @@
         "p-queue": "^9.1.0",
         "package-manager-detector": "^1.6.0",
         "piccolore": "^0.1.3",
-        "picomatch": "^4.0.3",
+        "picomatch": "^4.0.4",
         "rehype": "^13.0.2",
         "semver": "^7.7.4",
         "shiki": "^4.0.2",
@@ -6334,13 +6335,12 @@
         "tinyclip": "^0.1.12",
         "tinyexec": "^1.0.4",
         "tinyglobby": "^0.2.15",
-        "tsconfck": "^3.1.6",
         "ultrahtml": "^1.6.0",
         "unifont": "~0.7.4",
         "unist-util-visit": "^5.1.0",
-        "unstorage": "^1.17.4",
+        "unstorage": "^1.17.5",
         "vfile": "^6.0.3",
-        "vite": "^7.3.1",
+        "vite": "^7.3.2",
         "vitefu": "^1.1.2",
         "xxhash-wasm": "^1.1.0",
         "yargs-parser": "^22.0.0",
@@ -6416,9 +6416,30 @@
       }
     },
     "node_modules/astro/node_modules/@astrojs/compiler": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-3.0.1.tgz",
-      "integrity": "sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-4.0.0.tgz",
+      "integrity": "sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==",
+      "license": "MIT"
+    },
+    "node_modules/astro/node_modules/get-tsconfig": {
+      "version": "5.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-5.0.0-beta.4.tgz",
+      "integrity": "sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20.20.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/astro/node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "license": "MIT"
     },
     "node_modules/astro/node_modules/semver": {
@@ -6587,9 +6608,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -7264,9 +7285,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
-      "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -7290,12 +7311,6 @@
       "engines": {
         "node": ">=0.3.1"
       }
-    },
-    "node_modules/dlv": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "license": "MIT"
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -8220,9 +8235,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -11415,18 +11430,18 @@
       "license": "MIT"
     },
     "node_modules/oniguruma-parser": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
-      "integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
       "license": "MIT"
     },
     "node_modules/oniguruma-to-es": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.5.tgz",
-      "integrity": "sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
       "license": "MIT",
       "dependencies": {
-        "oniguruma-parser": "^0.12.1",
+        "oniguruma-parser": "^0.12.2",
         "regex": "^6.1.0",
         "regex-recursion": "^6.0.2"
       }
@@ -12217,7 +12232,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -13123,26 +13137,6 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
-      }
-    },
-    "node_modules/tsconfck": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
-      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
-      "license": "MIT",
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "SEE LICENSE IN LICENSE",
   "scripts": {
     "dev": "astro dev",
-    "build": "npm run generate-projects && astro build",
+    "build": "npm run generate-projects && astro build && node scripts/seo/meta-description-gate.mjs",
     "start": "astro preview",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",

--- a/scripts/seo/meta-description-gate.mjs
+++ b/scripts/seo/meta-description-gate.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DIST = path.resolve(__dirname, "../../dist");
+const MIN = 120;
+const MAX = 160;
+
+const EXCLUDE_PREFIXES = ["dev/docs/", "admin/"];
+const EXCLUDE_FILES = new Set(["index.html", "404.html"]);
+
+const META_RE =
+  /<meta\s+[^>]*name=["']description["'][^>]*content=(?:"([^"]*)"|'([^']*)')[^>]*>/i;
+
+function walk(dir) {
+  const out = [];
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) out.push(...walk(full));
+    else if (e.isFile() && e.name.endsWith(".html")) out.push(full);
+  }
+  return out;
+}
+
+if (!fs.existsSync(DIST)) {
+  console.error(`meta-description-gate: dist/ not found at ${DIST}`);
+  process.exit(1);
+}
+
+const files = walk(DIST);
+const tooLong = [];
+const tooShort = [];
+let checked = 0;
+let missing = 0;
+let excluded = 0;
+
+for (const file of files) {
+  const rel = path.relative(DIST, file).replace(/\\/g, "/");
+  if (
+    EXCLUDE_FILES.has(rel) ||
+    EXCLUDE_PREFIXES.some((p) => rel.startsWith(p))
+  ) {
+    excluded++;
+    continue;
+  }
+  const html = fs.readFileSync(file, "utf8");
+  const m = html.match(META_RE);
+  if (!m) {
+    missing++;
+    continue;
+  }
+  const desc = (m[1] ?? m[2] ?? "").trim();
+  const len = desc.length;
+  checked++;
+  if (len > MAX) tooLong.push({ rel, len, desc });
+  else if (len < MIN) tooShort.push({ rel, len, desc });
+}
+
+console.log(
+  `meta-description-gate: ${checked} pages checked, ${tooShort.length} too short (FAIL), ${tooLong.length} too long (FAIL), ${missing} missing meta, ${excluded} excluded`,
+);
+
+const failed = tooShort.length + tooLong.length;
+
+if (tooShort.length > 0) {
+  console.error(
+    `\n❌ FAIL — ${tooShort.length} pages with description < ${MIN} chars:`,
+  );
+  for (const v of tooShort) {
+    console.error(`  /${v.rel} (${v.len} chars)`);
+    console.error(`    "${v.desc}"`);
+  }
+}
+
+if (tooLong.length > 0) {
+  console.error(
+    `\n❌ FAIL — ${tooLong.length} pages with description > ${MAX} chars:`,
+  );
+  for (const v of tooLong) {
+    console.error(`  /${v.rel} (${v.len} chars)`);
+    console.error(`    "${v.desc}"`);
+  }
+}
+
+if (failed === 0) {
+  console.log(
+    `\n✅ PASS — all ${checked} pages have descriptions between ${MIN}-${MAX} chars`,
+  );
+  process.exit(0);
+}
+
+console.error(
+  `\n🚫 FIX REQUIRED — adjust ${failed} meta description(s) to be ${MIN}-${MAX} characters before deploying.`,
+);
+process.exit(1);

--- a/src/components/ConsultationBookingFlow.astro
+++ b/src/components/ConsultationBookingFlow.astro
@@ -208,7 +208,7 @@ const bookingStrings = {
                   type="text"
                   autocomplete="name"
                   required
-                  class="mt-2 w-full rounded-xl border border-border bg-canvas/40 px-4 py-3 text-sm text-foreground placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-cush-orange/40"
+                  class="mt-2 w-full rounded-xl border border-border bg-canvas/40 px-4 py-3 text-sm text-foreground placeholder:text-muted focus:outline-hidden focus:ring-2 focus:ring-cush-orange/40"
                 />
               </div>
               <div>
@@ -224,7 +224,7 @@ const bookingStrings = {
                   type="email"
                   autocomplete="email"
                   required
-                  class="mt-2 w-full rounded-xl border border-border bg-canvas/40 px-4 py-3 text-sm text-foreground placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-cush-orange/40"
+                  class="mt-2 w-full rounded-xl border border-border bg-canvas/40 px-4 py-3 text-sm text-foreground placeholder:text-muted focus:outline-hidden focus:ring-2 focus:ring-cush-orange/40"
                 />
               </div>
             </div>
@@ -245,7 +245,7 @@ const bookingStrings = {
                 type="tel"
                 autocomplete="tel"
                 aria-describedby="phone-hint"
-                class="mt-2 w-full rounded-xl border border-border bg-canvas/40 px-4 py-3 text-sm text-foreground placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-cush-orange/40"
+                class="mt-2 w-full rounded-xl border border-border bg-canvas/40 px-4 py-3 text-sm text-foreground placeholder:text-muted focus:outline-hidden focus:ring-2 focus:ring-cush-orange/40"
               />
             </div>
 
@@ -285,7 +285,7 @@ const bookingStrings = {
                 name="notes"
                 rows={6}
                 aria-describedby="notes-hint"
-                class="mt-2 w-full rounded-xl border border-border bg-canvas/40 px-4 py-3 text-sm text-foreground placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-cush-orange/40"
+                class="mt-2 w-full rounded-xl border border-border bg-canvas/40 px-4 py-3 text-sm text-foreground placeholder:text-muted focus:outline-hidden focus:ring-2 focus:ring-cush-orange/40"
               ></textarea>
             </div>
 

--- a/src/components/booking/BookingFormSteps.astro
+++ b/src/components/booking/BookingFormSteps.astro
@@ -112,7 +112,7 @@ const b = dict.booking;
             name="fullName"
             required
             autocomplete="name"
-            class="w-full rounded-xl border border-border bg-canvas/40 px-4 py-3 text-sm text-foreground placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-cush-orange/40"
+            class="w-full rounded-xl border border-border bg-canvas/40 px-4 py-3 text-sm text-foreground placeholder:text-muted focus:outline-hidden focus:ring-2 focus:ring-cush-orange/40"
           />
         </div>
 
@@ -126,7 +126,7 @@ const b = dict.booking;
             name="email"
             required
             autocomplete="email"
-            class="w-full rounded-xl border border-border bg-canvas/40 px-4 py-3 text-sm text-foreground placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-cush-orange/40"
+            class="w-full rounded-xl border border-border bg-canvas/40 px-4 py-3 text-sm text-foreground placeholder:text-muted focus:outline-hidden focus:ring-2 focus:ring-cush-orange/40"
           />
         </div>
 
@@ -139,7 +139,7 @@ const b = dict.booking;
             id="booking-phone"
             name="phone"
             autocomplete="tel"
-            class="w-full rounded-xl border border-border bg-canvas/40 px-4 py-3 text-sm text-foreground placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-cush-orange/40"
+            class="w-full rounded-xl border border-border bg-canvas/40 px-4 py-3 text-sm text-foreground placeholder:text-muted focus:outline-hidden focus:ring-2 focus:ring-cush-orange/40"
           />
           <p class="text-sm text-muted mt-2">{b.phoneHint}</p>
         </div>
@@ -153,7 +153,7 @@ const b = dict.booking;
             name="notes"
             rows="3"
             placeholder={b.notesPlaceholder}
-            class="w-full rounded-xl border border-border bg-canvas/40 px-4 py-3 text-sm text-foreground placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-cush-orange/40 resize-none"
+            class="w-full rounded-xl border border-border bg-canvas/40 px-4 py-3 text-sm text-foreground placeholder:text-muted focus:outline-hidden focus:ring-2 focus:ring-cush-orange/40 resize-none"
           ></textarea>
           <p class="text-sm text-muted mt-2">{b.notesHint}</p>
         </div>

--- a/src/components/home/Results.astro
+++ b/src/components/home/Results.astro
@@ -64,7 +64,7 @@ const t = content[locale];
 
     <!-- Featured Testimonial -->
     <div class="max-w-3xl mx-auto">
-      <div class="relative p-8 rounded-2xl bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 shadow-sm">
+      <div class="relative p-8 rounded-2xl bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 shadow-xs">
         <!-- Quote mark -->
         <svg class="absolute top-4 left-4 w-8 h-8 text-cush-orange/20" fill="currentColor" viewBox="0 0 24 24">
           <path d="M14.017 21v-7.391c0-5.704 3.731-9.57 8.983-10.609l.995 2.151c-2.432.917-3.995 3.638-3.995 5.849h4v10h-9.983zm-14.017 0v-7.391c0-5.704 3.748-9.57 9-10.609l.996 2.151c-2.433.917-3.996 3.638-3.996 5.849h3.983v10h-9.983z" />

--- a/src/components/home2/HowItWorks.astro
+++ b/src/components/home2/HowItWorks.astro
@@ -62,7 +62,7 @@ const t = content[locale];
       {t.steps.map((step, index) => (
         <div class={`relative flex items-center justify-between md:justify-normal md:odd:flex-row-reverse group border md:border-none border-gray-100 dark:border-gray-800 rounded-xl p-6 md:p-0 ${index % 2 === 0 ? 'md:pr-[50%]' : 'md:pl-[50%]'}`}>
           <!-- Marker -->
-          <div class="flex items-center justify-center w-10 h-10 rounded-full border-4 border-white dark:border-black bg-cush-orange/20 text-cush-orange font-bold font-display shadow-sm group-hover:bg-cush-orange group-hover:text-white transition-colors duration-300 z-10 
+          <div class="flex items-center justify-center w-10 h-10 rounded-full border-4 border-white dark:border-black bg-cush-orange/20 text-cush-orange font-bold font-display shadow-xs group-hover:bg-cush-orange group-hover:text-white transition-colors duration-300 z-10 
             absolute left-0 top-6 md:static md:left-auto md:top-auto
             md:absolute md:left-1/2 md:-translate-x-1/2">
             {index + 1}

--- a/src/components/services2/FAQ.astro
+++ b/src/components/services2/FAQ.astro
@@ -100,7 +100,7 @@ const t = content[locale];
         <details class="group bg-gray-50 dark:bg-gray-900/50 rounded-xl border border-gray-200 dark:border-gray-800 [&_summary::-webkit-details-marker]:hidden">
           <summary class="flex items-center justify-between cursor-pointer p-6 md:p-8 font-display font-semibold text-lg text-gray-900 dark:text-white mb-0">
             {faq.q}
-            <span class="ml-6 shrink-0 bg-white dark:bg-black p-2 rounded-full shadow-sm text-cush-orange transition-transform duration-300 group-open:rotate-180">
+            <span class="ml-6 shrink-0 bg-white dark:bg-black p-2 rounded-full shadow-xs text-cush-orange transition-transform duration-300 group-open:rotate-180">
               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
               </svg>

--- a/src/components/services2/InvestmentOverview.astro
+++ b/src/components/services2/InvestmentOverview.astro
@@ -151,7 +151,7 @@ const t = content[locale];
       </div>
 
       <!-- Voice Agent Card -->
-      <div class="relative bg-white dark:bg-black rounded-2xl border border-gray-200 dark:border-gray-800 shadow-sm p-8 md:p-10 flex flex-col">
+      <div class="relative bg-white dark:bg-black rounded-2xl border border-gray-200 dark:border-gray-800 shadow-xs p-8 md:p-10 flex flex-col">
         <div class="absolute -top-4 left-8">
           <span class="inline-block bg-gray-900 dark:bg-gray-700 text-white text-xs font-display font-bold uppercase tracking-wider px-4 py-1.5 rounded-full">
             {t.voiceLabel}

--- a/src/data/projects.generated.json
+++ b/src/data/projects.generated.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-05-06T05:50:01.894Z",
-  "count": 33,
+  "generatedAt": "2026-05-18T17:11:27.291Z",
+  "count": 34,
   "projects": [
     {
       "id": 1108213747,
@@ -44,13 +44,13 @@
       "status": null,
       "language": "TypeScript",
       "languages": {
-        "TypeScript": 1233817,
+        "TypeScript": 1234142,
         "JavaScript": 12530,
         "CSS": 10362
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-05-03T23:46:44Z",
+      "lastPushed": "2026-05-16T20:48:26Z",
       "createdAt": "2025-12-02T07:09:31Z",
       "isFeatured": true,
       "isArchived": false,
@@ -171,7 +171,7 @@
       "status": "Production",
       "language": "TypeScript",
       "languages": {
-        "TypeScript": 990962,
+        "TypeScript": 1038695,
         "JavaScript": 16173,
         "PLpgSQL": 10195,
         "CSS": 8090,
@@ -179,7 +179,7 @@
       },
       "stars": 1,
       "forks": 0,
-      "lastPushed": "2026-05-06T05:31:58Z",
+      "lastPushed": "2026-05-18T16:39:09Z",
       "createdAt": "2025-11-23T00:24:28Z",
       "isFeatured": true,
       "isArchived": false,
@@ -244,6 +244,95 @@
       ],
       "videoUrl": "https://cdn.cushlabs.ai/ny-ai-chatbot/video/ny-eng-chatbot-brief.mp4",
       "videoPoster": "https://cdn.cushlabs.ai/ny-ai-chatbot/video/ny-eng-chatbot-brief-poster.jpg"
+    },
+    {
+      "id": 1232252613,
+      "name": "cushlabs-messenger",
+      "title": "CushLabs Messenger",
+      "description": "AI-powered Facebook Messenger bot platform — bilingual onboarding now, multi-tenant Worker runtime next.",
+      "summary": "> The platform layer for CushLabs' AI-powered Messenger bots — starting with bilingual client onboarding, growing into a multi-tenant bot runtime.",
+      "url": "https://github.com/RCushmaniii/cushlabs-messenger",
+      "demoUrl": "https://cushlabs.ai",
+      "liveUrl": "https://cushlabs-messenger-admin.pages.dev/",
+      "homepage": "https://cushlabs.ai",
+      "topics": [
+        "ai-agents",
+        "bilingual",
+        "cloudflare-workers",
+        "cushlabs",
+        "kv-storage",
+        "messenger-platform",
+        "multi-tenant",
+        "react",
+        "tailwindcss",
+        "typescript"
+      ],
+      "categories": [
+        "AI Automation"
+      ],
+      "tags": [
+        "ai-agents",
+        "bilingual",
+        "cloudflare-workers",
+        "cushlabs",
+        "kv-storage",
+        "messenger-platform",
+        "multi-tenant",
+        "react",
+        "tailwindcss",
+        "typescript",
+        "client-onboarding"
+      ],
+      "stack": [
+        "Cloudflare Workers",
+        "Cloudflare KV",
+        "Cloudflare Pages",
+        "TypeScript (strict)",
+        "Vite",
+        "React 19",
+        "Tailwind 4",
+        "pnpm workspaces",
+        "Wrangler"
+      ],
+      "status": null,
+      "language": "TypeScript",
+      "languages": {
+        "TypeScript": 89532,
+        "JavaScript": 29278,
+        "HTML": 5130,
+        "Python": 3534,
+        "CSS": 2701
+      },
+      "stars": 0,
+      "forks": 0,
+      "lastPushed": "2026-05-17T19:27:43Z",
+      "createdAt": "2026-05-07T18:38:22Z",
+      "isFeatured": true,
+      "isArchived": false,
+      "isPrivate": true,
+      "tagline": "Multi-tenant AI Messenger bot platform — bilingual onboarding now, full Worker runtime next.",
+      "thumbnail": "https://cdn.cushlabs.ai/cushlabs-messenger/docs/social-preview.png",
+      "problem": "Every new Messenger bot client used to mean a fresh Worker deployment, a manual voice-profile email\nexchange, and a fragile ad-hoc configuration step. CushLabs Messenger replaces all three: a single\nbilingual EN/ES survey app captures the client's voice profile in under five minutes, persists it to\nCloudflare KV under the client's Page ID, and feeds directly into the platform's eventual multi-tenant\nWorker runtime. The platform is sized for many clients on one deployment from day one.\n",
+      "solution": null,
+      "keyFeatures": [
+        "Onboarding time per new client cut from days of email back-and-forth to a single CLI command + URL",
+        "Bilingual coverage at the data layer — EN and Mexican Professional Spanish, identical schema",
+        "One Cloudflare Worker deployment serves every client; no per-client infrastructure churn",
+        "Phase 1 primitives (KV namespace, access codes, Worker bindings) carry directly into the Phase 2 bot runtime",
+        "Sub-100ms KV reads at the edge; sub-50ms Worker cold starts globally"
+      ],
+      "metrics": [],
+      "priority": 3,
+      "dateCompleted": null,
+      "slides": [
+        {
+          "src": "https://cdn.cushlabs.ai/cushlabs-messenger/docs/social-preview.png",
+          "altEn": "CushLabs Messenger",
+          "altEs": "CushLabs Messenger"
+        }
+      ],
+      "videoUrl": null,
+      "videoPoster": null
     },
     {
       "id": 1164355422,
@@ -313,13 +402,13 @@
       "language": "HTML",
       "languages": {
         "HTML": 518122,
-        "JavaScript": 118063,
+        "JavaScript": 125063,
         "CSS": 8475,
         "Dockerfile": 358
       },
       "stars": 0,
-      "forks": 0,
-      "lastPushed": "2026-05-04T23:53:22Z",
+      "forks": 1,
+      "lastPushed": "2026-05-12T07:07:55Z",
       "createdAt": "2026-02-23T01:31:09Z",
       "isFeatured": true,
       "isArchived": false,
@@ -468,15 +557,15 @@
       "status": null,
       "language": "TypeScript",
       "languages": {
-        "TypeScript": 714113,
+        "TypeScript": 845138,
+        "JavaScript": 47285,
         "HTML": 29745,
-        "JavaScript": 12961,
-        "CSS": 3586,
-        "Dockerfile": 1126
+        "CSS": 7897,
+        "Dockerfile": 2198
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-05-06T05:29:57Z",
+      "lastPushed": "2026-05-17T19:41:09Z",
       "createdAt": "2026-03-30T19:46:00Z",
       "isFeatured": true,
       "isArchived": false,
@@ -545,150 +634,6 @@
       "videoPoster": "https://cdn.cushlabs.ai/cushlabs-marketsignal/portfolio/marketsignal/brief-poster.webp"
     },
     {
-      "id": 1203303335,
-      "name": "ny-english-messenger-bot",
-      "title": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant",
-      "description": "Bilingual AI assistant for the New York English Facebook page — Claude (Anthropic) on Cloudflare Workers, with RAG over a Qdrant knowledge base and Meta Messenger webhook integration. First deployment of a reusable CushLabs Messenger bot template.",
-      "summary": "> Facebook Messenger AI assistant for the New York English page — bilingual EN/ES customer engagement powered by Claude, RAG, and Cloudflare Workers.",
-      "url": "https://github.com/RCushmaniii/ny-english-messenger-bot",
-      "demoUrl": null,
-      "liveUrl": "",
-      "homepage": null,
-      "topics": [
-        "ai-assistant",
-        "anthropic",
-        "bilingual",
-        "chatbot",
-        "claude",
-        "cloudflare-workers",
-        "facebook-messenger",
-        "messenger-bot",
-        "qdrant",
-        "rag",
-        "typescript",
-        "workers-ai"
-      ],
-      "categories": [
-        "AI Automation"
-      ],
-      "tags": [
-        "ai-assistant",
-        "anthropic",
-        "bilingual",
-        "chatbot",
-        "claude",
-        "cloudflare-workers",
-        "facebook-messenger",
-        "messenger-bot",
-        "qdrant",
-        "rag",
-        "typescript",
-        "workers-ai",
-        "claude-ai",
-        "facebook",
-        "vector-search",
-        "conversational-ai"
-      ],
-      "stack": [
-        "Cloudflare Workers",
-        "TypeScript",
-        "Claude API (Haiku + Sonnet)",
-        "Cloudflare Vectorize (vector search)",
-        "Cloudflare Workers AI (embeddings)",
-        "Cloudflare KV (session state)",
-        "Meta Messenger Platform",
-        "Sentry (error monitoring)"
-      ],
-      "status": "Production",
-      "language": "TypeScript",
-      "languages": {
-        "TypeScript": 192999,
-        "JavaScript": 17589,
-        "PowerShell": 1415,
-        "HTML": 686,
-        "CSS": 323
-      },
-      "stars": 0,
-      "forks": 0,
-      "lastPushed": "2026-05-06T05:03:56Z",
-      "createdAt": "2026-04-06T23:20:56Z",
-      "isFeatured": true,
-      "isArchived": false,
-      "isPrivate": true,
-      "tagline": "Facebook Messenger chatbot that handles student inquiries with Claude AI, RAG-powered answers, and bilingual EN/ES support",
-      "thumbnail": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/thumb.webp",
-      "problem": "Small business owners on Facebook spend hours answering the same customer\nquestions in Messenger — pricing, availability, services, location. For\nbilingual markets like Mexico, they need to handle inquiries in both English\nand Spanish. A human can't be online 24/7, and generic chatbots sound robotic\nand can't answer business-specific questions accurately.\n",
-      "solution": null,
-      "keyFeatures": [
-        "24/7 automated customer engagement on Facebook Messenger",
-        "Bilingual EN/ES support with automatic language detection",
-        "RAG-powered answers grounded in actual business content — not hallucinated",
-        "Seamless human handover when the bot can't help",
-        "Reusable template architecture for deploying to additional Facebook pages"
-      ],
-      "metrics": [],
-      "priority": 5,
-      "dateCompleted": null,
-      "slides": [
-        {
-          "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-01.webp",
-          "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-01.webp",
-          "altEn": "The 24/7 AI Sales Assistant for Facebook Messenger — Built from your content, trained on your business. Made by CushLabs.",
-          "altEs": "El asistente de ventas con IA 24/7 para Facebook Messenger — Creado a partir de tu contenido. Entrenado en tu negocio. Hecho por CushLabs."
-        },
-        {
-          "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-02.webp",
-          "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-02.webp",
-          "altEn": "The problem every business owner knows — your Facebook page gets messages. You catch some. Most you don't.",
-          "altEs": "El problema que todo dueño de negocio conoce — tu página de Facebook recibe mensajes. Algunos los cachas. La mayoría no."
-        },
-        {
-          "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-03.webp",
-          "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-03.webp",
-          "altEn": "Generic auto-replies are a polite way to lose a potential client — the lead decay curve.",
-          "altEs": "Las respuestas automáticas son una forma amable de perder un cliente potencial — la curva de decaimiento de un cliente potencial."
-        },
-        {
-          "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-04.webp",
-          "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-04.webp",
-          "altEn": "What if your inbox answered itself? Introducing the CushLabs AI Messaging Assistant.",
-          "altEs": "¿Qué tal si tu bandeja de entrada se respondiera sola? Presentamos el Asistente de Mensajería AI CushLabs."
-        },
-        {
-          "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-05.webp",
-          "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-05.webp",
-          "altEn": "Never lose a prospect while you sleep — qualified conversations at 8:30 PM, 11:15 PM, 2:00 AM.",
-          "altEs": "Nunca pierdas un prospecto mientras duermes — conversaciones calificadas a las 8:30 PM, 11:15 PM, 2:00 AM."
-        },
-        {
-          "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-06.webp",
-          "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-06.webp",
-          "altEn": "Get your time back and stop repeating yourself — the bot handles FAQs so you only step in when a client is ready to buy.",
-          "altEs": "Recupera tu tiempo y deja de repetirte — el bot responde preguntas frecuentes para que solo intervengas cuando un cliente esté listo para comprar."
-        },
-        {
-          "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-07.webp",
-          "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-07.webp",
-          "altEn": "Speaks their language perfectly and without interruption — native bilingual EN/ES with no manual switching.",
-          "altEs": "Habla su idioma a la perfección y sin interrupciones — bilingüe nativo EN/ES sin cambios manuales."
-        },
-        {
-          "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-08.webp",
-          "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-08.webp",
-          "altEn": "Sells like you, because it's built from you — your website, your FAQs, your methodology, your prices.",
-          "altEs": "Vende como tú, porque está hecho de ti — tu sitio web, tus preguntas frecuentes, tu metodología, tus precios."
-        },
-        {
-          "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-09.webp",
-          "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-09.webp",
-          "altEn": "The math is simple: it pays for itself the first time it converts a client you would have otherwise lost.",
-          "altEs": "La matemática es simple: Se paga solo la primera vez que convierte a un cliente que de otro modo habrías perdido."
-        }
-      ],
-      "videoUrl": null,
-      "videoPoster": null
-    },
-    {
       "id": 953305892,
       "name": "ny-eng",
       "title": "NY English Teacher",
@@ -746,10 +691,10 @@
       "status": "Production",
       "language": "Astro",
       "languages": {
-        "Astro": 2430505,
-        "TypeScript": 2236929,
+        "Astro": 3013379,
+        "TypeScript": 2243321,
         "HTML": 838639,
-        "JavaScript": 407086,
+        "JavaScript": 408372,
         "CSS": 40875,
         "Python": 30138,
         "MDX": 23889,
@@ -757,7 +702,7 @@
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-05-04T23:21:40Z",
+      "lastPushed": "2026-05-18T00:01:14Z",
       "createdAt": "2025-03-23T03:27:14Z",
       "isFeatured": true,
       "isArchived": false,
@@ -839,6 +784,150 @@
       "videoPoster": "https://cdn.cushlabs.ai/ny-eng/video/ny-eng-brief-poster.jpg"
     },
     {
+      "id": 1203303335,
+      "name": "ny-english-messenger-bot",
+      "title": "NY English Messenger Bot — AI-Powered Bilingual Customer Assistant",
+      "description": "Bilingual AI assistant for the New York English Facebook page — Claude (Anthropic) on Cloudflare Workers, with RAG over a Qdrant knowledge base and Meta Messenger webhook integration. First deployment of a reusable CushLabs Messenger bot template.",
+      "summary": "> Facebook Messenger AI assistant for the New York English page — bilingual EN/ES customer engagement powered by Claude, RAG, and Cloudflare Workers.",
+      "url": "https://github.com/RCushmaniii/ny-english-messenger-bot",
+      "demoUrl": null,
+      "liveUrl": "",
+      "homepage": null,
+      "topics": [
+        "ai-assistant",
+        "anthropic",
+        "bilingual",
+        "chatbot",
+        "claude",
+        "cloudflare-workers",
+        "facebook-messenger",
+        "messenger-bot",
+        "qdrant",
+        "rag",
+        "typescript",
+        "workers-ai"
+      ],
+      "categories": [
+        "AI Automation"
+      ],
+      "tags": [
+        "ai-assistant",
+        "anthropic",
+        "bilingual",
+        "chatbot",
+        "claude",
+        "cloudflare-workers",
+        "facebook-messenger",
+        "messenger-bot",
+        "qdrant",
+        "rag",
+        "typescript",
+        "workers-ai",
+        "claude-ai",
+        "facebook",
+        "vector-search",
+        "conversational-ai"
+      ],
+      "stack": [
+        "Cloudflare Workers",
+        "TypeScript",
+        "Claude API (Haiku + Sonnet)",
+        "Cloudflare Vectorize (vector search)",
+        "Cloudflare Workers AI (embeddings)",
+        "Cloudflare KV (session state)",
+        "Meta Messenger Platform",
+        "Sentry (error monitoring)"
+      ],
+      "status": "Production",
+      "language": "TypeScript",
+      "languages": {
+        "TypeScript": 198803,
+        "JavaScript": 19844,
+        "PowerShell": 1415,
+        "HTML": 686,
+        "CSS": 323
+      },
+      "stars": 0,
+      "forks": 0,
+      "lastPushed": "2026-05-12T07:00:56Z",
+      "createdAt": "2026-04-06T23:20:56Z",
+      "isFeatured": true,
+      "isArchived": false,
+      "isPrivate": true,
+      "tagline": "Facebook Messenger chatbot that handles student inquiries with Claude AI, RAG-powered answers, and bilingual EN/ES support",
+      "thumbnail": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/thumb.webp",
+      "problem": "Small business owners on Facebook spend hours answering the same customer\nquestions in Messenger — pricing, availability, services, location. For\nbilingual markets like Mexico, they need to handle inquiries in both English\nand Spanish. A human can't be online 24/7, and generic chatbots sound robotic\nand can't answer business-specific questions accurately.\n",
+      "solution": null,
+      "keyFeatures": [
+        "24/7 automated customer engagement on Facebook Messenger",
+        "Bilingual EN/ES support with automatic language detection",
+        "RAG-powered answers grounded in actual business content — not hallucinated",
+        "Seamless human handover when the bot can't help",
+        "Reusable template architecture for deploying to additional Facebook pages"
+      ],
+      "metrics": [],
+      "priority": 5,
+      "dateCompleted": null,
+      "slides": [
+        {
+          "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-01.webp",
+          "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-01.webp",
+          "altEn": "The 24/7 AI Sales Assistant for Facebook Messenger — Built from your content, trained on your business. Made by CushLabs.",
+          "altEs": "El asistente de ventas con IA 24/7 para Facebook Messenger — Creado a partir de tu contenido. Entrenado en tu negocio. Hecho por CushLabs."
+        },
+        {
+          "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-02.webp",
+          "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-02.webp",
+          "altEn": "The problem every business owner knows — your Facebook page gets messages. You catch some. Most you don't.",
+          "altEs": "El problema que todo dueño de negocio conoce — tu página de Facebook recibe mensajes. Algunos los cachas. La mayoría no."
+        },
+        {
+          "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-03.webp",
+          "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-03.webp",
+          "altEn": "Generic auto-replies are a polite way to lose a potential client — the lead decay curve.",
+          "altEs": "Las respuestas automáticas son una forma amable de perder un cliente potencial — la curva de decaimiento de un cliente potencial."
+        },
+        {
+          "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-04.webp",
+          "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-04.webp",
+          "altEn": "What if your inbox answered itself? Introducing the CushLabs AI Messaging Assistant.",
+          "altEs": "¿Qué tal si tu bandeja de entrada se respondiera sola? Presentamos el Asistente de Mensajería AI CushLabs."
+        },
+        {
+          "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-05.webp",
+          "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-05.webp",
+          "altEn": "Never lose a prospect while you sleep — qualified conversations at 8:30 PM, 11:15 PM, 2:00 AM.",
+          "altEs": "Nunca pierdas un prospecto mientras duermes — conversaciones calificadas a las 8:30 PM, 11:15 PM, 2:00 AM."
+        },
+        {
+          "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-06.webp",
+          "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-06.webp",
+          "altEn": "Get your time back and stop repeating yourself — the bot handles FAQs so you only step in when a client is ready to buy.",
+          "altEs": "Recupera tu tiempo y deja de repetirte — el bot responde preguntas frecuentes para que solo intervengas cuando un cliente esté listo para comprar."
+        },
+        {
+          "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-07.webp",
+          "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-07.webp",
+          "altEn": "Speaks their language perfectly and without interruption — native bilingual EN/ES with no manual switching.",
+          "altEs": "Habla su idioma a la perfección y sin interrupciones — bilingüe nativo EN/ES sin cambios manuales."
+        },
+        {
+          "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-08.webp",
+          "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-08.webp",
+          "altEn": "Sells like you, because it's built from you — your website, your FAQs, your methodology, your prices.",
+          "altEs": "Vende como tú, porque está hecho de ti — tu sitio web, tus preguntas frecuentes, tu metodología, tus precios."
+        },
+        {
+          "src": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-en-09.webp",
+          "srcEs": "https://cdn.cushlabs.ai/ny-english-messenger-bot/public/images/hero-es-09.webp",
+          "altEn": "The math is simple: it pays for itself the first time it converts a client you would have otherwise lost.",
+          "altEs": "La matemática es simple: Se paga solo la primera vez que convierte a un cliente que de otro modo habrías perdido."
+        }
+      ],
+      "videoUrl": null,
+      "videoPoster": null
+    },
+    {
       "id": 1174690198,
       "name": "biojalisco-species-id",
       "title": "BioJalisco Species Identifier",
@@ -902,7 +991,7 @@
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-04-30T18:41:04Z",
+      "lastPushed": "2026-05-12T06:59:36Z",
       "createdAt": "2026-03-06T18:20:23Z",
       "isFeatured": true,
       "isArchived": false,
@@ -1169,7 +1258,7 @@
       },
       "stars": 2,
       "forks": 0,
-      "lastPushed": "2026-05-04T21:00:10Z",
+      "lastPushed": "2026-05-17T10:32:59Z",
       "createdAt": "2025-12-20T10:31:00Z",
       "isFeatured": false,
       "isArchived": false,
@@ -1307,7 +1396,7 @@
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-04-30T02:11:42Z",
+      "lastPushed": "2026-05-14T21:46:58Z",
       "createdAt": "2026-03-06T17:57:40Z",
       "isFeatured": false,
       "isArchived": false,
@@ -1690,7 +1779,7 @@
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-05-03T15:03:26Z",
+      "lastPushed": "2026-05-17T15:03:50Z",
       "createdAt": "2026-03-04T22:07:57Z",
       "isFeatured": false,
       "isArchived": false,
@@ -1830,7 +1919,7 @@
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-04-13T23:11:18Z",
+      "lastPushed": "2026-05-12T05:26:17Z",
       "createdAt": "2026-01-25T01:59:32Z",
       "isFeatured": false,
       "isArchived": false,
@@ -1931,7 +2020,7 @@
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-05-03T05:43:01Z",
+      "lastPushed": "2026-05-17T05:42:51Z",
       "createdAt": "2026-03-08T19:31:57Z",
       "isFeatured": false,
       "isArchived": false,
@@ -2078,7 +2167,7 @@
       },
       "stars": 0,
       "forks": 1,
-      "lastPushed": "2026-04-11T01:54:06Z",
+      "lastPushed": "2026-05-12T10:15:20Z",
       "createdAt": "2026-02-13T18:42:29Z",
       "isFeatured": false,
       "isArchived": false,
@@ -2215,9 +2304,9 @@
         "CSS": 1968,
         "HTML": 362
       },
-      "stars": 0,
+      "stars": 1,
       "forks": 1,
-      "lastPushed": "2026-04-24T17:16:31Z",
+      "lastPushed": "2026-05-06T18:27:09Z",
       "createdAt": "2026-01-12T02:37:39Z",
       "isFeatured": false,
       "isArchived": false,
@@ -2358,7 +2447,7 @@
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-04-11T21:33:47Z",
+      "lastPushed": "2026-05-12T08:10:40Z",
       "createdAt": "2025-12-11T17:38:35Z",
       "isFeatured": false,
       "isArchived": false,
@@ -2502,7 +2591,7 @@
       },
       "stars": 1,
       "forks": 0,
-      "lastPushed": "2026-04-29T22:32:46Z",
+      "lastPushed": "2026-05-13T18:40:12Z",
       "createdAt": "2026-03-03T07:21:12Z",
       "isFeatured": false,
       "isArchived": false,
@@ -2749,7 +2838,7 @@
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-04-13T23:22:14Z",
+      "lastPushed": "2026-05-12T18:59:34Z",
       "createdAt": "2026-02-13T19:55:19Z",
       "isFeatured": false,
       "isArchived": false,
@@ -2871,16 +2960,16 @@
       "status": null,
       "language": "Astro",
       "languages": {
-        "Astro": 656764,
-        "TypeScript": 336917,
+        "Astro": 657962,
+        "TypeScript": 337061,
+        "JavaScript": 83670,
         "HTML": 61067,
-        "JavaScript": 45645,
         "Python": 6606,
-        "CSS": 4657
+        "CSS": 4655
       },
       "stars": 2,
       "forks": 0,
-      "lastPushed": "2026-05-06T05:40:45Z",
+      "lastPushed": "2026-05-14T21:29:53Z",
       "createdAt": "2026-01-08T03:52:43Z",
       "isFeatured": false,
       "isArchived": false,
@@ -3012,7 +3101,7 @@
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-04-14T00:10:37Z",
+      "lastPushed": "2026-05-12T07:18:29Z",
       "createdAt": "2026-01-05T15:06:48Z",
       "isFeatured": false,
       "isArchived": false,
@@ -3265,7 +3354,7 @@
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-04-27T15:07:53Z",
+      "lastPushed": "2026-05-12T03:03:56Z",
       "createdAt": "2026-01-04T03:47:35Z",
       "isFeatured": false,
       "isArchived": false,
@@ -3507,7 +3596,7 @@
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-05-03T05:52:36Z",
+      "lastPushed": "2026-05-12T22:43:32Z",
       "createdAt": "2026-01-13T22:16:37Z",
       "isFeatured": false,
       "isArchived": false,
@@ -3629,9 +3718,9 @@
         "CSS": 5636,
         "JavaScript": 559
       },
-      "stars": 0,
+      "stars": 1,
       "forks": 0,
-      "lastPushed": "2026-04-10T23:12:31Z",
+      "lastPushed": "2026-05-12T00:24:44Z",
       "createdAt": "2026-01-23T00:50:02Z",
       "isFeatured": false,
       "isArchived": false,
@@ -3759,7 +3848,7 @@
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-05-04T04:58:37Z",
+      "lastPushed": "2026-05-18T05:52:27Z",
       "createdAt": "2026-02-17T04:40:23Z",
       "isFeatured": false,
       "isArchived": false,
@@ -3949,7 +4038,7 @@
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-04-11T21:34:11Z",
+      "lastPushed": "2026-05-12T10:50:46Z",
       "createdAt": "2025-12-18T20:18:05Z",
       "isFeatured": false,
       "isArchived": false,

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -134,7 +134,7 @@ const hero = content[locale];
                   name="name"
                   type="text"
                   required
-                  class="mt-2 w-full rounded-lg border border-border bg-canvas/40 px-3 py-2 text-foreground placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-cush-orange"
+                  class="mt-2 w-full rounded-lg border border-border bg-canvas/40 px-3 py-2 text-foreground placeholder:text-muted focus:outline-hidden focus:ring-2 focus:ring-cush-orange"
                 />
               </div>
 
@@ -151,7 +151,7 @@ const hero = content[locale];
                   name="email"
                   type="email"
                   required
-                  class="mt-2 w-full rounded-lg border border-border bg-canvas/40 px-3 py-2 text-foreground placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-cush-orange"
+                  class="mt-2 w-full rounded-lg border border-border bg-canvas/40 px-3 py-2 text-foreground placeholder:text-muted focus:outline-hidden focus:ring-2 focus:ring-cush-orange"
                 />
               </div>
             </div>
@@ -168,7 +168,7 @@ const hero = content[locale];
                 name="phone"
                 type="tel"
                 placeholder={dict.contact.formPhoneHint}
-                class="mt-2 w-full rounded-lg border border-border bg-canvas/40 px-3 py-2 text-foreground placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-cush-orange"
+                class="mt-2 w-full rounded-lg border border-border bg-canvas/40 px-3 py-2 text-foreground placeholder:text-muted focus:outline-hidden focus:ring-2 focus:ring-cush-orange"
               />
             </div>
 
@@ -186,7 +186,7 @@ const hero = content[locale];
                 required
                 rows={6}
                 placeholder={dict.contact.formMessageHint}
-                class="mt-2 w-full rounded-lg border border-border bg-canvas/40 px-3 py-2 text-foreground placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-cush-orange"
+                class="mt-2 w-full rounded-lg border border-border bg-canvas/40 px-3 py-2 text-foreground placeholder:text-muted focus:outline-hidden focus:ring-2 focus:ring-cush-orange"
               ></textarea>
             </div>
 

--- a/src/pages/data-deletion.astro
+++ b/src/pages/data-deletion.astro
@@ -4,7 +4,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 
 <BaseLayout
   title="Data Deletion Instructions | CushLabs.ai"
-  description="How to request deletion of personal data collected by CushLabs AI Messenger Assistants. We respond within 30 days."
+  description="Request deletion of personal data collected by CushLabs AI Messenger Assistants. Submit via email, WhatsApp, or Messenger. We respond within 30 days."
 >
   <main class="min-h-screen bg-white dark:bg-gray-950">
     <!-- Hero -->

--- a/src/pages/es/contact.astro
+++ b/src/pages/es/contact.astro
@@ -68,22 +68,22 @@ const hero = {
             <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
               <div>
                 <label for="name" class="block text-sm font-display font-semibold text-foreground">{dict.contact.formName}<span class="text-cush-orange">*</span></label>
-                <input id="name" name="name" type="text" required class="mt-2 w-full rounded-lg border border-border bg-canvas/40 px-3 py-2 text-foreground placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-cush-orange" />
+                <input id="name" name="name" type="text" required class="mt-2 w-full rounded-lg border border-border bg-canvas/40 px-3 py-2 text-foreground placeholder:text-muted focus:outline-hidden focus:ring-2 focus:ring-cush-orange" />
               </div>
               <div>
                 <label for="email" class="block text-sm font-display font-semibold text-foreground">{dict.contact.formEmail}<span class="text-cush-orange">*</span></label>
-                <input id="email" name="email" type="email" required class="mt-2 w-full rounded-lg border border-border bg-canvas/40 px-3 py-2 text-foreground placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-cush-orange" />
+                <input id="email" name="email" type="email" required class="mt-2 w-full rounded-lg border border-border bg-canvas/40 px-3 py-2 text-foreground placeholder:text-muted focus:outline-hidden focus:ring-2 focus:ring-cush-orange" />
               </div>
             </div>
 
             <div>
               <label for="phone" class="block text-sm font-display font-semibold text-foreground">{dict.contact.formPhone}</label>
-              <input id="phone" name="phone" type="tel" placeholder={dict.contact.formPhoneHint} class="mt-2 w-full rounded-lg border border-border bg-canvas/40 px-3 py-2 text-foreground placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-cush-orange" />
+              <input id="phone" name="phone" type="tel" placeholder={dict.contact.formPhoneHint} class="mt-2 w-full rounded-lg border border-border bg-canvas/40 px-3 py-2 text-foreground placeholder:text-muted focus:outline-hidden focus:ring-2 focus:ring-cush-orange" />
             </div>
 
             <div>
               <label for="message" class="block text-sm font-display font-semibold text-foreground">{dict.contact.formMessage}<span class="text-cush-orange">*</span></label>
-              <textarea id="message" name="message" required rows={6} placeholder={dict.contact.formMessageHint} class="mt-2 w-full rounded-lg border border-border bg-canvas/40 px-3 py-2 text-foreground placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-cush-orange"></textarea>
+              <textarea id="message" name="message" required rows={6} placeholder={dict.contact.formMessageHint} class="mt-2 w-full rounded-lg border border-border bg-canvas/40 px-3 py-2 text-foreground placeholder:text-muted focus:outline-hidden focus:ring-2 focus:ring-cush-orange"></textarea>
             </div>
 
             <div class="flex items-start gap-3">

--- a/src/pages/es/data-deletion.astro
+++ b/src/pages/es/data-deletion.astro
@@ -4,7 +4,7 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 
 <BaseLayout
   title="Instrucciones de Eliminación de Datos | CushLabs.ai"
-  description="Cómo solicitar la eliminación de los datos personales recopilados por los Asistentes de IA en Messenger de CushLabs. Respondemos en un plazo de 30 días."
+  description="Solicita eliminación de tus datos personales por los Asistentes IA de CushLabs. Envía solicitudes por email, WhatsApp o Messenger. Respondemos en 30 días."
 >
   <main class="min-h-screen bg-white dark:bg-gray-950">
     <!-- Hero -->

--- a/src/pages/es/messenger-assistant/connected.astro
+++ b/src/pages/es/messenger-assistant/connected.astro
@@ -7,7 +7,7 @@ import Container from "../../../components/layout/Container.astro";
 
 <BaseLayout
   title="Conectado | Asistente Messenger CushLabs"
-  description="Tu página de Facebook está conectada al Asistente Messenger de CushLabs."
+  description="Tu página de Facebook está conectada al Asistente Messenger de CushLabs. Configura tu llamada y activa tu asistente IA bilingüe en 5 días hábiles."
   noindex={true}
 >
   <section class="relative pt-24 pb-16 md:pt-32 md:pb-24 overflow-hidden min-h-[60vh]">

--- a/src/pages/es/portfolio.astro
+++ b/src/pages/es/portfolio.astro
@@ -109,7 +109,7 @@ const t = {
       <div class="flex justify-center mb-6">
         <div class="relative w-full max-w-md">
           <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>
-          <input type="text" id="search-input" placeholder={t.filters.search} class="w-full pl-9 pr-4 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 font-display text-sm text-gray-700 dark:text-gray-300 placeholder-gray-400 dark:placeholder-gray-500 focus:border-cush-orange focus:outline-none focus:ring-1 focus:ring-cush-orange transition-all" />
+          <input type="text" id="search-input" placeholder={t.filters.search} class="w-full pl-9 pr-4 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 font-display text-sm text-gray-700 dark:text-gray-300 placeholder-gray-400 dark:placeholder-gray-500 focus:border-cush-orange focus:outline-hidden focus:ring-1 focus:ring-cush-orange transition-all" />
         </div>
       </div>
 

--- a/src/pages/es/projects/[slug].astro
+++ b/src/pages/es/projects/[slug].astro
@@ -46,6 +46,7 @@ const metaDescriptions: Record<string, string> = {
   'biojalisco-pitch': 'Sitio de pitch con scrollytelling cinematográfico para una plataforma de biodiversidad ciudadana en el occidente de México. Next.js, animaciones y contenido bilingüe.',
   'ai-resume-tailor': 'Herramienta de optimización de CV con IA que analiza descripciones de empleo y adapta tu currículum. Identifica brechas de habilidades y mejora tu puntuación ATS.',
   'comp-plan-simulator': 'Simulador interactivo de planes de compensación para empresas de venta directa. Modela ingresos por rango, visualiza escenarios de crecimiento y compara estructuras.',
+  'cushlabs-ai-dispatch': 'Plataforma Claude Dispatch para operaciones multi-tenant, integración móvil y coordinación de agentes IA. Fase de investigación de arquitectura serverless.',
 };
 
 // For ES pages falling back to English GitHub descriptions, prefix with the project

--- a/src/pages/messenger-assistant/connected.astro
+++ b/src/pages/messenger-assistant/connected.astro
@@ -8,7 +8,7 @@ import Container from "../../components/layout/Container.astro";
 
 <BaseLayout
   title="Connected | CushLabs Messenger Assistant"
-  description="Your Facebook Page is connected to CushLabs Messenger Assistant."
+  description="Your Facebook Page is connected to CushLabs Messenger Assistant. Configure intake call and activate your bilingual AI assistant in 5 business days."
   noindex={true}
 >
   <section class="relative pt-24 pb-16 md:pt-32 md:pb-24 overflow-hidden min-h-[60vh]">

--- a/src/pages/portfolio.astro
+++ b/src/pages/portfolio.astro
@@ -227,7 +227,7 @@ const t = content[locale];
             type="text"
             id="search-input"
             placeholder={t.filters.search}
-            class="w-full pl-9 pr-4 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 font-display text-sm text-gray-700 dark:text-gray-300 placeholder-gray-400 dark:placeholder-gray-500 focus:border-cush-orange focus:outline-none focus:ring-1 focus:ring-cush-orange transition-all"
+            class="w-full pl-9 pr-4 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 font-display text-sm text-gray-700 dark:text-gray-300 placeholder-gray-400 dark:placeholder-gray-500 focus:border-cush-orange focus:outline-hidden focus:ring-1 focus:ring-cush-orange transition-all"
           />
         </div>
       </div>

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -42,6 +42,9 @@ const metaDescriptions: Record<string, string> = {
   'biojalisco-pitch': 'Cinematic scrollytelling pitch site for a citizen-science biodiversity platform in western Mexico. Built with Next.js, scroll-triggered animations, and bilingual content.',
   'ai-resume-tailor': 'AI-powered resume optimization tool that analyzes job descriptions and tailors your resume to match. Highlights skill gaps and suggests improvements for better ATS scores.',
   'comp-plan-simulator': 'Interactive compensation plan simulator for direct-selling companies. Model earnings across ranks, visualize team growth scenarios, and compare plan structures.',
+  'cushlabs-ai-dispatch': 'Claude Dispatch platform for multi-tenant operations, mobile integration, and AI agent coordination. Research phase exploring serverless architecture.',
+  'cushlabs-ai-marketing': 'AI-powered marketing toolkit with 15 Claude slash commands for competitive analysis, content audits, SEO strategy, and client deliverables. Built with Anthropic API.',
+  'cushlabs-messenger': 'Bilingual AI-powered Facebook Messenger bot platform with RAG knowledge base, Spanish-English support, and multi-tenant Cloudflare Workers runtime for business automation.',
 };
 
 const rawDescription = (


### PR DESCRIPTION
## Summary
- **shadow-sm → shadow-xs** (4 occurrences, 4 components): restores the v3 visual intent — in Tailwind v4 `shadow-sm` is one tier larger than it was in v3; `shadow-xs` is the correct equivalent
- **focus:outline-none → focus:outline-hidden** (18 occurrences, 6 files): all instances are paired with `focus:ring-*` so the focus indicator is preserved; `outline-hidden` is safer in Windows High Contrast / forced-colors mode
- **npm audit fix**: resolves 4 Dependabot CVEs via package-lock.json transitive dep bumps — astro <6.1.10 (low), devalue 5.6.3–5.8.0 (high), fast-uri ≤3.1.1 (2× high), brace-expansion 5.0.2–5.0.5 (moderate). No direct dependency changes.

## Test plan
- [ ] `npx astro check` — 0 errors ✓ (verified pre-commit)
- [ ] `npm audit` — 0 vulnerabilities ✓ (verified pre-commit)
- [ ] Visual spot-check: cards on `/`, `/services/`, `/faq/` should look identical or subtly less shadowed (correct — shadow-xs is smaller)
- [ ] Keyboard focus on form inputs: orange ring should still appear on focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)