### PR TITLE
fix: remove stale EN SEO title override (BioJalisco pitch)

### DIFF
--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -26,7 +26,6 @@ const metaTitles: Record<string, string> = {
   'ai-chatbot-saas': 'Converso AI — Bilingual AI Chatbot SaaS',
   'ny-ai-chatbot': 'AI Chatbot Widget for Small Business Websites',
   'ny-english-messenger-bot': 'NY English Messenger — Bilingual AI Assistant',
-  'biojalisco-pitch': 'BioJalisco — Biodiversity Atlas',
   'expat-driver-license-prep': 'ExpatDrive — Bilingual License Exam Prep',
   'cushlabs-marketsignal': 'MarketSignal — Local Competitive Intelligence',
 };


### PR DESCRIPTION
Live verification after #133 caught that the **EN detail page `<title>`** still rendered:

> BioJalisco — Biodiversity Atlas | CushLabs.ai

A leftover `metaTitles` override in `src/pages/projects/[slug].astro` missed in the unification pass (the EN meta *descriptions* were checked; the EN meta *titles* map was not).

Removing the override → EN SEO `<title>` falls back to `project.title` (the generated canonical **BioJalisco — Cinematic Scrollytelling Pitch Site**, 48 chars, within SEO snippet bounds). EN SEO title is now single-source from generated data, matching the ES single-source const from #133.

This completes the title unification: every EN surface flows from `projects.generated.json` `title`; every ES surface flows from `ES_TITLE_BIOJALISCO_PITCH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)