### PR TITLE
chore: unify BioJalisco pitch title (card / detail / SEO)

### DIFF
--- a/src/data/projectCardsEs.ts
+++ b/src/data/projectCardsEs.ts
@@ -85,7 +85,7 @@ export const esCardCopy: Record<string, EsCardCopy> = {
       "Optimización de CV para sistemas ATS con IA, soporte bilingüe y retroalimentación instantánea",
   },
   "biojalisco-pitch": {
-    title: "BioJalisco — Atlas de Biodiversidad e Identificador de Especies",
+    title: "BioJalisco — Sitio de Presentación Cinematográfico",
     tagline:
       "Sitio de pitch con scrollytelling cinematográfico e identificación de especies con IA para la plataforma de biodiversidad del occidente de México",
   },

--- a/src/data/projectDetails.ts
+++ b/src/data/projectDetails.ts
@@ -825,7 +825,7 @@ const details: Record<string, ProjectDetailOverride> = {
     slug: "biojalisco-pitch",
     demoUrl: "https://biojalisco-pitch.vercel.app",
     en: {
-      headline: "BioJalisco Pitch Site",
+      headline: "BioJalisco — Cinematic Scrollytelling Pitch Site",
       subheadline:
         "Cinematic scrollytelling site pitching a citizen-science biodiversity platform for western Mexico",
       overallVerdictTitle: "The Verdict",
@@ -863,7 +863,7 @@ const details: Record<string, ProjectDetailOverride> = {
       ],
     },
     es: {
-      headline: "Sitio de Presentación BioJalisco",
+      headline: "BioJalisco — Sitio de Presentación Cinematográfico",
       subheadline:
         "Sitio de scrollytelling cinemático presentando una plataforma de biodiversidad de ciencia ciudadana para el occidente de México",
       overallVerdictTitle: "El Veredicto",

--- a/src/data/projects.generated.json
+++ b/src/data/projects.generated.json
@@ -13,9 +13,7 @@
       "liveUrl": "",
       "homepage": "https://www.soyconverso.com",
       "topics": [],
-      "categories": [
-        "AI Automation"
-      ],
+      "categories": ["AI Automation"],
       "tags": [
         "ai-chatbot",
         "saas",
@@ -142,9 +140,7 @@
         "tailwindcss",
         "vercel-deployment"
       ],
-      "categories": [
-        "AI Automation"
-      ],
+      "categories": ["AI Automation"],
       "tags": [
         "ai-chatbot",
         "nextjs",
@@ -274,9 +270,7 @@
         "vapi",
         "voice-agent"
       ],
-      "categories": [
-        "AI Automation"
-      ],
+      "categories": ["AI Automation"],
       "tags": [
         "ai",
         "appointment-booking",
@@ -433,9 +427,7 @@
         "tailwindcss",
         "typescript"
       ],
-      "categories": [
-        "AI Automation"
-      ],
+      "categories": ["AI Automation"],
       "tags": [
         "ai-agents",
         "bilingual",
@@ -579,9 +571,7 @@
         "saas",
         "whatsapp-api"
       ],
-      "categories": [
-        "AI Automation"
-      ],
+      "categories": ["AI Automation"],
       "tags": [
         "ai-analytics",
         "business-intelligence",
@@ -722,9 +712,7 @@
         "typescript",
         "workers-ai"
       ],
-      "categories": [
-        "AI Automation"
-      ],
+      "categories": ["AI Automation"],
       "tags": [
         "ai-assistant",
         "anthropic",
@@ -862,9 +850,7 @@
         "tailwindcss",
         "typescript"
       ],
-      "categories": [
-        "Client Work"
-      ],
+      "categories": ["Client Work"],
       "tags": [
         "astro",
         "bilingual",
@@ -1007,9 +993,7 @@
         "nextjs",
         "species-identification"
       ],
-      "categories": [
-        "AI Automation"
-      ],
+      "categories": ["AI Automation"],
       "tags": [
         "ai",
         "biodiversity",
@@ -1155,9 +1139,7 @@
         "typescript",
         "vitest"
       ],
-      "categories": [
-        "Tools"
-      ],
+      "categories": ["Tools"],
       "tags": [
         "decision-support",
         "etrade-api",
@@ -1286,9 +1268,7 @@
         "typescript",
         "vercel"
       ],
-      "categories": [
-        "Tools"
-      ],
+      "categories": ["Tools"],
       "tags": [
         "analytics",
         "dashboard",
@@ -1413,9 +1393,7 @@
         "llm-tools",
         "writing-system"
       ],
-      "categories": [
-        "AI Automation"
-      ],
+      "categories": ["AI Automation"],
       "tags": [
         "ai-assistant",
         "ai-content-generation",
@@ -1556,9 +1534,7 @@
         "svelte",
         "tailwindcss"
       ],
-      "categories": [
-        "Templates"
-      ],
+      "categories": ["Templates"],
       "tags": [
         "astro",
         "bilingual",
@@ -1699,9 +1675,7 @@
         "sam",
         "watermark-removal"
       ],
-      "categories": [
-        "AI Automation"
-      ],
+      "categories": ["AI Automation"],
       "tags": [
         "ai",
         "automation",
@@ -1821,9 +1795,7 @@
       "liveUrl": "https://resume.cushlabs.ai",
       "homepage": "https://resume.cushlabs.ai",
       "topics": [],
-      "categories": [
-        "AI Automation"
-      ],
+      "categories": ["AI Automation"],
       "tags": [
         "ai",
         "saas",
@@ -1924,7 +1896,7 @@
     {
       "id": 1172972613,
       "name": "biojalisco-pitch",
-      "title": "Scrollytelling Pitch Site — BioJalisco Biodiversity Vision",
+      "title": "BioJalisco — Cinematic Scrollytelling Pitch Site",
       "description": "BioJalisco — bilingual scrollytelling pitch site for a citizen-science biodiversity platform in western Mexico",
       "summary": "> Cinematic scrollytelling site pitching BioJalisco — a citizen-science biodiversity platform for western Mexico — plus an AI-powered Species Identifier tool.",
       "url": "https://github.com/RCushmaniii/biojalisco-pitch",
@@ -1946,9 +1918,7 @@
         "text-to-voice-application",
         "vercel"
       ],
-      "categories": [
-        "Client Work"
-      ],
+      "categories": ["Client Work"],
       "tags": [
         "bilingual",
         "biodiversity",
@@ -2091,9 +2061,7 @@
         "tailwindcss",
         "typescript"
       ],
-      "categories": [
-        "AI Automation"
-      ],
+      "categories": ["AI Automation"],
       "tags": [
         "framer-motion",
         "i18n",
@@ -2207,9 +2175,7 @@
       "liveUrl": "",
       "homepage": null,
       "topics": [],
-      "categories": [
-        "AI Automation"
-      ],
+      "categories": ["AI Automation"],
       "tags": [
         "claude-code",
         "marketing-automation",
@@ -2348,9 +2314,7 @@
         "vercel",
         "weighted-scoring"
       ],
-      "categories": [
-        "Tools"
-      ],
+      "categories": ["Tools"],
       "tags": [
         "3pl",
         "build-vs-outsource",
@@ -2490,9 +2454,7 @@
         "typescript",
         "windows-app"
       ],
-      "categories": [
-        "AI Automation"
-      ],
+      "categories": ["AI Automation"],
       "tags": [
         "ai",
         "desktop-app",
@@ -2510,13 +2472,7 @@
         "bilingual",
         "windows"
       ],
-      "stack": [
-        "Tauri 2",
-        "Rust",
-        "React",
-        "TypeScript",
-        "Claude Haiku"
-      ],
+      "stack": ["Tauri 2", "Rust", "React", "TypeScript", "Claude Haiku"],
       "status": "Demo",
       "language": "TypeScript",
       "languages": {
@@ -2633,9 +2589,7 @@
         "tailwindcss",
         "typescript"
       ],
-      "categories": [
-        "Tools"
-      ],
+      "categories": ["Tools"],
       "tags": [
         "bilingual",
         "digital-nomad",
@@ -2775,9 +2729,7 @@
         "tailwindcss",
         "typescript"
       ],
-      "categories": [
-        "Tools"
-      ],
+      "categories": ["Tools"],
       "tags": [
         "astro",
         "bilingual",
@@ -2892,9 +2844,7 @@
         "windows",
         "windows-notifications"
       ],
-      "categories": [
-        "Tools"
-      ],
+      "categories": ["Tools"],
       "tags": [
         "desktop-app",
         "python",
@@ -3026,9 +2976,7 @@
         "webp",
         "whatsapp"
       ],
-      "categories": [
-        "Developer Tools"
-      ],
+      "categories": ["Developer Tools"],
       "tags": [
         "android",
         "automation",
@@ -3141,9 +3089,7 @@
         "typescript",
         "zustand"
       ],
-      "categories": [
-        "Tools"
-      ],
+      "categories": ["Tools"],
       "tags": [
         "compensation-plan",
         "cushlabs",
@@ -3269,9 +3215,7 @@
         "static-site",
         "tailwindcss"
       ],
-      "categories": [
-        "Tools"
-      ],
+      "categories": ["Tools"],
       "tags": [
         "ai-consulting",
         "astro",
@@ -3405,9 +3349,7 @@
         "typescript",
         "vercel"
       ],
-      "categories": [
-        "Developer Tools"
-      ],
+      "categories": ["Developer Tools"],
       "tags": [
         "github-api",
         "nextjs",
@@ -3544,9 +3486,7 @@
         "typescipt",
         "vite"
       ],
-      "categories": [
-        "Games"
-      ],
+      "categories": ["Games"],
       "tags": [
         "anagram-solver",
         "free-game",
@@ -3665,9 +3605,7 @@
         "typescript",
         "vercel"
       ],
-      "categories": [
-        "Creative"
-      ],
+      "categories": ["Creative"],
       "tags": [
         "cdn",
         "cdn-distribution",
@@ -3794,9 +3732,7 @@
       "liveUrl": "https://gallery.cushlabs.ai/",
       "homepage": "https://cushlabs-image-portfolio.vercel.app",
       "topics": [],
-      "categories": [
-        "Tools"
-      ],
+      "categories": ["Tools"],
       "tags": [
         "next-js",
         "typescript",
@@ -3910,9 +3846,7 @@
         "typescript",
         "windows-app"
       ],
-      "categories": [
-        "Marketing"
-      ],
+      "categories": ["Marketing"],
       "tags": [
         "ai",
         "claude-ai",
@@ -4038,9 +3972,7 @@
         "windows-alert",
         "windows-app"
       ],
-      "categories": [
-        "Templates"
-      ],
+      "categories": ["Templates"],
       "tags": [
         "price-alerts",
         "stock-alerts",
@@ -4173,9 +4105,7 @@
         "trello-power-up",
         "vercel"
       ],
-      "categories": [
-        "Developer Tools"
-      ],
+      "categories": ["Developer Tools"],
       "tags": [
         "game-development",
         "nodejs",
@@ -4188,13 +4118,7 @@
         "automation",
         "api-integration"
       ],
-      "stack": [
-        "Node.js",
-        "axios",
-        "dotenv",
-        "Trello REST API",
-        "Vercel"
-      ],
+      "stack": ["Node.js", "axios", "dotenv", "Trello REST API", "Vercel"],
       "status": null,
       "language": "HTML",
       "languages": {
@@ -4267,9 +4191,7 @@
       "liveUrl": "https://mazebreak-wiki.vercel.app/",
       "homepage": "https://mazebreak-wiki.vercel.app",
       "topics": [],
-      "categories": [
-        "Developer Tools"
-      ],
+      "categories": ["Developer Tools"],
       "tags": [
         "developer-tools",
         "documentation",
@@ -4365,15 +4287,8 @@
       "demoUrl": "https://nextjs-react-agency-starter.vercel.app/",
       "liveUrl": "https://nextjs-react-agency-starter.vercel.app/",
       "homepage": "https://nextjs-react-agency-starter.vercel.app/",
-      "topics": [
-        "nextjs",
-        "react",
-        "starter-kit",
-        "tailwindcss"
-      ],
-      "categories": [
-        "Templates"
-      ],
+      "topics": ["nextjs", "react", "starter-kit", "tailwindcss"],
+      "categories": ["Templates"],
       "tags": [
         "nextjs",
         "react",
@@ -4386,13 +4301,7 @@
         "agency",
         "resend"
       ],
-      "stack": [
-        "Next.js 14",
-        "TypeScript",
-        "Tailwind CSS",
-        "MDX",
-        "Resend"
-      ],
+      "stack": ["Next.js 14", "TypeScript", "Tailwind CSS", "MDX", "Resend"],
       "status": "Production",
       "language": "TypeScript",
       "languages": {
@@ -4486,16 +4395,8 @@
       "demoUrl": "https://react-vite-tailwind-base.vercel.app/components",
       "liveUrl": "https://react-vite-tailwind-base.vercel.app",
       "homepage": "https://react-vite-tailwind-base.vercel.app",
-      "topics": [
-        "react",
-        "shadcn",
-        "shadcn-ui",
-        "tailwindcss",
-        "vite"
-      ],
-      "categories": [
-        "Templates"
-      ],
+      "topics": ["react", "shadcn", "shadcn-ui", "tailwindcss", "vite"],
+      "categories": ["Templates"],
       "tags": [
         "react",
         "shadcn",

--- a/src/data/skills.generated.json
+++ b/src/data/skills.generated.json
@@ -20,12 +20,7 @@
       "Svelte",
       "Express.js"
     ],
-    "topDatabases": [
-      "PostgreSQL",
-      "Drizzle ORM",
-      "Redis",
-      "pgvector"
-    ],
+    "topDatabases": ["PostgreSQL", "Drizzle ORM", "Redis", "pgvector"],
     "topAPIs": [
       "OpenAI GPT-4o",
       "Anthropic Claude API",
@@ -150,9 +145,7 @@
       {
         "name": "Rust",
         "projectCount": 1,
-        "projects": [
-          "ai-filesense"
-        ],
+        "projects": ["ai-filesense"],
         "firstUsed": "2026-01-12T02:37:39Z",
         "lastUsed": "2026-03-13T01:28:59Z"
       }
@@ -249,45 +242,35 @@
       {
         "name": "Svelte",
         "projectCount": 1,
-        "projects": [
-          "cushlabs-scrollytelling"
-        ],
+        "projects": ["cushlabs-scrollytelling"],
         "firstUsed": "2026-03-06T17:57:40Z",
         "lastUsed": "2026-03-15T04:53:44Z"
       },
       {
         "name": "Express.js",
         "projectCount": 1,
-        "projects": [
-          "cushlabs-ai-voice-agent"
-        ],
+        "projects": ["cushlabs-ai-voice-agent"],
         "firstUsed": "2026-02-23T01:31:09Z",
         "lastUsed": "2026-03-13T04:47:10Z"
       },
       {
         "name": "Flask",
         "projectCount": 1,
-        "projects": [
-          "ai-resume-tailor"
-        ],
+        "projects": ["ai-resume-tailor"],
         "firstUsed": "2025-11-05T18:11:38Z",
         "lastUsed": "2026-03-13T01:29:15Z"
       },
       {
         "name": "FastAPI",
         "projectCount": 1,
-        "projects": [
-          "cushlabs-ai-unwatermark"
-        ],
+        "projects": ["cushlabs-ai-unwatermark"],
         "firstUsed": "2026-03-09T19:14:08Z",
         "lastUsed": "2026-03-17T01:41:55Z"
       },
       {
         "name": "Tauri",
         "projectCount": 1,
-        "projects": [
-          "ai-filesense"
-        ],
+        "projects": ["ai-filesense"],
         "firstUsed": "2026-01-12T02:37:39Z",
         "lastUsed": "2026-03-13T01:28:59Z"
       }
@@ -332,10 +315,7 @@
       {
         "name": "pgvector",
         "projectCount": 2,
-        "projects": [
-          "ai-chatbot-saas",
-          "ny-ai-chatbot"
-        ],
+        "projects": ["ai-chatbot-saas", "ny-ai-chatbot"],
         "firstUsed": "2025-11-23T00:24:28Z",
         "lastUsed": "2026-03-13T22:32:27Z"
       }
@@ -382,74 +362,56 @@
       {
         "name": "Stripe",
         "projectCount": 2,
-        "projects": [
-          "ai-chatbot-saas",
-          "ai-resume-tailor"
-        ],
+        "projects": ["ai-chatbot-saas", "ai-resume-tailor"],
         "firstUsed": "2025-11-05T18:11:38Z",
         "lastUsed": "2026-03-13T22:32:27Z"
       },
       {
         "name": "Twilio",
         "projectCount": 2,
-        "projects": [
-          "cushlabs-ai-voice-agent",
-          "stock-alert"
-        ],
+        "projects": ["cushlabs-ai-voice-agent", "stock-alert"],
         "firstUsed": "2025-10-23T22:24:30Z",
         "lastUsed": "2026-03-13T04:47:10Z"
       },
       {
         "name": "iNaturalist API",
         "projectCount": 1,
-        "projects": [
-          "biojalisco-species-id"
-        ],
+        "projects": ["biojalisco-species-id"],
         "firstUsed": "2026-03-06T18:20:23Z",
         "lastUsed": "2026-03-16T01:17:53Z"
       },
       {
         "name": "GBIF API",
         "projectCount": 1,
-        "projects": [
-          "biojalisco-species-id"
-        ],
+        "projects": ["biojalisco-species-id"],
         "firstUsed": "2026-03-06T18:20:23Z",
         "lastUsed": "2026-03-16T01:17:53Z"
       },
       {
         "name": "EncicloVida/CONABIO API",
         "projectCount": 1,
-        "projects": [
-          "biojalisco-species-id"
-        ],
+        "projects": ["biojalisco-species-id"],
         "firstUsed": "2026-03-06T18:20:23Z",
         "lastUsed": "2026-03-16T01:17:53Z"
       },
       {
         "name": "Google Calendar API",
         "projectCount": 1,
-        "projects": [
-          "cushlabs-ai-voice-agent"
-        ],
+        "projects": ["cushlabs-ai-voice-agent"],
         "firstUsed": "2026-02-23T01:31:09Z",
         "lastUsed": "2026-03-13T04:47:10Z"
       },
       {
         "name": "Cloudflare Workers",
         "projectCount": 1,
-        "projects": [
-          "ny-eng"
-        ],
+        "projects": ["ny-eng"],
         "firstUsed": "2025-03-23T03:27:14Z",
         "lastUsed": "2026-03-15T02:54:06Z"
       },
       {
         "name": "Google Fonts",
         "projectCount": 1,
-        "projects": [
-          "biojalisco-pitch"
-        ],
+        "projects": ["biojalisco-pitch"],
         "firstUsed": "2026-03-04T22:07:57Z",
         "lastUsed": "2026-03-13T01:27:45Z"
       }
@@ -491,18 +453,14 @@
       {
         "name": "Netlify",
         "projectCount": 1,
-        "projects": [
-          "ai-idea-validator"
-        ],
+        "projects": ["ai-idea-validator"],
         "firstUsed": "2026-01-25T01:59:32Z",
         "lastUsed": "2026-03-17T16:58:18Z"
       },
       {
         "name": "Vercel Serverless",
         "projectCount": 1,
-        "projects": [
-          "stock-alert"
-        ],
+        "projects": ["stock-alert"],
         "firstUsed": "2025-10-23T22:24:30Z",
         "lastUsed": "2026-03-13T01:29:20Z"
       }
@@ -565,18 +523,14 @@
       {
         "name": "Cron Jobs",
         "projectCount": 1,
-        "projects": [
-          "ny-ai-chatbot"
-        ],
+        "projects": ["ny-ai-chatbot"],
         "firstUsed": "2025-11-23T00:24:28Z",
         "lastUsed": "2026-03-13T01:29:52Z"
       },
       {
         "name": "localStorage (Phase 1)",
         "projectCount": 1,
-        "projects": [
-          "expat-driver-license-prep"
-        ],
+        "projects": ["expat-driver-license-prep"],
         "firstUsed": "2026-03-03T07:21:12Z",
         "lastUsed": "2026-03-13T01:29:37Z"
       }
@@ -585,9 +539,7 @@
       {
         "name": "Uvicorn",
         "projectCount": 1,
-        "projects": [
-          "cushlabs-ai-unwatermark"
-        ],
+        "projects": ["cushlabs-ai-unwatermark"],
         "firstUsed": "2026-03-09T19:14:08Z",
         "lastUsed": "2026-03-17T01:41:55Z"
       }
@@ -754,484 +706,371 @@
       {
         "name": "LangChain (OpenAI)",
         "projectCount": 2,
-        "projects": [
-          "ai-chatbot-saas",
-          "ny-ai-chatbot"
-        ],
+        "projects": ["ai-chatbot-saas", "ny-ai-chatbot"],
         "firstUsed": "2025-11-23T00:24:28Z",
         "lastUsed": "2026-03-13T22:32:27Z"
       },
       {
         "name": "Cheerio",
         "projectCount": 2,
-        "projects": [
-          "ai-chatbot-saas",
-          "ny-ai-chatbot"
-        ],
+        "projects": ["ai-chatbot-saas", "ny-ai-chatbot"],
         "firstUsed": "2025-11-23T00:24:28Z",
         "lastUsed": "2026-03-13T22:32:27Z"
       },
       {
         "name": "nanoid",
         "projectCount": 2,
-        "projects": [
-          "ai-chatbot-saas",
-          "ny-ai-chatbot"
-        ],
+        "projects": ["ai-chatbot-saas", "ny-ai-chatbot"],
         "firstUsed": "2025-11-23T00:24:28Z",
         "lastUsed": "2026-03-13T22:32:27Z"
       },
       {
         "name": "Requests",
         "projectCount": 2,
-        "projects": [
-          "ai-resume-tailor",
-          "stock-alert"
-        ],
+        "projects": ["ai-resume-tailor", "stock-alert"],
         "firstUsed": "2025-10-23T22:24:30Z",
         "lastUsed": "2026-03-13T01:29:20Z"
       },
       {
         "name": "Pillow",
         "projectCount": 2,
-        "projects": [
-          "cushlabs-ai-unwatermark",
-          "stock-alert"
-        ],
+        "projects": ["cushlabs-ai-unwatermark", "stock-alert"],
         "firstUsed": "2025-10-23T22:24:30Z",
         "lastUsed": "2026-03-17T01:41:55Z"
       },
       {
         "name": "Zustand 4.4",
         "projectCount": 2,
-        "projects": [
-          "comp-plan-simulator",
-          "freelance-income-planner"
-        ],
+        "projects": ["comp-plan-simulator", "freelance-income-planner"],
         "firstUsed": "2025-12-11T17:38:35Z",
         "lastUsed": "2026-03-13T01:29:32Z"
       },
       {
         "name": "next-intl",
         "projectCount": 2,
-        "projects": [
-          "ai-filesense-website",
-          "ai-stock-alert-website"
-        ],
+        "projects": ["ai-filesense-website", "ai-stock-alert-website"],
         "firstUsed": "2026-01-13T22:16:37Z",
         "lastUsed": "2026-03-13T01:29:27Z"
       },
       {
         "name": "EXIF Extraction (exifr)",
         "projectCount": 1,
-        "projects": [
-          "biojalisco-species-id"
-        ],
+        "projects": ["biojalisco-species-id"],
         "firstUsed": "2026-03-06T18:20:23Z",
         "lastUsed": "2026-03-16T01:17:53Z"
       },
       {
         "name": "OpenStreetMap Nominatim (reverse geocoding)",
         "projectCount": 1,
-        "projects": [
-          "biojalisco-species-id"
-        ],
+        "projects": ["biojalisco-species-id"],
         "firstUsed": "2026-03-06T18:20:23Z",
         "lastUsed": "2026-03-16T01:17:53Z"
       },
       {
         "name": "Three.js",
         "projectCount": 1,
-        "projects": [
-          "cushlabs-scrollytelling"
-        ],
+        "projects": ["cushlabs-scrollytelling"],
         "firstUsed": "2026-03-06T17:57:40Z",
         "lastUsed": "2026-03-15T04:53:44Z"
       },
       {
         "name": "Vapi",
         "projectCount": 1,
-        "projects": [
-          "cushlabs-ai-voice-agent"
-        ],
+        "projects": ["cushlabs-ai-voice-agent"],
         "firstUsed": "2026-02-23T01:31:09Z",
         "lastUsed": "2026-03-13T04:47:10Z"
       },
       {
         "name": "Claude Sonnet",
         "projectCount": 1,
-        "projects": [
-          "cushlabs-ai-voice-agent"
-        ],
+        "projects": ["cushlabs-ai-voice-agent"],
         "firstUsed": "2026-02-23T01:31:09Z",
         "lastUsed": "2026-03-13T04:47:10Z"
       },
       {
         "name": "Groq Llama 3.1",
         "projectCount": 1,
-        "projects": [
-          "cushlabs-ai-voice-agent"
-        ],
+        "projects": ["cushlabs-ai-voice-agent"],
         "firstUsed": "2026-02-23T01:31:09Z",
         "lastUsed": "2026-03-13T04:47:10Z"
       },
       {
         "name": "Deepgram Nova-2/3",
         "projectCount": 1,
-        "projects": [
-          "cushlabs-ai-voice-agent"
-        ],
+        "projects": ["cushlabs-ai-voice-agent"],
         "firstUsed": "2026-02-23T01:31:09Z",
         "lastUsed": "2026-03-13T04:47:10Z"
       },
       {
         "name": "Cartesia",
         "projectCount": 1,
-        "projects": [
-          "cushlabs-ai-voice-agent"
-        ],
+        "projects": ["cushlabs-ai-voice-agent"],
         "firstUsed": "2026-02-23T01:31:09Z",
         "lastUsed": "2026-03-13T04:47:10Z"
       },
       {
         "name": "ReportLab",
         "projectCount": 1,
-        "projects": [
-          "cushlabs-ai-marketing"
-        ],
+        "projects": ["cushlabs-ai-marketing"],
         "firstUsed": "2026-03-08T19:31:57Z",
         "lastUsed": "2026-03-13T01:28:05Z"
       },
       {
         "name": "Claude Code Skills System",
         "projectCount": 1,
-        "projects": [
-          "cushlabs-ai-marketing"
-        ],
+        "projects": ["cushlabs-ai-marketing"],
         "firstUsed": "2026-03-08T19:31:57Z",
         "lastUsed": "2026-03-13T01:28:05Z"
       },
       {
         "name": "Bash",
         "projectCount": 1,
-        "projects": [
-          "cushlabs-ai-marketing"
-        ],
+        "projects": ["cushlabs-ai-marketing"],
         "firstUsed": "2026-03-08T19:31:57Z",
         "lastUsed": "2026-03-13T01:28:05Z"
       },
       {
         "name": "HTML Parser (stdlib)",
         "projectCount": 1,
-        "projects": [
-          "cushlabs-ai-marketing"
-        ],
+        "projects": ["cushlabs-ai-marketing"],
         "firstUsed": "2026-03-08T19:31:57Z",
         "lastUsed": "2026-03-13T01:28:05Z"
       },
       {
         "name": "pdf-lib",
         "projectCount": 1,
-        "projects": [
-          "ny-eng"
-        ],
+        "projects": ["ny-eng"],
         "firstUsed": "2025-03-23T03:27:14Z",
         "lastUsed": "2026-03-15T02:54:06Z"
       },
       {
         "name": "HTML5",
         "projectCount": 1,
-        "projects": [
-          "biojalisco-pitch"
-        ],
+        "projects": ["biojalisco-pitch"],
         "firstUsed": "2026-03-04T22:07:57Z",
         "lastUsed": "2026-03-13T01:27:45Z"
       },
       {
         "name": "CSS3 (custom properties, grid, flexbox, scroll-snap)",
         "projectCount": 1,
-        "projects": [
-          "biojalisco-pitch"
-        ],
+        "projects": ["biojalisco-pitch"],
         "firstUsed": "2026-03-04T22:07:57Z",
         "lastUsed": "2026-03-13T01:27:45Z"
       },
       {
         "name": "Intersection Observer API",
         "projectCount": 1,
-        "projects": [
-          "biojalisco-pitch"
-        ],
+        "projects": ["biojalisco-pitch"],
         "firstUsed": "2026-03-04T22:07:57Z",
         "lastUsed": "2026-03-13T01:27:45Z"
       },
       {
         "name": "Web Audio API (procedural ambient + MP3 narration)",
         "projectCount": 1,
-        "projects": [
-          "biojalisco-pitch"
-        ],
+        "projects": ["biojalisco-pitch"],
         "firstUsed": "2026-03-04T22:07:57Z",
         "lastUsed": "2026-03-13T01:27:45Z"
       },
       {
         "name": "Base64 image embedding",
         "projectCount": 1,
-        "projects": [
-          "biojalisco-pitch"
-        ],
+        "projects": ["biojalisco-pitch"],
         "firstUsed": "2026-03-04T22:07:57Z",
         "lastUsed": "2026-03-13T01:27:45Z"
       },
       {
         "name": "SM-2 Spaced Repetition",
         "projectCount": 1,
-        "projects": [
-          "expat-driver-license-prep"
-        ],
+        "projects": ["expat-driver-license-prep"],
         "firstUsed": "2026-03-03T07:21:12Z",
         "lastUsed": "2026-03-13T01:29:37Z"
       },
       {
         "name": "JSON Content Collections",
         "projectCount": 1,
-        "projects": [
-          "expat-driver-license-prep"
-        ],
+        "projects": ["expat-driver-license-prep"],
         "firstUsed": "2026-03-03T07:21:12Z",
         "lastUsed": "2026-03-13T01:29:37Z"
       },
       {
         "name": "i18next",
         "projectCount": 1,
-        "projects": [
-          "ai-resume-tailor"
-        ],
+        "projects": ["ai-resume-tailor"],
         "firstUsed": "2025-11-05T18:11:38Z",
         "lastUsed": "2026-03-13T01:29:15Z"
       },
       {
         "name": "Beautiful Soup",
         "projectCount": 1,
-        "projects": [
-          "ai-resume-tailor"
-        ],
+        "projects": ["ai-resume-tailor"],
         "firstUsed": "2025-11-05T18:11:38Z",
         "lastUsed": "2026-03-13T01:29:15Z"
       },
       {
         "name": "JWT",
         "projectCount": 1,
-        "projects": [
-          "ai-resume-tailor"
-        ],
+        "projects": ["ai-resume-tailor"],
         "firstUsed": "2025-11-05T18:11:38Z",
         "lastUsed": "2026-03-13T01:29:15Z"
       },
       {
         "name": "PyMuPDF",
         "projectCount": 1,
-        "projects": [
-          "cushlabs-ai-unwatermark"
-        ],
+        "projects": ["cushlabs-ai-unwatermark"],
         "firstUsed": "2026-03-09T19:14:08Z",
         "lastUsed": "2026-03-17T01:41:55Z"
       },
       {
         "name": "Click",
         "projectCount": 1,
-        "projects": [
-          "cushlabs-ai-unwatermark"
-        ],
+        "projects": ["cushlabs-ai-unwatermark"],
         "firstUsed": "2026-03-09T19:14:08Z",
         "lastUsed": "2026-03-17T01:41:55Z"
       },
       {
         "name": "NumPy",
         "projectCount": 1,
-        "projects": [
-          "cushlabs-ai-unwatermark"
-        ],
+        "projects": ["cushlabs-ai-unwatermark"],
         "firstUsed": "2026-03-09T19:14:08Z",
         "lastUsed": "2026-03-17T01:41:55Z"
       },
       {
         "name": "SciPy",
         "projectCount": 1,
-        "projects": [
-          "cushlabs-ai-unwatermark"
-        ],
+        "projects": ["cushlabs-ai-unwatermark"],
         "firstUsed": "2026-03-09T19:14:08Z",
         "lastUsed": "2026-03-17T01:41:55Z"
       },
       {
         "name": "Multipart Form Handling",
         "projectCount": 1,
-        "projects": [
-          "cushlabs-ai-unwatermark"
-        ],
+        "projects": ["cushlabs-ai-unwatermark"],
         "firstUsed": "2026-03-09T19:14:08Z",
         "lastUsed": "2026-03-17T01:41:55Z"
       },
       {
         "name": "HTML / CSS / JS",
         "projectCount": 1,
-        "projects": [
-          "context-writing-system"
-        ],
+        "projects": ["context-writing-system"],
         "firstUsed": "2025-12-20T10:31:00Z",
         "lastUsed": "2026-03-17T04:23:07Z"
       },
       {
         "name": "JSON Context Files",
         "projectCount": 1,
-        "projects": [
-          "context-writing-system"
-        ],
+        "projects": ["context-writing-system"],
         "firstUsed": "2025-12-20T10:31:00Z",
         "lastUsed": "2026-03-17T04:23:07Z"
       },
       {
         "name": "Markdown Skills",
         "projectCount": 1,
-        "projects": [
-          "context-writing-system"
-        ],
+        "projects": ["context-writing-system"],
         "firstUsed": "2025-12-20T10:31:00Z",
         "lastUsed": "2026-03-17T04:23:07Z"
       },
       {
         "name": "Context Engineering",
         "projectCount": 1,
-        "projects": [
-          "context-writing-system"
-        ],
+        "projects": ["context-writing-system"],
         "firstUsed": "2025-12-20T10:31:00Z",
         "lastUsed": "2026-03-17T04:23:07Z"
       },
       {
         "name": "Claims Policy Engine",
         "projectCount": 1,
-        "projects": [
-          "context-writing-system"
-        ],
+        "projects": ["context-writing-system"],
         "firstUsed": "2025-12-20T10:31:00Z",
         "lastUsed": "2026-03-17T04:23:07Z"
       },
       {
         "name": "Formspree",
         "projectCount": 1,
-        "projects": [
-          "ai-idea-validator"
-        ],
+        "projects": ["ai-idea-validator"],
         "firstUsed": "2026-01-25T01:59:32Z",
         "lastUsed": "2026-03-17T16:58:18Z"
       },
       {
         "name": "GitHub API",
         "projectCount": 1,
-        "projects": [
-          "ai-portfolio"
-        ],
+        "projects": ["ai-portfolio"],
         "firstUsed": "2026-01-05T15:06:48Z",
         "lastUsed": "2026-03-16T21:04:13Z"
       },
       {
         "name": "Claude Haiku",
         "projectCount": 1,
-        "projects": [
-          "ai-filesense"
-        ],
+        "projects": ["ai-filesense"],
         "firstUsed": "2026-01-12T02:37:39Z",
         "lastUsed": "2026-03-13T01:28:59Z"
       },
       {
         "name": "PyQt6",
         "projectCount": 1,
-        "projects": [
-          "stock-alert"
-        ],
+        "projects": ["stock-alert"],
         "firstUsed": "2025-10-23T22:24:30Z",
         "lastUsed": "2026-03-13T01:29:20Z"
       },
       {
         "name": "Finnhub API",
         "projectCount": 1,
-        "projects": [
-          "stock-alert"
-        ],
+        "projects": ["stock-alert"],
         "firstUsed": "2025-10-23T22:24:30Z",
         "lastUsed": "2026-03-13T01:29:20Z"
       },
       {
         "name": "Remark",
         "projectCount": 1,
-        "projects": [
-          "marble-does-not-yield"
-        ],
+        "projects": ["marble-does-not-yield"],
         "firstUsed": "2026-01-04T03:47:35Z",
         "lastUsed": "2026-03-13T01:29:42Z"
       },
       {
         "name": "Axios",
         "projectCount": 1,
-        "projects": [
-          "mazebreak-trello"
-        ],
+        "projects": ["mazebreak-trello"],
         "firstUsed": "2026-02-17T04:40:23Z",
         "lastUsed": "2026-03-13T01:28:23Z"
       },
       {
         "name": "Node.js",
         "projectCount": 1,
-        "projects": [
-          "mazebreak-trello"
-        ],
+        "projects": ["mazebreak-trello"],
         "firstUsed": "2026-02-17T04:40:23Z",
         "lastUsed": "2026-03-13T01:28:23Z"
       },
       {
         "name": "dotenv",
         "projectCount": 1,
-        "projects": [
-          "mazebreak-trello"
-        ],
+        "projects": ["mazebreak-trello"],
         "firstUsed": "2026-02-17T04:40:23Z",
         "lastUsed": "2026-03-13T01:28:23Z"
       },
       {
         "name": "Fuse.js",
         "projectCount": 1,
-        "projects": [
-          "mazebreak-wiki"
-        ],
+        "projects": ["mazebreak-wiki"],
         "firstUsed": "2026-02-10T04:11:19Z",
         "lastUsed": "2026-03-16T23:00:46Z"
       },
       {
         "name": "MDX",
         "projectCount": 1,
-        "projects": [
-          "nextjs-react-agency-starter"
-        ],
+        "projects": ["nextjs-react-agency-starter"],
         "firstUsed": "2025-12-18T20:18:05Z",
         "lastUsed": "2026-03-13T01:29:47Z"
       },
       {
         "name": "ShadCN UI (Radix)",
         "projectCount": 1,
-        "projects": [
-          "react-vite-tailwind-base"
-        ],
+        "projects": ["react-vite-tailwind-base"],
         "firstUsed": "2025-10-02T22:40:01Z",
         "lastUsed": "2026-03-13T01:29:57Z"
       },
       {
         "name": "MSW",
         "projectCount": 1,
-        "projects": [
-          "react-vite-tailwind-base"
-        ],
+        "projects": ["react-vite-tailwind-base"],
         "firstUsed": "2025-10-02T22:40:01Z",
         "lastUsed": "2026-03-13T01:29:57Z"
       }
@@ -1251,15 +1090,8 @@
         "Netlify",
         "Formspree"
       ],
-      "patterns": [
-        "PWA",
-        "REST API"
-      ],
-      "languages": [
-        "TypeScript",
-        "JavaScript",
-        "CSS"
-      ],
+      "patterns": ["PWA", "REST API"],
+      "languages": ["TypeScript", "JavaScript", "CSS"],
       "createdAt": "2026-01-25T01:59:32Z",
       "lastPushed": "2026-03-17T16:58:18Z"
     },
@@ -1277,13 +1109,7 @@
         "Claims Policy Engine"
       ],
       "patterns": [],
-      "languages": [
-        "JavaScript",
-        "HTML/CSS",
-        "HTML",
-        "CSS",
-        "PowerShell"
-      ],
+      "languages": ["JavaScript", "HTML/CSS", "HTML", "CSS", "PowerShell"],
       "createdAt": "2025-12-20T10:31:00Z",
       "lastPushed": "2026-03-17T04:23:07Z"
     },
@@ -1307,10 +1133,7 @@
         "Render"
       ],
       "patterns": [],
-      "languages": [
-        "Python",
-        "Shell"
-      ],
+      "languages": ["Python", "Shell"],
       "createdAt": "2026-03-09T19:14:08Z",
       "lastPushed": "2026-03-17T01:41:55Z"
     },
@@ -1329,13 +1152,7 @@
         "Fuse.js"
       ],
       "patterns": [],
-      "languages": [
-        "JavaScript",
-        "HTML/CSS",
-        "Python",
-        "CSS",
-        "HTML"
-      ],
+      "languages": ["JavaScript", "HTML/CSS", "Python", "CSS", "HTML"],
       "createdAt": "2026-02-10T04:11:19Z",
       "lastPushed": "2026-03-16T23:00:46Z"
     },
@@ -1356,15 +1173,8 @@
         "Vercel",
         "GitHub API"
       ],
-      "patterns": [
-        "Internationalization (i18n)"
-      ],
-      "languages": [
-        "TypeScript",
-        "JavaScript",
-        "PowerShell",
-        "CSS"
-      ],
+      "patterns": ["Internationalization (i18n)"],
+      "languages": ["TypeScript", "JavaScript", "PowerShell", "CSS"],
       "createdAt": "2026-01-05T15:06:48Z",
       "lastPushed": "2026-03-16T21:04:13Z"
     },
