### PR TITLE
fix(portfolio): repoint 3 dead demo/live links

### DIFF
--- a/src/data/projects.generated.json
+++ b/src/data/projects.generated.json
@@ -1209,9 +1209,9 @@
       "description": "Context-engineering system to lock brand voice, enforce truth, and generate consistent AI-written content at scale.",
       "summary": "> A context-engineering framework that makes AI write like the founder, not like AI.",
       "url": "https://github.com/RCushmaniii/context-writing-system",
-      "demoUrl": "https://cushlabs-writing-system.vercel.app",
+      "demoUrl": "https://context-writing-system.vercel.app",
       "liveUrl": "https://context-writing-system.vercel.app",
-      "homepage": "https://cushlabs-writing-system.vercel.app",
+      "homepage": "https://context-writing-system.vercel.app",
       "topics": [
         "ai-assistant",
         "ai-content-generation",
@@ -1344,9 +1344,9 @@
       "description": "Cinematic scrollytelling presentations by CushLabs — bilingual, narrated, scroll-driven marketing sites that make audiences lean in.",
       "summary": "> Cinematic, bilingual scrollytelling pitch decks that feel like cinema — not slides.",
       "url": "https://github.com/RCushmaniii/cushlabs-scrollytelling",
-      "demoUrl": "https://cushlabs-scrollytelling.vercel.app",
-      "liveUrl": "https://cushlabs-scrollytelling.vercel.app",
-      "homepage": "https://cushlabs-scrollytelling.vercel.app",
+      "demoUrl": "https://scrollytelling.cushlabs.ai",
+      "liveUrl": "https://scrollytelling.cushlabs.ai",
+      "homepage": "https://scrollytelling.cushlabs.ai",
       "topics": [
         "astro",
         "bilingual",
@@ -1615,9 +1615,9 @@
       "description": "Helps candidates create a tailored resume for a specific job. ",
       "summary": "> Bilingual AI-powered ATS resume optimization — instant structured feedback, zero friction, privacy by design.",
       "url": "https://github.com/RCushmaniii/ai-resume-tailor",
-      "demoUrl": "https://ai-resume-tailor-client.vercel.app/analyze",
-      "liveUrl": "https://ai-resume-tailor-client.vercel.app",
-      "homepage": "https://ai-resume-tailor-client.vercel.app",
+      "demoUrl": "https://resume.cushlabs.ai/analyze",
+      "liveUrl": "https://resume.cushlabs.ai",
+      "homepage": "https://resume.cushlabs.ai",
       "topics": [],
       "categories": [
         "AI Automation"


### PR DESCRIPTION
## Summary
Audited all 37 demo/live URLs referenced in the portfolio (`src/data/projects.generated.json`). 4 were broken; this PR fixes the 3 that were wrong-URL issues.

| Project | Was (404) | Now (200) |
|---|---|---|
| AI Resume Tailor | `ai-resume-tailor-client.vercel.app` | `resume.cushlabs.ai` |
| Scrollytelling | `cushlabs-scrollytelling.vercel.app` | `scrollytelling.cushlabs.ai` |
| Writing System | `cushlabs-writing-system.vercel.app` | `context-writing-system.vercel.app` |

The 4th broken link (`ai-chatbot-saas-delta.vercel.app`, 404) was a dropped Vercel alias — fixed out-of-band by re-pointing the alias to the latest ready production deployment, so no JSON change was needed.

## Notes
- Surgical string edit to the committed JSON (the CI/Vercel build uses the committed `projects.generated.json` as source of truth, not a live regen).
- A full `generate-projects` run was deliberately **not** committed: it would have swept in 4 unrelated newly-enabled projects, 3 with `null` thumbnails (placeholder cards). Those are out of scope for a link fix.
- Source-of-truth `PORTFOLIO.md` frontmatter in the three sibling repos was updated to match, plus the GitHub repo "Website" fields for ai-resume-tailor and context-writing-system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)