### PR TITLE
chore: make BioJalisco ES title single-source (no drift)

### DIFF
--- a/src/data/esCanonicalTitles.ts
+++ b/src/data/esCanonicalTitles.ts
@@ -1,0 +1,14 @@
+// Canonical Spanish (es-MX) portfolio titles — single source of truth.
+//
+// English titles single-source from `projects.generated.json` `title` (built from
+// each repo's PORTFOLIO.md). There is no generated ES title, so the canonical ES
+// string for a project lives HERE and is referenced by every ES render path:
+//   - the ES card title       (projectCardsEs.ts)
+//   - the ES detail headline  (projectDetails.ts)
+//   - the ES SEO <title>       (src/pages/es/projects/[slug].astro)
+//
+// Edit the value in this file and all three ES surfaces update together — they
+// cannot drift. Add new entries here as ES titles need to be pinned across surfaces.
+
+export const ES_TITLE_BIOJALISCO_PITCH =
+  "BioJalisco — Sitio de Presentación Cinematográfico";

--- a/src/data/projectCardsEs.ts
+++ b/src/data/projectCardsEs.ts
@@ -15,6 +15,8 @@
 // in prose, "agendar". Common dev anglicisms (full-stack, pipeline, serverless, scroll)
 // are kept as they read naturally to a Mexican technical audience.
 
+import { ES_TITLE_BIOJALISCO_PITCH } from "./esCanonicalTitles";
+
 export interface EsCardCopy {
   /** Omit to keep the English brand/product name. */
   title?: string;
@@ -85,7 +87,7 @@ export const esCardCopy: Record<string, EsCardCopy> = {
       "Optimización de CV para sistemas ATS con IA, soporte bilingüe y retroalimentación instantánea",
   },
   "biojalisco-pitch": {
-    title: "BioJalisco — Sitio de Presentación Cinematográfico",
+    title: ES_TITLE_BIOJALISCO_PITCH,
     tagline:
       "Sitio de pitch con scrollytelling cinematográfico e identificación de especies con IA para la plataforma de biodiversidad del occidente de México",
   },

--- a/src/data/projectDetails.ts
+++ b/src/data/projectDetails.ts
@@ -1,3 +1,5 @@
+import { ES_TITLE_BIOJALISCO_PITCH } from "./esCanonicalTitles";
+
 export type ProjectDetailLocale = {
   headline: string;
   subheadline: string;
@@ -863,7 +865,7 @@ const details: Record<string, ProjectDetailOverride> = {
       ],
     },
     es: {
-      headline: "BioJalisco — Sitio de Presentación Cinematográfico",
+      headline: ES_TITLE_BIOJALISCO_PITCH,
       subheadline:
         "Sitio de scrollytelling cinemático presentando una plataforma de biodiversidad de ciencia ciudadana para el occidente de México",
       overallVerdictTitle: "El Veredicto",

--- a/src/pages/es/projects/[slug].astro
+++ b/src/pages/es/projects/[slug].astro
@@ -4,6 +4,7 @@ import projectsData from "../../../data/projects.generated.json";
 import { t } from "../../../i18n";
 import { getProjectDetailOverride } from "../../../data/projectDetails";
 import { getEsCardCopy } from "../../../data/projectCardsEs";
+import { ES_TITLE_BIOJALISCO_PITCH } from "../../../data/esCanonicalTitles";
 
 type Project = (typeof projectsData.projects)[number];
 
@@ -28,7 +29,7 @@ const metaTitles: Record<string, string> = {
   'ai-chatbot-saas': 'Converso AI — Chatbot Bilingüe SaaS',
   'ny-ai-chatbot': 'Chatbot IA para Sitios Web de PYMES',
   'ny-english-messenger-bot': 'NY English Messenger — Asistente Bilingüe IA',
-  'biojalisco-pitch': 'BioJalisco — Sitio de Presentación Cinematográfico',
+  'biojalisco-pitch': ES_TITLE_BIOJALISCO_PITCH,
   'expat-driver-license-prep': 'ExpatDrive — Examen de Licencia Bilingüe',
   'cushlabs-marketsignal': 'MarketSignal — Inteligencia Competitiva Local',
 };


### PR DESCRIPTION
## Why
Follow-up to #132. The Spanish title **renders correctly live** (verified on the detail page + SEO `<title>`), but it existed as three independent string literals:
- ES card title (`projectCardsEs.ts`)
- ES detail headline (`projectDetails.ts`)
- ES SEO `<title>` (`es/projects/[slug].astro`)

Three copies = the same drift class that caused the original four-way title mismatch.

## Fix
New `src/data/esCanonicalTitles.ts` is the single source of truth for pinned Spanish titles. All three ES surfaces now reference `ES_TITLE_BIOJALISCO_PITCH` — edit the one constant and every ES render path updates. They cannot diverge.

Scoped to `biojalisco-pitch` via a **named constant** rather than changing the shared ES fallback chain, which would have altered ES card titles for ~6 other projects (mazebreak-wiki, ny-eng, cushlabs-scrollytelling, ai-resume-tailor, etc.).

## Verification
- `tsc --noEmit` — clean
- `astro check` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)