@@ -1389,14 +1199,8 @@
         "EncicloVida/CONABIO API",
         "OpenStreetMap Nominatim (reverse geocoding)"
       ],
-      "patterns": [
-        "PWA"
-      ],
-      "languages": [
-        "TypeScript",
-        "JavaScript",
-        "CSS"
-      ],
+      "patterns": ["PWA"],
+      "languages": ["TypeScript", "JavaScript", "CSS"],
       "createdAt": "2026-03-06T18:20:23Z",
       "lastPushed": "2026-03-16T01:17:53Z"
     },
@@ -1412,14 +1216,8 @@
         "Three.js",
         "Vercel"
       ],
-      "patterns": [
-        "Monorepo"
-      ],
-      "languages": [
-        "JavaScript",
-        "TypeScript",
-        "CSS"
-      ],
+      "patterns": ["Monorepo"],
+      "languages": ["JavaScript", "TypeScript", "CSS"],
       "createdAt": "2026-03-06T17:57:40Z",
       "lastPushed": "2026-03-15T04:53:44Z"
     },
@@ -1442,10 +1240,7 @@
         "Vercel",
         "Cloudflare Workers"
       ],
-      "patterns": [
-        "Internationalization (i18n)",
-        "REST API"
-      ],
+      "patterns": ["Internationalization (i18n)", "REST API"],
       "languages": [
         "TypeScript",
         "JavaScript",
@@ -1488,13 +1283,7 @@
         "OpenAI GPT-4o"
       ],
       "patterns": [],
