### PR TITLE
chore: hide homepage demo chatbot pending ai-chatbot-saas replacement

### DIFF
--- a/src/components/home2/Hero.astro
+++ b/src/components/home2/Hero.astro
@@ -17,7 +17,6 @@ const content = {
       '50+ projects in production',
       'Native bilingual EN/ES',
       'Fixed price, fixed scope',
-      'Live demo below ↓',
     ],
     ctaPrimary: 'Book a Free 30-min Call',
     ctaSecondary: 'Try the Live Chatbot →',
@@ -32,7 +31,6 @@ const content = {
       '50+ proyectos en producción',
       'Bilingüe EN/ES nativo',
       'Precio fijo, alcance fijo',
-      'Demo en vivo aquí abajo ↓',
     ],
     ctaPrimary: 'Agendar Llamada Gratis — 30 min',
     ctaSecondary: 'Probar el Chatbot en Vivo →',
@@ -109,6 +107,7 @@ const t = content[locale];
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
           </svg>
         </a>
+        <!-- "Try the Live Chatbot" CTA hidden 2026-06-06 — demo retired pending ai-chatbot-saas replacement
         <a
           href="#demo"
           class="inline-flex items-center gap-2 px-8 py-4 border-2 border-gray-500 dark:border-gray-600 text-gray-900 dark:text-white font-display font-semibold rounded-lg hover:border-cush-orange hover:text-cush-orange dark:hover:border-cush-orange dark:hover:text-cush-orange transition-all duration-300 text-lg"
@@ -118,6 +117,8 @@ const t = content[locale];
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
           </svg>
         </a>
+        -->
+        {/* ctaSecondary retained in content for easy re-enable */}
       </div>
     </div>
   </Container>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -216,9 +216,14 @@ const ogLocaleAlternate = locale === "es" ? "en_US" : "es_MX";
     <!-- CushLabs Demo Chat Widget — floating bottom-right -->
     <script is:inline define:vars={{ locale, pathname }}>
     (function() {
+      // Demo chatbot hidden 2026-06-06 — old cushlabs-demo-chat worker retired,
+      // pending replacement with an ai-chatbot-saas instance. Flip DEMO_ENABLED
+      // back to true (and re-enable ChatDemo + the hero CTA) when wired.
+      const DEMO_ENABLED = false;
+
       // Only show on homepage (EN and ES)
       const isHome = pathname === '/' || pathname === '/es/' || pathname === '/es';
-      if (!isHome) return;
+      if (!DEMO_ENABLED || !isHome) return;
 
       const DEMO_URL = 'https://cushlabs-demo-chat.rcushmaniii.workers.dev';
       const isMobile = () => window.matchMedia('(max-width: 768px)').matches;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 import Hero from "../components/home2/Hero.astro";
-import ChatDemo from "../components/home2/ChatDemo.astro";
+// import ChatDemo from "../components/home2/ChatDemo.astro"; // Hidden 2026-06-06 — old worker demo retired; pending replacement with ai-chatbot-saas instance
 // import VideoSection from "../components/home2/VideoSection.astro"; // Hidden until personal intro video is ready
 import PainPoints from "../components/home2/PainPoints.astro";
 import SolutionOverview from "../components/home2/SolutionOverview.astro";
@@ -35,8 +35,10 @@ const meta = {
   <VideoSection locale={locale} />
   -->
 
-  <!-- Section 2: Live chat demo — anchors the hero "Try the Live Chatbot" CTA -->
+  <!-- Section 2: Live chat demo — hidden 2026-06-06, pending replacement with ai-chatbot-saas instance
   <ChatDemo locale={locale} />
+  -->
+
 
   <!-- Section 3: Pain Points -->
   <PainPoints locale={locale} />


### PR DESCRIPTION
## What

Hides the homepage demo chatbot (old `cushlabs-demo-chat` worker) at all three touchpoints:
- Inline `<ChatDemo>` section (commented in `index.astro`)
- Floating widget (`DEMO_ENABLED = false` flag in `BaseLayout.astro` — one-line revert)
- Hero "Try the Live Chatbot" CTA + "Live demo below ↓" trust item (EN/ES)

## Why

The standalone worker is a rudimentary, ungrounded system-prompt bot. It underperforms and — worse — contradicts the no-hallucination / answers-only-from-approved-content promise it makes in its own prompt. A weak live demo is a credibility risk on the page that pitches AI services. Hiding it until a grounded instance of the real product (`ai-chatbot-saas`) replaces it.

Verified `astro build` passes (99 pages). Re-enable = uncomment `ChatDemo`, flip `DEMO_ENABLED`, restore the hero CTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)