### PR TITLE
chore: point biojalisco-species-id portfolio links at custom domain

### DIFF
--- a/src/data/projects.generated.json
+++ b/src/data/projects.generated.json
@@ -947,9 +947,9 @@
       "description": "AI-powered vertebrate species identification for Jalisco field research. Next.js 15, GPT-4o Vision, Clerk, Neon Postgres.",
       "summary": "> AI-powered species identification for Jalisco biodiversity research. Four-API pipeline delivers verified taxonomy, IUCN status, Mexico-specific conservation data (NOM-059), and endemic classificatio",
       "url": "https://github.com/RCushmaniii/biojalisco-species-id",
-      "demoUrl": "https://biojalisco-species-id.vercel.app",
-      "liveUrl": "https://biojalisco-species-id.vercel.app",
-      "homepage": "https://biojalisco-species-id.vercel.app",
+      "demoUrl": "https://biojalisco.cushlabs.ai",
+      "liveUrl": "https://biojalisco.cushlabs.ai",
+      "homepage": "https://biojalisco.cushlabs.ai",
       "topics": [
         "ai",
         "biodiversity",


### PR DESCRIPTION
BioJalisco Species Identifier is now live at its custom domain **biojalisco.cushlabs.ai**.

Updates the `demoUrl` / `liveUrl` / `homepage` fields for the `biojalisco-species-id` entry in the committed `projects.generated.json` — the file used directly on Vercel builds (the generator short-circuits to the committed JSON on CI). The portfolio detail page's "live demo" button resolves to `project.demoUrl`, so this is what it needs.

Surgical 3-line edit (not a full regen) to keep the diff reviewable and avoid re-fetching ~40 repos via the GitHub API. The source repo's `PORTFOLIO.md` was updated to match, so a future intentional regen stays consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)