-      "languages": [
-        "TypeScript",
-        "JavaScript",
-        "SQL",
-        "HTML/CSS",
-        "CSS"
-      ],
+      "languages": ["TypeScript", "JavaScript", "SQL", "HTML/CSS", "CSS"],
       "createdAt": "2025-12-02T07:09:31Z",
       "lastPushed": "2026-03-13T22:32:27Z"
     },
@@ -1517,15 +1306,8 @@
         "Twilio",
         "Google Calendar API"
       ],
-      "patterns": [
-        "PWA"
-      ],
-      "languages": [
-        "JavaScript",
-        "HTML/CSS",
-        "HTML",
-        "CSS"
-      ],
+      "patterns": ["PWA"],
+      "languages": ["JavaScript", "HTML/CSS", "HTML", "CSS"],
       "createdAt": "2026-02-23T01:31:09Z",
       "lastPushed": "2026-03-13T04:47:10Z"
     },
@@ -1546,17 +1328,8 @@
         "ShadCN UI (Radix)",
         "MSW"
       ],
-      "patterns": [
-        "PWA",
-        "Monorepo"
-      ],
-      "languages": [
-        "TypeScript",
-        "JavaScript",
-        "HTML/CSS",
-        "HTML",
-        "CSS"
-      ],
+      "patterns": ["PWA", "Monorepo"],
+      "languages": ["TypeScript", "JavaScript", "HTML/CSS", "HTML", "CSS"],
       "createdAt": "2025-10-02T22:40:01Z",
       "lastPushed": "2026-03-13T01:29:57Z"
     },
