### PR TITLE
chore: add .prettierignore for generator-owned data files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,10 @@
+# Generator-owned data files — written by scripts/generate-*.ts via
+# JSON.stringify(..., null, 2). Prettier would reflow them (collapsing
+# arrays), producing a noisy diff that diverges from the generator output
+# and churns back on the next regen. Leave them as the generator emits.
+src/data/projects.generated.json
+src/data/skills.generated.json
+
+# Build output
+dist/
+.astro/


### PR DESCRIPTION
Adds a `.prettierignore` covering `src/data/projects.generated.json` and `src/data/skills.generated.json`.

These are written by `scripts/generate-*.ts` via `JSON.stringify(..., null, 2)`. Without ignoring them, a formatter-on-save reflows the files (collapsing short arrays onto single lines), producing a noisy all-projects diff that diverges from the generator's output format and churns straight back on the next regen.

Surfaced while updating the BioJalisco live URL — the formatter tried to rewrite 183 lines across all projects for a 3-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)