### PR TITLE
feat(seo): HowTo schema on all 4 service pages (EN+ES)

### DIFF
--- a/src/pages/es/messenger-assistant.astro
+++ b/src/pages/es/messenger-assistant.astro
@@ -256,4 +256,32 @@ const bestFor = [
 
   <FinalCTA locale={locale} />
 
+  <script type="application/ld+json" is:inline set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "HowTo",
+    "name": "Cómo agregar un asistente de IA a tu página de Facebook",
+    "description": "Despliega un asistente de ventas bilingüe con IA en Facebook Messenger en 3 pasos — completamente administrado, sin configuración técnica.",
+    "estimatedCost": { "@type": "MonetaryAmount", "currency": "MXN", "value": "8497" },
+    "step": [
+      {
+        "@type": "HowToStep",
+        "position": 1,
+        "name": "Agenda una llamada de descubrimiento gratuita",
+        "text": "Dedicamos 20 minutos a conocer tu negocio: las preguntas más frecuentes de tus clientes, tus servicios y precios, y el tono que quieres que use el asistente. Sin compromiso."
+      },
+      {
+        "@type": "HowToStep",
+        "position": 2,
+        "name": "Construimos y entrenamos tu asistente de IA",
+        "text": "Tu asistente de Messenger se entrena con el conocimiento específico de tu negocio y se conecta a tu página de Facebook. Nos encargamos de toda la configuración técnica. Tiempo de entrega típico: 5–7 días hábiles."
+      },
+      {
+        "@type": "HowToStep",
+        "position": 3,
+        "name": "Entra en operación — tu asistente responde cada mensaje",
+        "text": "Tu IA responde de inmediato cada mensaje de Facebook 24/7 en inglés y español. Cuando un cliente está listo para comprar, recibes una alerta por WhatsApp con sus datos de contacto para que puedas cerrar la venta."
+      }
+    ]
+  })} />
+
 </BaseLayout>

--- a/src/pages/es/voice-agent.astro
+++ b/src/pages/es/voice-agent.astro
@@ -320,4 +320,32 @@ const bestFor = [
 
   <FinalCTA locale={locale} />
 
+  <script type="application/ld+json" is:inline set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "HowTo",
+    "name": "Cómo obtener un agente de voz con IA para tu negocio",
+    "description": "Despliega un agente de voz 24/7 con IA en 3 pasos — completamente administrado, sin configuración técnica.",
+    "estimatedCost": { "@type": "MonetaryAmount", "currency": "MXN", "value": "10997" },
+    "step": [
+      {
+        "@type": "HowToStep",
+        "position": 1,
+        "name": "Agenda una llamada de descubrimiento gratuita",
+        "text": "Dedicamos 20 minutos a entender tu negocio: las llamadas que recibes, tus preguntas frecuentes, tu sistema de citas y el tono de tu marca. Sin compromiso."
+      },
+      {
+        "@type": "HowToStep",
+        "position": 2,
+        "name": "Configuramos y entrenamos tu agente",
+        "text": "Tu agente de voz con IA se configura con el conocimiento de tu negocio, se conecta a tu número telefónico y se prueba de principio a fin. Tiempo de entrega típico: 5–7 días hábiles."
+      },
+      {
+        "@type": "HowToStep",
+        "position": 3,
+        "name": "Entra en operación — tu agente contesta cada llamada",
+        "text": "Tu agente de voz con IA contesta llamadas 24/7 en inglés y español, agenda citas, captura datos de leads y te envía un resumen de cada conversación por WhatsApp."
+      }
+    ]
+  })} />
+
 </BaseLayout>

--- a/src/pages/messenger-assistant.astro
+++ b/src/pages/messenger-assistant.astro
@@ -256,4 +256,32 @@ const bestFor = [
 
   <FinalCTA locale={locale} />
 
+  <script type="application/ld+json" is:inline set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "HowTo",
+    "name": "How to add an AI assistant to your Facebook page",
+    "description": "Deploy a bilingual AI sales assistant to Facebook Messenger in 3 steps — fully managed, no technical setup required.",
+    "estimatedCost": { "@type": "MonetaryAmount", "currency": "USD", "value": "997" },
+    "step": [
+      {
+        "@type": "HowToStep",
+        "position": 1,
+        "name": "Schedule a free discovery call",
+        "text": "We spend 20 minutes learning your business: your most common customer questions, your services and pricing, and the tone you want the AI to use. No commitment required."
+      },
+      {
+        "@type": "HowToStep",
+        "position": 2,
+        "name": "We build and train your AI assistant",
+        "text": "Your Messenger AI is trained on your specific business knowledge and connected to your Facebook page. We handle all the technical setup. Typical turnaround: 5–7 business days."
+      },
+      {
+        "@type": "HowToStep",
+        "position": 3,
+        "name": "Go live — your assistant handles every message",
+        "text": "Your AI responds instantly to every Facebook message 24/7 in English and Spanish. When a customer is ready to buy, you get a WhatsApp alert with their contact info so you can close the deal."
+      }
+    ]
+  })} />
+
 </BaseLayout>

--- a/src/pages/voice-agent.astro
+++ b/src/pages/voice-agent.astro
@@ -320,4 +320,32 @@ const bestFor = [
 
   <FinalCTA locale={locale} />
 
+  <script type="application/ld+json" is:inline set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "HowTo",
+    "name": "How to get an AI voice agent for your business",
+    "description": "Deploy a 24/7 AI voice agent in 3 steps — fully managed, no technical setup required.",
+    "estimatedCost": { "@type": "MonetaryAmount", "currency": "USD", "value": "1497" },
+    "step": [
+      {
+        "@type": "HowToStep",
+        "position": 1,
+        "name": "Schedule a free discovery call",
+        "text": "We spend 20 minutes understanding your business: the calls you receive, your FAQs, your booking system, and your brand voice. No commitment required."
+      },
+      {
+        "@type": "HowToStep",
+        "position": 2,
+        "name": "We build and train your agent",
+        "text": "Your AI voice agent is configured with your business knowledge, connected to your phone number, and tested end-to-end. Typical turnaround: 5–7 business days."
+      },
+      {
+        "@type": "HowToStep",
+        "position": 3,
+        "name": "Go live — your agent answers every call",
+        "text": "Your AI voice agent answers calls 24/7 in English and Spanish, books appointments, captures lead details, and texts you a summary of every conversation."
+      }
+    ]
+  })} />
+
 </BaseLayout>


### PR DESCRIPTION
## Summary
- Adds `schema.org/HowTo` JSON-LD to `/messenger-assistant/`, `/voice-agent/`, and their `/es/` equivalents
- Each schema has 3 steps (discovery call → build & train → go live) with `estimatedCost` (USD for EN, MXN for ES)
- Bilingual parity: EN + ES on both service types (4 files total)
- Google can render as rich results (numbered steps) in search — potential CTR lift without any page content changes

## Test plan
- [ ] `npx astro check` — 0 errors ✓ (verified pre-commit)
- [ ] Validate via Google Rich Results Test on the Vercel preview URLs for both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)