@@ -1588,9 +1361,7 @@
         "GitHub Actions",
         "OpenAI GPT-4o"
       ],
-      "patterns": [
-        "Cron Jobs"
-      ],
+      "patterns": ["Cron Jobs"],
       "languages": [
         "TypeScript",
         "JavaScript",
@@ -1619,11 +1390,7 @@
         "MDX"
       ],
       "patterns": [],
-      "languages": [
-        "TypeScript",
-        "JavaScript",
-        "CSS"
-      ],
+      "languages": ["TypeScript", "JavaScript", "CSS"],
       "createdAt": "2025-12-18T20:18:05Z",
       "lastPushed": "2026-03-13T01:29:47Z"
     },
@@ -1640,14 +1407,8 @@
         "Tailwind CSS 3",
         "Vercel"
       ],
-      "patterns": [
-        "Internationalization (i18n)"
-      ],
-      "languages": [
-        "TypeScript",
-        "JavaScript",
-        "CSS"
-      ],
+      "patterns": ["Internationalization (i18n)"],
+      "languages": ["TypeScript", "JavaScript", "CSS"],
       "createdAt": "2026-01-04T03:47:35Z",
       "lastPushed": "2026-03-13T01:29:42Z"
     },
@@ -1667,16 +1428,8 @@
         "SM-2 Spaced Repetition",
         "JSON Content Collections"
       ],
