### PR TITLE
feat(portfolio): messenger Live demo → services #messenger-ai anchor

### DIFF
--- a/src/components/services2/ServiceBlock.astro
+++ b/src/components/services2/ServiceBlock.astro
@@ -276,7 +276,7 @@ const bgClass = isAlternate ? 'bg-gray-50 dark:bg-gray-900/30' : 'bg-white dark:
 // "Also Available" section removed — maps and product photos are now included in the Growth Bundle.
 ---
 
-<section id={id} class={`py-20 md:py-32 border-b border-gray-100 dark:border-gray-800 ${bgClass}`}>
+<section id={id} class={`scroll-mt-24 py-20 md:py-32 border-b border-gray-100 dark:border-gray-800 ${bgClass}`}>
   <Container size="lg">
     <!-- Header -->
     <div class="mb-16 md:mb-20 max-w-4xl">

--- a/src/data/projectDetails.ts
+++ b/src/data/projectDetails.ts
@@ -19,7 +19,9 @@ export type ProjectDetailLocale = {
 
 export type ProjectDetailOverride = {
   slug: string;
-  demoUrl?: string;
+  // string for a single URL across locales, or { en, es } when the demo
+  // destination is locale-specific (e.g. an on-site section anchor).
+  demoUrl?: string | { en: string; es: string };
   thumbnail?: string;
   videoUrl?: string;
   videoPoster?: string;
@@ -31,6 +33,11 @@ export type ProjectDetailOverride = {
 const details: Record<string, ProjectDetailOverride> = {
   "cushlabs-messenger": {
     slug: "cushlabs-messenger",
+    // "Live demo" → the Messenger AI section of the services page (locale-aware).
+    demoUrl: {
+      en: "/services/#messenger-ai",
+      es: "/es/services/#messenger-ai",
+    },
     en: {
       headline:
         "CushLabs Messenger — The 24/7 Bilingual AI Assistant for Facebook Messenger",

--- a/src/pages/es/projects/[slug].astro
+++ b/src/pages/es/projects/[slug].astro
@@ -67,8 +67,12 @@ const description = rawDescription.length > 160
   ? rawDescription.slice(0, 157).replace(/\s+\S*$/, "") + "..."
   : rawDescription;
 
+const overrideDemoUrl =
+  typeof override?.demoUrl === "string"
+    ? override.demoUrl
+    : override?.demoUrl?.[locale];
 const demoUrl =
-  override?.demoUrl || project.demoUrl || project.homepage || null;
+  overrideDemoUrl || project.demoUrl || project.homepage || null;
 const codeUrl = project.url;
 
 const githubMatch = project.url.match(/github\.com\/([^/]+)\/([^/]+)(?:\/|$)/i);

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -60,8 +60,12 @@ const description = rawDescription.length > 160
   ? rawDescription.slice(0, 157).replace(/\s+\S*$/, "") + "..."
   : rawDescription;
 
+const overrideDemoUrl =
+  typeof override?.demoUrl === "string"
+    ? override.demoUrl
+    : override?.demoUrl?.[locale];
 const demoUrl =
-  override?.demoUrl || project.demoUrl || project.homepage || null;
+  overrideDemoUrl || project.demoUrl || project.homepage || null;
 const codeUrl = project.url;
 
 const githubMatch = project.url.match(/github\.com\/([^/]+)\/([^/]+)(?:\/|$)/i);


### PR DESCRIPTION
## What

The messenger project page's **Live demo** button pointed at `cushlabs.ai` (a fallback to the repo homepage), which just looped back to the portfolio. This repoints it to the **Messenger AI section of the services page** — a public, polished destination with the offering + "Book a Discovery Call" CTA (a much stronger conversion path than a gated admin console).

## Changes

- **`projectDetails.ts`** — add a locale-aware `demoUrl` to the messenger override (`en: /services/#messenger-ai`, `es: /es/services/#messenger-ai`). `demoUrl` type widened to `string | { en, es }`; all 14 other projects keep their string `demoUrl` unchanged.
- **`projects/[slug].astro`** + **`es/projects/[slug].astro`** — resolve `demoUrl` per locale, backward-compatible with the string form.
- **`ServiceBlock.astro`** — add `scroll-mt-24` to the shared `<section id>` so **all four** service anchors (`#messenger-ai`, `#intelligence`, `#support-assistants`, `#voice-agent`) clear the ~65px sticky header on mobile/tablet/desktop instead of tucking under it.

## Verify on preview

- EN project page → click **Live demo** → should land on `/services/#messenger-ai` with the "AI Assistant on Your Facebook Page…" heading clear of the header.
- ES project page → **Live demo** → `/es/services/#messenger-ai`.
- Check the anchor jump on mobile width too (header offset).

`tsc` + `astro check`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)