### PR TITLE
fix(portfolio): no broken GitHub OG image on private-repo project pages

### DIFF
--- a/src/pages/es/projects/[slug].astro
+++ b/src/pages/es/projects/[slug].astro
@@ -86,7 +86,7 @@ const images = override?.images?.length
         src: (img.srcEs || img.src) as string,
         alt: { en: img.altEn || project.title, es: img.altEs || project.title },
       }))
-    : ogImageUrl
+    : ogImageUrl && !project.isPrivate
       ? [{ src: ogImageUrl, alt: { en: project.title, es: project.title } }]
       : [];
 

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -79,7 +79,7 @@ const images = override?.images?.length
         src: img.src as string,
         alt: { en: img.altEn || project.title, es: img.altEs || project.title },
       }))
-    : ogImageUrl
+    : ogImageUrl && !project.isPrivate
       ? [{ src: ogImageUrl, alt: { en: project.title, es: project.title } }]
       : [];
 


### PR DESCRIPTION
Private repos return a non-loading image from opengraph.githubassets.com, so any private project with no slides showed a broken image in the Screenshots panel — visible now on /projects/ny-english-messenger-bot/ after its generic slides moved to the platform page.

Fix: skip the GitHub OG fallback when project.isPrivate (EN + ES page templates). Private repos with no slides now omit the Screenshots section entirely instead of rendering a broken image.

Verified: local build passes, meta-gate passes, NYE Screenshots section no longer renders, generic messenger gallery unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)