-      "patterns": [
-        "Monorepo",
-        "localStorage (Phase 1)"
-      ],
-      "languages": [
-        "TypeScript",
-        "JavaScript",
-        "Python",
-        "CSS"
-      ],
+      "patterns": ["Monorepo", "localStorage (Phase 1)"],
+      "languages": ["TypeScript", "JavaScript", "Python", "CSS"],
       "createdAt": "2026-03-03T07:21:12Z",
       "lastPushed": "2026-03-13T01:29:37Z"
     },
@@ -1695,14 +1448,8 @@
         "Vercel",
         "Zustand"
       ],
-      "patterns": [
-        "Monorepo"
-      ],
-      "languages": [
-        "TypeScript",
-        "JavaScript",
-        "CSS"
-      ],
+      "patterns": ["Monorepo"],
+      "languages": ["TypeScript", "JavaScript", "CSS"],
       "createdAt": "2026-02-13T19:55:19Z",
       "lastPushed": "2026-03-13T01:29:32Z"
     },
@@ -1721,15 +1468,8 @@
         "Tailwind CSS 4",
         "shadcn/ui"
       ],
-      "patterns": [
-        "Internationalization (i18n)"
-      ],
-      "languages": [
-        "TypeScript",
-        "JavaScript",
-        "HTML/CSS",
-        "CSS"
-      ],
+      "patterns": ["Internationalization (i18n)"],
+      "languages": ["TypeScript", "JavaScript", "HTML/CSS", "CSS"],
       "createdAt": "2026-01-23T00:50:02Z",
       "lastPushed": "2026-03-13T01:29:27Z"
     },
