### PR TITLE
feat(chat): one floating chat surface, on every page incl. home

### DIFF
--- a/src/components/home2/ChatDemo.astro
+++ b/src/components/home2/ChatDemo.astro
@@ -7,8 +7,6 @@ interface Props {
 
 const { locale } = Astro.props;
 
-const DEMO_URL = 'https://www.soyconverso.com/embed/chat';
-
 const content = {
   en: {
     eyebrow: 'LIVE DEMO',
@@ -35,7 +33,6 @@ const content = {
 };
 
 const t = content[locale];
-const iframeSrc = `${DEMO_URL}?language=${locale}`;
 ---
 
 <section id="demo" aria-label="Live chatbot demo" class="scroll-mt-24 py-20 md:py-28 bg-surface/40">
@@ -72,20 +69,17 @@ const iframeSrc = `${DEMO_URL}?language=${locale}`;
         </p>
       </div>
 
-      <!-- Right: live chat — click-to-load facade. The cross-origin embed
-           autofocuses its input on load and scrolls the page to it; loading it
-           only on an explicit click keeps that out of the "scroll to demo" path. -->
+      <!-- Right: invitation card. "Start chatting" opens the single floating
+           assistant (a fixed-position overlay), rather than embedding a chat in
+           the page flow — so opening it never moves the page. -->
       <div class="order-1 lg:order-2">
         <div
-          id="cl-demo-shell"
           class="rounded-2xl overflow-hidden shadow-2xl shadow-black/10 dark:shadow-black/40 border border-border w-full"
           style="height: 520px;"
-          data-src={iframeSrc}
-          data-title={locale === 'es' ? 'Asistente de IA de CushLabs' : 'CushLabs AI assistant'}
         >
           <button
-            id="cl-demo-start"
             type="button"
+            data-open-chat
             class="group w-full h-full flex flex-col items-center justify-center gap-4 px-8 text-center bg-white dark:bg-cush-gray-900 cursor-pointer"
           >
             <span class="flex items-center justify-center w-16 h-16 rounded-full bg-cush-orange/10 text-cush-orange transition-transform group-hover:scale-105">
@@ -103,24 +97,3 @@ const iframeSrc = `${DEMO_URL}?language=${locale}`;
     </div>
   </Container>
 </section>
-
-<script>
-  // Load the cross-origin chat embed only when the visitor explicitly starts it.
-  // The embed autofocuses its input on load and scrolls the parent page to reach
-  // it; keeping it unloaded until click means the hero "scroll to demo" lands
-  // cleanly on the section top instead of being yanked down to the chat input.
-  const shell = document.getElementById('cl-demo-shell');
-  const startBtn = document.getElementById('cl-demo-start');
-  if (shell && startBtn) {
-    startBtn.addEventListener('click', () => {
-      const src = shell.dataset.src;
-      if (!src) return;
-      const iframe = document.createElement('iframe');
-      iframe.src = src;
-      iframe.title = shell.dataset.title || 'AI assistant';
-      iframe.className = 'w-full h-full border-0';
-      iframe.allow = 'clipboard-write';
-      shell.replaceChildren(iframe);
-    });
-  }
-</script>

--- a/src/components/home2/Hero.astro
+++ b/src/components/home2/Hero.astro
@@ -109,15 +109,16 @@ const t = content[locale];
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
           </svg>
         </a>
-        <a
-          href="#demo"
-          class="group inline-flex items-center gap-2 px-8 py-4 border-2 border-gray-500 dark:border-gray-600 text-gray-900 dark:text-white font-display font-semibold rounded-lg hover:border-cush-orange hover:text-cush-orange dark:hover:border-cush-orange dark:hover:text-cush-orange transition-all duration-300 text-lg"
+        <button
+          type="button"
+          data-open-chat
+          class="group inline-flex items-center gap-2 px-8 py-4 border-2 border-gray-500 dark:border-gray-600 text-gray-900 dark:text-white font-display font-semibold rounded-lg hover:border-cush-orange hover:text-cush-orange dark:hover:border-cush-orange dark:hover:text-cush-orange transition-all duration-300 text-lg cursor-pointer"
         >
           {t.ctaSecondary}
           <svg class="w-5 h-5 transition-transform group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
           </svg>
-        </a>
+        </button>
       </div>
     </div>
   </Container>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -226,11 +226,11 @@ const ogLocaleAlternate = locale === "es" ? "en_US" : "es_MX";
     (function() {
       const DEMO_ENABLED = true;
 
-      // Show the floating assistant on every page EXCEPT the homepage.
-      // The homepage already has the inline live demo, so a floating chat there
-      // just duplicates it; everywhere else this is the persistent site assistant.
-      const isHome = pathname === '/' || pathname === '/es/' || pathname === '/es';
-      if (!DEMO_ENABLED || isHome) return;
+      // The floating assistant is the single chat surface — shown on every page,
+      // including the homepage. In-page CTAs (the hero "Try the Live Chatbot"
+      // button and the "Try It Right Now" card) open it via [data-open-chat];
+      // opening it never moves the page because it's a fixed-position overlay.
+      if (!DEMO_ENABLED) return;
 
       // CushLabs bot served by the Converso SaaS (one tenant per deploy).
       const DEMO_URL = 'https://www.soyconverso.com/embed/chat';
@@ -350,6 +350,17 @@ const ogLocaleAlternate = locale === "es" ? "en_US" : "es_MX";
       let iframeLoaded = false;
 
       function openChat() {
+        // The chat is a fixed-position overlay, so opening it must not move the
+        // page. The embed autofocuses its input on load, which can nudge scroll;
+        // pin the page position for ~1s to absorb that.
+        const sx = window.scrollX, sy = window.scrollY;
+        let pins = 0;
+        const pin = () => {
+          if (window.scrollX !== sx || window.scrollY !== sy) window.scrollTo(sx, sy);
+          if (pins++ < 60) requestAnimationFrame(pin);
+        };
+        requestAnimationFrame(pin);
+
         if (!iframeLoaded) {
           iframe.src = DEMO_URL + '?language=' + lang;
           iframeLoaded = true;
@@ -364,6 +375,14 @@ const ogLocaleAlternate = locale === "es" ? "en_US" : "es_MX";
       }
 
       btn.addEventListener('click', openChat);
+      // In-page CTAs marked [data-open-chat] open this same widget, so the page
+      // never embeds a second chat in its flow.
+      document.querySelectorAll('[data-open-chat]').forEach((el) => {
+        el.addEventListener('click', (e) => {
+          e.preventDefault();
+          openChat();
+        });
+      });
       // The embedded SaaS chat closes itself by posting 'close-chat' to the parent.
       window.addEventListener('message', (event) => {
         if (event.origin === 'https://www.soyconverso.com' && event.data === 'close-chat') {
@@ -371,9 +390,9 @@ const ogLocaleAlternate = locale === "es" ? "en_US" : "es_MX";
         }
       });
 
-      // Launcher only — the widget stays a collapsed icon and opens on click.
-      // (No auto-open: the homepage already has an inline live demo, and an
-      // auto-popping second chat read as two chatbots side by side.)
+      // Launcher only — the widget stays a collapsed icon and opens on click
+      // (or via an in-page [data-open-chat] CTA). No auto-open: it shouldn't
+      // pop open and cover content before the visitor asks for it.
     })();
     </script>
   </body>


### PR DESCRIPTION
Reworks the homepage chat per the chosen direction: **stop embedding a chat in the page flow** (the root cause of every scroll bug here) and use one floating widget as the single chat surface.

- Floating assistant now shows on **all pages including the homepage** — a chat belongs on the landing page.
- The "Try It Right Now" section keeps its copy, but its card no longer embeds an iframe. Its button and the hero "Try the Live Chatbot" CTA are `[data-open-chat]` triggers that open the single floating widget.
- Opening the widget **pins the scroll** briefly so the embed's autofocus can't nudge the page — a fixed-position overlay opening now moves the page **zero pixels**.

**Browser-verified (headless Playwright):** launcher present on home; hero CTA opens overlay with scrollY bump = **0**; scroll chevron lands `#demo` at 96px. astro check: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)