### PR TITLE
feat: homepage demo → Converso SaaS (CushLabs bot)

### DIFF
--- a/src/components/home2/ChatDemo.astro
+++ b/src/components/home2/ChatDemo.astro
@@ -7,7 +7,7 @@ interface Props {
 
 const { locale } = Astro.props;
 
-const DEMO_URL = 'https://cushlabs-demo-chat.rcushmaniii.workers.dev';
+const DEMO_URL = 'https://www.soyconverso.com/embed/chat';
 
 const content = {
   en: {
@@ -29,7 +29,7 @@ const content = {
 };
 
 const t = content[locale];
-const iframeSrc = `${DEMO_URL}?lang=${locale}`;
+const iframeSrc = `${DEMO_URL}?language=${locale}`;
 ---
 
 <section id="demo" aria-label="Live chatbot demo" class="py-20 md:py-28 bg-surface/40">

--- a/src/components/home2/Hero.astro
+++ b/src/components/home2/Hero.astro
@@ -17,6 +17,7 @@ const content = {
       '50+ projects in production',
       'Native bilingual EN/ES',
       'Fixed price, fixed scope',
+      'Live demo below ↓',
     ],
     ctaPrimary: 'Book a Free 30-min Call',
     ctaSecondary: 'Try the Live Chatbot →',
@@ -31,6 +32,7 @@ const content = {
       '50+ proyectos en producción',
       'Bilingüe EN/ES nativo',
       'Precio fijo, alcance fijo',
+      'Demo en vivo aquí abajo ↓',
     ],
     ctaPrimary: 'Agendar Llamada Gratis — 30 min',
     ctaSecondary: 'Probar el Chatbot en Vivo →',
@@ -107,7 +109,6 @@ const t = content[locale];
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
           </svg>
         </a>
-        <!-- "Try the Live Chatbot" CTA hidden 2026-06-06 — demo retired pending ai-chatbot-saas replacement
         <a
           href="#demo"
           class="inline-flex items-center gap-2 px-8 py-4 border-2 border-gray-500 dark:border-gray-600 text-gray-900 dark:text-white font-display font-semibold rounded-lg hover:border-cush-orange hover:text-cush-orange dark:hover:border-cush-orange dark:hover:text-cush-orange transition-all duration-300 text-lg"
@@ -117,8 +118,6 @@ const t = content[locale];
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
           </svg>
         </a>
-        -->
-        {/* ctaSecondary retained in content for easy re-enable */}
       </div>
     </div>
   </Container>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -216,16 +216,14 @@ const ogLocaleAlternate = locale === "es" ? "en_US" : "es_MX";
     <!-- CushLabs Demo Chat Widget — floating bottom-right -->
     <script is:inline define:vars={{ locale, pathname }}>
     (function() {
-      // Demo chatbot hidden 2026-06-06 — old cushlabs-demo-chat worker retired,
-      // pending replacement with an ai-chatbot-saas instance. Flip DEMO_ENABLED
-      // back to true (and re-enable ChatDemo + the hero CTA) when wired.
-      const DEMO_ENABLED = false;
+      const DEMO_ENABLED = true;
 
       // Only show on homepage (EN and ES)
       const isHome = pathname === '/' || pathname === '/es/' || pathname === '/es';
       if (!DEMO_ENABLED || !isHome) return;
 
-      const DEMO_URL = 'https://cushlabs-demo-chat.rcushmaniii.workers.dev';
+      // CushLabs bot served by the Converso SaaS (one tenant per deploy).
+      const DEMO_URL = 'https://www.soyconverso.com/embed/chat';
       const isMobile = () => window.matchMedia('(max-width: 768px)').matches;
       const lang = document.documentElement.lang || 'en';
 
@@ -326,14 +324,10 @@ const ogLocaleAlternate = locale === "es" ? "en_US" : "es_MX";
       document.body.appendChild(btn);
 
       // ── Create overlay ──
+      // No close button here: the embedded SaaS chat renders its own × (top-right)
+      // and posts 'close-chat' to us. A second button would overlap it.
       const overlay = document.createElement('div');
       overlay.id = 'cl-chat-overlay';
-
-      const closeBtn = document.createElement('button');
-      closeBtn.id = 'cl-chat-close';
-      closeBtn.setAttribute('aria-label', 'Close chat');
-      closeBtn.textContent = s.close;
-      overlay.appendChild(closeBtn);
 
       const iframe = document.createElement('iframe');
       iframe.id = 'cl-chat-iframe';
@@ -347,7 +341,7 @@ const ogLocaleAlternate = locale === "es" ? "en_US" : "es_MX";
 
       function openChat() {
         if (!iframeLoaded) {
-          iframe.src = DEMO_URL + '?lang=' + lang;
+          iframe.src = DEMO_URL + '?language=' + lang;
           iframeLoaded = true;
         }
         overlay.classList.add('open');
@@ -360,7 +354,12 @@ const ogLocaleAlternate = locale === "es" ? "en_US" : "es_MX";
       }
 
       btn.addEventListener('click', openChat);
-      closeBtn.addEventListener('click', closeChat);
+      // The embedded SaaS chat closes itself by posting 'close-chat' to the parent.
+      window.addEventListener('message', (event) => {
+        if (event.origin === 'https://www.soyconverso.com' && event.data === 'close-chat') {
+          closeChat();
+        }
+      });
 
       // Desktop auto-open after 9 seconds
       if (!isMobile()) {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 import Hero from "../components/home2/Hero.astro";
-// import ChatDemo from "../components/home2/ChatDemo.astro"; // Hidden 2026-06-06 — old worker demo retired; pending replacement with ai-chatbot-saas instance
+import ChatDemo from "../components/home2/ChatDemo.astro";
 // import VideoSection from "../components/home2/VideoSection.astro"; // Hidden until personal intro video is ready
 import PainPoints from "../components/home2/PainPoints.astro";
 import SolutionOverview from "../components/home2/SolutionOverview.astro";
@@ -35,9 +35,8 @@ const meta = {
   <VideoSection locale={locale} />
   -->
 
-  <!-- Section 2: Live chat demo — hidden 2026-06-06, pending replacement with ai-chatbot-saas instance
+  <!-- Section 2: Live chat demo — CushLabs bot on the Converso SaaS (soyconverso.com) -->
   <ChatDemo locale={locale} />
-  -->
 
 
   <!-- Section 3: Pain Points -->

--- a/vercel.json
+++ b/vercel.json
@@ -1,53 +1,149 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "trailingSlash": true,
   "redirects": [
-    { "source": "/work", "destination": "/portfolio/", "permanent": true },
-    { "source": "/work/", "destination": "/portfolio/", "permanent": true },
-    { "source": "/solutions", "destination": "/portfolio/", "permanent": true },
-    { "source": "/solutions/", "destination": "/portfolio/", "permanent": true },
-    { "source": "/es/work", "destination": "/es/portfolio/", "permanent": true },
-    { "source": "/es/work/", "destination": "/es/portfolio/", "permanent": true },
-    { "source": "/es/solutions", "destination": "/es/portfolio/", "permanent": true },
-    { "source": "/es/solutions/", "destination": "/es/portfolio/", "permanent": true },
-    { "source": "/es/servicios", "destination": "/es/services/", "permanent": true },
-    { "source": "/es/servicios/", "destination": "/es/services/", "permanent": true },
-    { "source": "/blog", "destination": "/portfolio/", "permanent": true },
-    { "source": "/blog/", "destination": "/portfolio/", "permanent": true },
-    { "source": "/blog/:path*", "destination": "/portfolio/", "permanent": true },
-    { "source": "/es/blog", "destination": "/es/portfolio/", "permanent": true },
-    { "source": "/es/blog/", "destination": "/es/portfolio/", "permanent": true },
-    { "source": "/es/blog/:path*", "destination": "/es/portfolio/", "permanent": true }
+    {
+      "source": "/work",
+      "destination": "/portfolio/",
+      "permanent": true
+    },
+    {
+      "source": "/work/",
+      "destination": "/portfolio/",
+      "permanent": true
+    },
+    {
+      "source": "/solutions",
+      "destination": "/portfolio/",
+      "permanent": true
+    },
+    {
+      "source": "/solutions/",
+      "destination": "/portfolio/",
+      "permanent": true
+    },
+    {
+      "source": "/es/work",
+      "destination": "/es/portfolio/",
+      "permanent": true
+    },
+    {
+      "source": "/es/work/",
+      "destination": "/es/portfolio/",
+      "permanent": true
+    },
+    {
+      "source": "/es/solutions",
+      "destination": "/es/portfolio/",
+      "permanent": true
+    },
+    {
+      "source": "/es/solutions/",
+      "destination": "/es/portfolio/",
+      "permanent": true
+    },
+    {
+      "source": "/es/servicios",
+      "destination": "/es/services/",
+      "permanent": true
+    },
+    {
+      "source": "/es/servicios/",
+      "destination": "/es/services/",
+      "permanent": true
+    },
+    {
+      "source": "/blog",
+      "destination": "/portfolio/",
+      "permanent": true
+    },
+    {
+      "source": "/blog/",
+      "destination": "/portfolio/",
+      "permanent": true
+    },
+    {
+      "source": "/blog/:path*",
+      "destination": "/portfolio/",
+      "permanent": true
+    },
+    {
+      "source": "/es/blog",
+      "destination": "/es/portfolio/",
+      "permanent": true
+    },
+    {
+      "source": "/es/blog/",
+      "destination": "/es/portfolio/",
+      "permanent": true
+    },
+    {
+      "source": "/es/blog/:path*",
+      "destination": "/es/portfolio/",
+      "permanent": true
+    }
   ],
   "headers": [
     {
       "source": "/images/(.*)",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
       ]
     },
     {
       "source": "/videos/(.*)",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
       ]
     },
     {
       "source": "/_astro/(.*)",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
       ]
     },
     {
       "source": "/(.*)",
       "headers": [
-        { "key": "X-Content-Type-Options", "value": "nosniff" },
-        { "key": "X-Frame-Options", "value": "DENY" },
-        { "key": "X-XSS-Protection", "value": "1; mode=block" },
-        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
-        { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://analytics.ahrefs.com https://va.vercel-scripts.com https://browser.sentry-cdn.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' https://cdn.cushlabs.ai https://opengraph.githubassets.com data:; media-src 'self' https://cdn.cushlabs.ai; connect-src 'self' https://analytics.ahrefs.com https://va.vercel-scripts.com https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://cushlabs-booking.rcushmaniii.workers.dev https://cushlabs-demo-chat.rcushmaniii.workers.dev https://demo.cushlabs.ai; frame-src https://cushlabs-demo-chat.rcushmaniii.workers.dev https://demo.cushlabs.ai" }
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-XSS-Protection",
+          "value": "1; mode=block"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=()"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=63072000; includeSubDomains; preload"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://analytics.ahrefs.com https://va.vercel-scripts.com https://browser.sentry-cdn.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' https://cdn.cushlabs.ai https://opengraph.githubassets.com data:; media-src 'self' https://cdn.cushlabs.ai; connect-src 'self' https://analytics.ahrefs.com https://va.vercel-scripts.com https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://cushlabs-booking.rcushmaniii.workers.dev https://cushlabs-demo-chat.rcushmaniii.workers.dev https://demo.cushlabs.ai; frame-src https://www.soyconverso.com https://demo.cushlabs.ai"
+        }
       ]
     }
-  ]
+  ],
+  "ignoreCommand": "git rev-parse --verify HEAD^ > /dev/null 2>&1 && git diff --quiet HEAD^ HEAD -- . ':!docs/' ':!README.md' ':!CLAUDE.md' ':!LICENSE' ':!portfolio.md' ':!.gitignore'"
 }


### PR DESCRIPTION
Replaces the retired standalone worker with a CushLabs-configured bot on the Converso SaaS (grounded RAG, bilingual, verified working). Re-enables the inline demo section + floating widget + hero CTA, points both at soyconverso.com/embed/chat, fixes the close-button overlap via postMessage, and updates CSP frame-src. Backend verified live (EN+ES, cites cushlabs.ai sources).