@@ -1747,10 +1487,7 @@
         "Vercel Serverless"
       ],
       "patterns": [],
-      "languages": [
-        "Python",
-        "PowerShell"
-      ],
+      "languages": ["Python", "PowerShell"],
       "createdAt": "2025-10-23T22:24:30Z",
       "lastPushed": "2026-03-13T01:29:20Z"
     },
@@ -1779,9 +1516,7 @@
         "Vercel",
         "Render"
       ],
-      "patterns": [
-        "Monorepo"
-      ],
+      "patterns": ["Monorepo"],
       "languages": [
         "JavaScript",
         "TypeScript",
@@ -1811,14 +1546,8 @@
         "Vercel",
         "Resend"
       ],
-      "patterns": [
-        "Internationalization (i18n)"
-      ],
-      "languages": [
-        "TypeScript",
-        "JavaScript",
-        "CSS"
-      ],
+      "patterns": ["Internationalization (i18n)"],
+      "languages": ["TypeScript", "JavaScript", "CSS"],
       "createdAt": "2026-01-13T22:16:37Z",
       "lastPushed": "2026-03-13T01:29:05Z"
     },
@@ -1827,15 +1556,8 @@
       "title": "AI FileSense",
       "category": "AI Automation",
       "status": "Demo",
-      "techStack": [
-        "Tauri",
-        "React 18",
-        "Tailwind CSS 3",
-        "Claude Haiku"
-      ],
-      "patterns": [
-        "Internationalization (i18n)"
-      ],
+      "techStack": ["Tauri", "React 18", "Tailwind CSS 3", "Claude Haiku"],
+      "patterns": ["Internationalization (i18n)"],
       "languages": [
         "TypeScript",
         "JavaScript",
@@ -1862,14 +1584,8 @@
         "shadcn/ui",
         "Vercel"
       ],
-      "patterns": [
-        "Monorepo"
-      ],
-      "languages": [
-        "TypeScript",
-        "JavaScript",
-        "CSS"
-      ],
+      "patterns": ["Monorepo"],
+      "languages": ["TypeScript", "JavaScript", "CSS"],
       "createdAt": "2026-02-13T18:42:29Z",
       "lastPushed": "2026-03-13T01:28:54Z"
     },
@@ -1878,20 +1594,9 @@
       "title": "MazeBreak Trello Board Automation",
       "category": "Developer Tools",
       "status": null,
-      "techStack": [
-        "Axios",
-        "Vercel",
-        "Node.js",
-        "dotenv"
-      ],
-      "patterns": [
-        "Trello REST API"
-      ],
-      "languages": [
-        "JavaScript",
-        "HTML/CSS",
-        "HTML"
-      ],
+      "techStack": ["Axios", "Vercel", "Node.js", "dotenv"],
+      "patterns": ["Trello REST API"],
+      "languages": ["JavaScript", "HTML/CSS", "HTML"],
       "createdAt": "2026-02-17T04:40:23Z",
       "lastPushed": "2026-03-13T01:28:23Z"
     },
@@ -1911,11 +1616,7 @@
         "Zustand 4.4"
       ],
       "patterns": [],
-      "languages": [
-        "TypeScript",
-        "JavaScript",
-        "CSS"
-      ],
+      "languages": ["TypeScript", "JavaScript", "CSS"],
       "createdAt": "2025-12-11T17:38:35Z",
       "lastPushed": "2026-03-13T01:28:18Z"
     },
@@ -1931,16 +1632,13 @@
         "HTML Parser (stdlib)"
       ],
       "patterns": [],
-      "languages": [
-        "Python",
-        "Shell"
-      ],
+      "languages": ["Python", "Shell"],
       "createdAt": "2026-03-08T19:31:57Z",
       "lastPushed": "2026-03-13T01:28:05Z"
     },
     {
       "name": "biojalisco-pitch",
-      "title": "BioJalisco — Biodiversity Atlas Pitch Site + Species Identifier",
+      "title": "BioJalisco — Cinematic Scrollytelling Pitch Site",
       "category": "Client Work",
       "status": null,
       "techStack": [
@@ -1955,14 +1653,8 @@
         "Google Fonts",
         "Base64 image embedding"
       ],
-      "patterns": [
-        "REST API"
-      ],
-      "languages": [
-        "Python",
-        "HTML/CSS",
-        "HTML"
-      ],
+      "patterns": ["REST API"],
+      "languages": ["Python", "HTML/CSS", "HTML"],
       "createdAt": "2026-03-04T22:07:57Z",
       "lastPushed": "2026-03-13T01:27:45Z"
     },
@@ -1978,17 +1670,8 @@
         "Vite 7",
         "OpenAI GPT-4o-mini"
       ],
-      "patterns": [
-        "Internationalization (i18n)",
-        "Monorepo"
-      ],
-      "languages": [
-        "TypeScript",
-        "JavaScript",
-        "HTML/CSS",
-        "CSS",
-        "HTML"
-      ],
+      "patterns": ["Internationalization (i18n)", "Monorepo"],
+      "languages": ["TypeScript", "JavaScript", "HTML/CSS", "CSS", "HTML"],
       "createdAt": "2025-09-23T19:15:28Z",
       "lastPushed": "2026-03-13T01:27:40Z"
     }

--- a/src/pages/es/projects/[slug].astro
+++ b/src/pages/es/projects/[slug].astro
@@ -28,7 +28,7 @@ const metaTitles: Record<string, string> = {
   'ai-chatbot-saas': 'Converso AI — Chatbot Bilingüe SaaS',
   'ny-ai-chatbot': 'Chatbot IA para Sitios Web de PYMES',
   'ny-english-messenger-bot': 'NY English Messenger — Asistente Bilingüe IA',
-  'biojalisco-pitch': 'BioJalisco — Atlas de Biodiversidad',
+  'biojalisco-pitch': 'BioJalisco — Sitio de Presentación Cinematográfico',
   'expat-driver-license-prep': 'ExpatDrive — Examen de Licencia Bilingüe',
   'cushlabs-marketsignal': 'MarketSignal — Inteligencia Competitiva Local',
 };
@@ -45,7 +45,7 @@ const metaDescriptions: Record<string, string> = {
   'ai-chatbot-saas': 'Chatbot SaaS multi-tenant con soporte bilingüe, base de conocimiento e widget embebible. Automatiza atención al cliente y ventas.',
   'ny-ai-chatbot': 'Widget de chatbot con IA, inteligencia RAG, soporte multi-idioma y panel de administración. Solución plug-and-play para sitios web de PYMES.',
   'cushlabs-OS-dashboard': 'Dashboard interno de operaciones con analíticas en vivo del portafolio de GitHub, monitoreo de despliegues y métricas de salud de proyectos para CushLabs.',
-  'biojalisco-pitch': 'Sitio de pitch con scrollytelling cinematográfico para una plataforma de biodiversidad ciudadana en el occidente de México. Next.js, animaciones y contenido bilingüe.',
+  'biojalisco-pitch': 'Sitio de pitch con scrollytelling cinematográfico para una plataforma de biodiversidad ciudadana en el occidente de México. HTML5 autocontenido, animaciones por scroll y contenido bilingüe.',
   'ai-resume-tailor': 'Herramienta de optimización de CV con IA que analiza descripciones de empleo y adapta tu currículum. Identifica brechas de habilidades y mejora tu puntuación ATS.',
   'comp-plan-simulator': 'Simulador interactivo de planes de compensación para empresas de venta directa. Modela ingresos por rango, visualiza escenarios de crecimiento y compara estructuras.',
   'cushlabs-ai-dispatch': 'Plataforma Claude Dispatch para operaciones multi-tenant, integración móvil y coordinación de agentes IA. Fase de investigación de arquitectura serverless.',

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -39,7 +39,7 @@ const metaDescriptions: Record<string, string> = {
   'ai-chatbot-saas': 'Multi-tenant AI chatbot SaaS with bilingual support, knowledge base integration, and embeddable widget. Automates front desk and sales.',
   'ny-ai-chatbot': 'Production-ready AI chatbot widget with RAG intelligence, multi-language support, and admin dashboard. Drop-in solution for small business websites.',
   'cushlabs-OS-dashboard': 'Internal operations dashboard with live GitHub portfolio analytics, deployment status monitoring, and project health metrics for CushLabs management.',
-  'biojalisco-pitch': 'Cinematic scrollytelling pitch site for a citizen-science biodiversity platform in western Mexico. Built with Next.js, scroll-triggered animations, and bilingual content.',
+  'biojalisco-pitch': 'Cinematic scrollytelling pitch site for a citizen-science biodiversity platform in western Mexico. Built as self-contained HTML5 with scroll-triggered animations and bilingual content.',
   'ai-resume-tailor': 'AI-powered resume optimization tool that analyzes job descriptions and tailors your resume to match. Highlights skill gaps and suggests improvements for better ATS scores.',
   'comp-plan-simulator': 'Interactive compensation plan simulator for direct-selling companies. Model earnings across ranks, visualize team growth scenarios, and compare plan structures.',
   'cushlabs-ai-dispatch': 'Claude Dispatch platform for multi-tenant operations, mobile integration, and AI agent coordination. Research phase exploring serverless architecture.',


### PR DESCRIPTION
## Problem
The `biojalisco-pitch` project rendered **four different titles** across the portfolio:

| Location | Was |
|---|---|
| EN card | BioJalisco — Biodiversity Atlas Pitch Site + Species Identifier |
| Detail headline | BioJalisco Pitch Site |
| Generated `title` | Scrollytelling Pitch Site — BioJalisco Biodiversity Vision |
| ES card | BioJalisco — Atlas de Biodiversidad e Identificador de Especies |

## Fix — single canonical title
- **EN:** BioJalisco — Cinematic Scrollytelling Pitch Site
- **ES:** BioJalisco — Sitio de Presentación Cinematográfico

EN card, detail headline, and SEO title now all derive from the single generated `title`, so they cannot drift again. ES overrides aligned to the canonical ES string.

## Bonus
EN + ES SEO meta descriptions falsely claimed the site was **"Built with Next.js"** — corrected to self-contained HTML5 (this project has zero Next.js).

## Files
- `src/data/projects.generated.json`, `src/data/skills.generated.json` — canonical EN title
- `src/data/projectCardsEs.ts`, `src/data/projectDetails.ts` — EN/ES card + detail headlines
- `src/pages/projects/[slug].astro`, `src/pages/es/projects/[slug].astro` — ES SEO title + Next.js fact fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)