### PR TITLE
feat: es-MX salon/spa landing page (Recepción Digital)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,16 +1,16 @@
-import { defineConfig } from 'astro/config';
-import tailwindcss from '@tailwindcss/vite';
-import sitemap from '@astrojs/sitemap';
-import sentry from '@sentry/astro';
+import { defineConfig } from "astro/config";
+import tailwindcss from "@tailwindcss/vite";
+import sitemap from "@astrojs/sitemap";
+import sentry from "@sentry/astro";
 
 // ── Slug-mismatched route pairs for sitemap hreflang ────────────────
 // EN path (no prefix) → ES slug (no /es prefix)
 const routePairs = {
-  '/consultation': '/reservar',
+  "/consultation": "/reservar",
 };
 
 // Build full bidirectional URL map: absolute EN URL ↔ absolute ES URL
-const SITE = 'https://www.cushlabs.ai';
+const SITE = "https://www.cushlabs.ai";
 const hreflangMap = new Map();
 
 // Static route pairs
@@ -23,13 +23,14 @@ for (const [enPath, esSlug] of Object.entries(routePairs)) {
 
 // ── Priority rules by URL pattern ───────────────────────────────────
 function getPriority(url) {
-  const path = url.replace(SITE, '');
-  if (path === '/' || path === '/es/' || path === '/es') return 1.0;
+  const path = url.replace(SITE, "");
+  if (path === "/" || path === "/es/" || path === "/es") return 1.0;
   if (/^\/(es\/)?services/.test(path)) return 0.9;
   if (/^\/(es\/)?portfolio/.test(path)) return 0.8;
   if (/^\/(es\/)?projects\//.test(path)) return 0.7;
   if (/^\/(es\/)?about/.test(path)) return 0.7;
-  if (/^\/(es\/)?consultation/.test(path) || /^\/(es\/)?reservar/.test(path)) return 0.8;
+  if (/^\/(es\/)?consultation/.test(path) || /^\/(es\/)?reservar/.test(path))
+    return 0.8;
   if (/^\/(es\/)?contact/.test(path)) return 0.7;
   if (/^\/(es\/)?faq/.test(path)) return 0.6;
   if (/^\/(es\/)?(terms|privacy)/.test(path)) return 0.3;
@@ -37,10 +38,10 @@ function getPriority(url) {
 }
 
 function getChangefreq(url) {
-  const path = url.replace(SITE, '');
-  if (path === '/' || path === '/es/' || path === '/es') return 'weekly';
-  if (/^\/(es\/)?(terms|privacy)/.test(path)) return 'yearly';
-  return 'monthly';
+  const path = url.replace(SITE, "");
+  if (path === "/" || path === "/es/" || path === "/es") return "weekly";
+  if (/^\/(es\/)?(terms|privacy)/.test(path)) return "yearly";
+  return "monthly";
 }
 
 export default defineConfig({
@@ -57,13 +58,17 @@ export default defineConfig({
     }),
     sitemap({
       filter: (page) => {
-        const path = page.replace(SITE, '');
-        if (path.includes('404')) return false;
-        if (path.includes('_')) return false;
+        const path = page.replace(SITE, "");
+        if (path.includes("404")) return false;
+        if (path.includes("_")) return false;
         // Internal flow pages with noindex meta — must NOT appear in sitemap
         // (Ahrefs flags "noindex page in sitemap" as a hard error).
         if (/\/messenger-assistant\/connect(ed)?\/?$/.test(path)) return false;
-        if (/\/es\/messenger-assistant\/connect(ed)?\/?$/.test(path)) return false;
+        if (/\/es\/messenger-assistant\/connect(ed)?\/?$/.test(path))
+          return false;
+        // es-MX cold-outreach landing pages (noindex, DM-driven, not organic SEO)
+        // — deliberately kept out of the sitemap. See docs/strategy/MEXICO-GTM-STRATEGY.md.
+        if (/\/(salones|clinicas-dentales)\/?$/.test(path)) return false;
         return true;
       },
       serialize: (item) => {
@@ -77,10 +82,10 @@ export default defineConfig({
         // Tier 1: Check explicit mismatched-slug map
         const partner = hreflangMap.get(url);
         if (partner) {
-          const isEs = url.includes('/es/') || url.endsWith('/es');
+          const isEs = url.includes("/es/") || url.endsWith("/es");
           item.links = [
-            { lang: 'en-US', url: isEs ? partner : url },
-            { lang: 'es-MX', url: isEs ? url : partner },
+            { lang: "en-US", url: isEs ? partner : url },
+            { lang: "es-MX", url: isEs ? url : partner },
           ];
           return item;
         }
@@ -93,20 +98,20 @@ export default defineConfig({
         return item;
       },
       i18n: {
-        defaultLocale: 'en',
+        defaultLocale: "en",
         locales: {
-          en: 'en-US',
-          es: 'es-MX',
+          en: "en-US",
+          es: "es-MX",
         },
       },
     }),
   ],
-  output: 'static',
-  trailingSlash: 'always',
-  site: 'https://www.cushlabs.ai',
+  output: "static",
+  trailingSlash: "always",
+  site: "https://www.cushlabs.ai",
   i18n: {
-    defaultLocale: 'en',
-    locales: ['en', 'es'],
+    defaultLocale: "en",
+    locales: ["en", "es"],
     routing: {
       prefixDefaultLocale: false,
     },

--- a/docs/outreach/salones-outreach-es.md
+++ b/docs/outreach/salones-outreach-es.md
@@ -1,0 +1,81 @@
+# Outreach Playbook — Beauty Salons & Spas (es-MX)
+
+> Cold-outreach assets for the salon beachhead. All copy is Mexican Professional Spanish (es-MX).
+> Landing page: **https://www.cushlabs.ai/salones/** (send every prospect here).
+> Strategy context: `docs/strategy/MEXICO-GTM-STRATEGY.md`.
+
+---
+
+## The one rule
+
+**Lead with the conversational gap, not reminders.** Booksy/Fresha already give salons free reminders. What they CANNOT do is answer a clienta's DM at 9pm and book her. That's the whole pitch: _"contesto los mensajes que se te escapan."_
+
+---
+
+## Cold DM — opener (Instagram / Facebook)
+
+Pick one; rotate to avoid pattern-matching. Warm, respectful, short. First touch uses light "usted/su"; warms to "tú" once they reply.
+
+**A — the missed-message angle (default)**
+
+> Hola 👋 Vi su salón y se ve precioso el trabajo que hacen. Una pregunta rápida: ¿alcanzan a contestar todos los mensajes que les llegan por Instagram y Facebook? A muchos salones se les escapan citas porque los mensajes llegan cuando están atendiendo. Armé un asistente con IA que contesta al instante y agenda por usted. ¿Le muestro cómo funciona? Sin compromiso 🙂
+
+**B — the after-hours angle**
+
+> Hola 👋 Me encantó su trabajo. ¿Le ha pasado que una clienta escribe a las 10 de la noche preguntando precios y, para cuando contesta, ya reservó en otro lado? Tengo algo que contesta esos mensajes al instante, 24/7, y le avisa cuando alguien está lista para reservar. ¿Le interesa verlo?
+
+**C — the time-saver angle**
+
+> Hola 👋 Pregunta honesta: ¿cuántas veces al día contesta lo mismo — precios, horarios, "¿tienen espacio?" — por Instagram? Hay forma de que eso se conteste solo, con la voz de su salón, y usted solo atienda a las clientas listas para agendar. Le paso el link si quiere verlo.
+
+---
+
+## Follow-ups (space 2–3 days apart; max 2)
+
+**Follow-up 1**
+
+> Hola de nuevo 🙂 Le dejo aquí el link por si quiere echarle un ojo cuando tenga un momento: https://www.cushlabs.ai/salones/ — son 2 semanas de prueba gratis, sin contratos.
+
+**Follow-up 2 (final, soft close)**
+
+> Sé que anda ocupada — solo le confirmo que la prueba gratis sigue disponible. Si en algún momento quiere que su salón conteste mensajes 24/7, aquí estoy. ¡Le deseo mucho éxito! 🙌
+
+---
+
+## Objection bank (quick replies)
+
+| Si dice…                               | Responde…                                                                                                                                                                          |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "Ya uso Booksy / una app de citas"     | "¡Perfecto, no la quita! Esa app manda recordatorios, pero no contesta los mensajes de sus clientas en Instagram o Facebook. Eso es justo lo que yo hago. Se complementan."        |
+| "Está muy caro / no tengo presupuesto" | "Le entiendo. Son $1,990 al mes, todo incluido — y con una sola clienta al mes que no se le escape ya se pagó. Por eso le ofrezco 2 semanas gratis: lo prueba sin arriesgar nada." |
+| "No le sé a la tecnología"             | "No se preocupe, yo lo configuro y lo cuido todo. Usted solo atiende a las clientas que le lleguen listas para agendar."                                                           |
+| "¿Suena a robot?"                      | "Para nada — habla con la voz de su salón, en español, natural y cálido. Si quiere le mando un ejemplo."                                                                           |
+| "Déjame pensarlo"                      | "¡Claro! Le dejo el link para cuando guste: https://www.cushlabs.ai/salones/ La prueba gratis está disponible cuando decida."                                                      |
+| "¿Cómo te pago?"                       | "Por SPEI u OXXO, lo que le sea más fácil, y le doy factura sin costo extra."                                                                                                      |
+
+---
+
+## WhatsApp prefilled message (already wired into the landing page)
+
+The landing CTA opens WhatsApp with:
+
+> "Hola, vi la página de Recepción Digital y quiero mi diagnóstico gratis para mi salón."
+
+When they arrive, run the **qualification flow** (see strategy doc §7B): página activa → mensajes sin contestar → ¿ya usan app de citas? → reseñas → sitio web → pago.
+
+---
+
+## Go-live checklist (before the first paying client)
+
+- [ ] **Meta app approval finished** (Cloud API direct) — the gate to going live on Messenger/IG/WhatsApp.
+- [ ] **`PUBLIC_WHATSAPP_NUMBER` confirmed** in the cushlabs env (landing CTA falls back to +52 33 1559 0572 if unset).
+- [ ] **Client intake:** their FB/IG page access + a list of services & prices (the only things needed to train the assistant).
+- [ ] **WhatsApp utility templates** drafted + submitted for approval (appointment reminders).
+- [ ] **Payment:** SPEI account + OXXO reference ready; CFDI invoicing set up.
+- [ ] **First case study:** capture before/after (response time, citas recovered) from client #1 for social proof.
+
+---
+
+## Measurement (so we know what's working)
+
+Track per outreach batch: DMs sent → replies → landing visits (Ahrefs/Vercel on `/salones/`) → diagnósticos → trials → paid. The reply rate on the opener IS the manual-tail validation the desk research couldn't give us.

--- a/docs/strategy/MEXICO-GTM-STRATEGY.md
+++ b/docs/strategy/MEXICO-GTM-STRATEGY.md
@@ -169,10 +169,10 @@ Cold DM → landing page → **"Diagnóstico gratis"** → qualify & route:
 
 ## 8. Go-To-Market Tactics
 
-- **Acquisition:** cold FB/IG DM + WhatsApp → stripped es-MX landing page (`/spas`) → free diagnosis → 2-week free trial → paid (SPEI/OXXO).
-- **Outreach IS the validation.** Rather than a "call 20 businesses" checklist, the cold campaign measures manual-tail responsiveness directly — every reply/non-reply is data the desk research couldn't provide.
+- **Acquisition:** cold FB/IG DM + WhatsApp → stripped es-MX landing page (**`/salones/`**, LIVE) → free diagnosis → 2-week free trial → paid (SPEI/OXXO).
+- **Outreach IS the validation.** Rather than a "call 20 businesses" checklist, the cold campaign measures manual-tail responsiveness directly — every reply/non-reply is data the desk research couldn't provide. Outreach playbook (DM sequence + objection bank + go-live checklist): `docs/outreach/salones-outreach-es.md`.
 - **Repositioned pitch:** lead with "nunca pierdas un mensaje / agenda mientras duermes"; reminders + review-approval as included bonuses.
-- **Landing pages:** stripped, standalone, es-MX, single WhatsApp CTA. Sidesteps the site's old-pricing contradiction. First: beauty-spa `Recepción Digital` (copy drafted; rebuild headline around conversational AI).
+- **Landing pages:** stripped, standalone, es-MX, single WhatsApp CTA, `noindex` + sitemap-excluded (protects Ahrefs score). Built via reusable `src/layouts/LandingLayout.astro` (dental LP reuses it). First page LIVE: `/salones/` (`Recepción Digital`, headline = conversational AI).
 - **Proof engine:** land first salon wins fast → testimonials + before/after → reduce future friction → graduate to dental with case studies in hand.
 - **Trial framing:** 2-week free trial, "si no se gana su lugar, nos despedimos como amigos."
 
@@ -192,7 +192,8 @@ Cold DM → landing page → **"Diagnóstico gratis"** → qualify & route:
 - [ ] Live MX WhatsApp marketing per-message rate (verify in WhatsApp Manager)
 - [ ] Size of the manual tail in each niche (no public data — outreach will reveal)
 - [ ] Confirm product name `Recepción Digital`
-- [ ] Rebuild `/spas` landing copy around the conversational-AI headline (current draft leads with reminders/no-shows)
+- [x] ~~Rebuild landing copy around the conversational-AI headline~~ — DONE: `/salones/` live, headline = "nunca pierdas otra clienta por un mensaje sin contestar"
+- [ ] Dental LP (`/clinicas-dentales/`) — reuse `LandingLayout`, reviews co-headline, higher price tier
 
 ---
 

--- a/src/layouts/LandingLayout.astro
+++ b/src/layouts/LandingLayout.astro
@@ -1,0 +1,140 @@
+---
+// Stripped, standalone landing layout for es-MX cold-outreach pages.
+// NO global Header/Footer (they link to other-market pricing) and NO demo
+// chat widget — just brand polish + a single conversion focus.
+// Defaults to noindex; these pages are DM-driven, not organic SEO, and are
+// excluded from the sitemap in astro.config.mjs to protect the Ahrefs score.
+import "../styles/global.css";
+import ThemeScript from "../components/ThemeScript.astro";
+
+interface Props {
+  title: string;
+  description: string;
+  ogImage?: string;
+  lang?: string;
+  noindex?: boolean;
+}
+
+const {
+  title,
+  description,
+  ogImage = "images/og/cushlabs-og.png",
+  lang = "es",
+  noindex = true,
+} = Astro.props;
+
+const pathname = Astro.url.pathname;
+const ensureTrailingSlash = (p: string) =>
+  p === "/" || p.endsWith("/") ? p : `${p}/`;
+const canonicalURL = new URL(ensureTrailingSlash(pathname), Astro.site);
+const resolvedOgImage = `${Astro.site}${ogImage.replace(/^\//, "")}`;
+---
+
+<!doctype html>
+<html lang={lang}>
+  <head>
+    <ThemeScript />
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="dns-prefetch" href="https://analytics.ahrefs.com" />
+
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Source+Serif+4:ital,opsz,wght@0,8..60,300;0,8..60,400;0,8..60,500;1,8..60,400&display=swap"
+      media="print"
+      onload="this.media='all'"
+    />
+    <noscript>
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Source+Serif+4:ital,opsz,wght@0,8..60,300;0,8..60,400;0,8..60,500;1,8..60,400&display=swap"
+      />
+    </noscript>
+
+    <title>{title}</title>
+    <meta name="description" content={description} />
+    <meta
+      name="robots"
+      content={noindex ? "noindex, nofollow" : "index, follow"}
+    />
+    <link rel="canonical" href={canonicalURL} />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content={canonicalURL} />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:image" content={resolvedOgImage} />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:site_name" content="CushLabs.ai" />
+    <meta property="og:locale" content="es_MX" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={resolvedOgImage} />
+
+    <meta name="theme-color" content="#FF6A3D" />
+    <meta name="author" content="Robert Cushman, CushLabs.ai" />
+    <meta name="generator" content={Astro.generator} />
+
+    <link rel="icon" href="/favicon.ico" sizes="48x48" />
+    <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32" />
+    <link rel="apple-touch-icon" href="/images/logo/cushlabs-logo.png" />
+
+    <script
+      src="https://analytics.ahrefs.com/analytics.js"
+      data-key="ruxKH1qjytlbUmJcCXIcUA"
+      async></script>
+  </head>
+  <body class="bg-white dark:bg-cush-gray-900 text-gray-900 dark:text-gray-100">
+    <!-- Brand background texture -->
+    <div
+      class="fixed inset-0 -z-20 bg-linear-to-b from-cush-orange/5 via-transparent to-transparent"
+    >
+    </div>
+    <div
+      class="fixed inset-0 -z-10 opacity-[0.015] pointer-events-none"
+      style="background-image: url(&quot;data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E&quot;)"
+    >
+    </div>
+
+    <!-- Minimal top bar: logo only, no nav (no links to other-market pricing) -->
+    <header
+      class="relative z-10 flex items-center justify-center py-5 border-b border-gray-100 dark:border-gray-800"
+    >
+      <img
+        src="/images/logo/cushlabs-logo.webp"
+        alt="CushLabs"
+        width="40"
+        height="40"
+        class="h-9 w-auto"
+      />
+      <span class="ml-2 font-display font-bold text-lg tracking-tight"
+        >CushLabs</span
+      >
+    </header>
+
+    <main>
+      <slot />
+    </main>
+
+    <footer
+      class="relative z-10 border-t border-gray-100 dark:border-gray-800 py-8 text-center text-sm text-gray-500 dark:text-gray-500"
+    >
+      <p>© 2026 CushLabs AI Services · Guadalajara, México</p>
+      <p class="mt-1">
+        <a href="/es/privacy/" class="hover:text-cush-orange underline underline-offset-4"
+          >Aviso de privacidad</a
+        >
+      </p>
+    </footer>
+
+    <script>
+      import { inject } from "@vercel/analytics";
+      inject();
+    </script>
+  </body>
+</html>

--- a/src/pages/salones.astro
+++ b/src/pages/salones.astro
@@ -1,0 +1,458 @@
+---
+import LandingLayout from "../layouts/LandingLayout.astro";
+
+// ── WhatsApp CTA ────────────────────────────────────────────────────
+// Reads the same env vars the rest of the site uses, with a safe fallback
+// to the public business number.
+const whatsappRaw =
+  import.meta.env.PUBLIC_WHATSAPP_NUMBER ||
+  import.meta.env.WHATSAPP_NUMBER ||
+  "+52 33 1559 0572";
+const whatsappDigits = whatsappRaw.replace(/\D/g, "");
+const waMessage = encodeURIComponent(
+  "Hola, vi la página de Recepción Digital y quiero mi diagnóstico gratis para mi salón.",
+);
+const whatsappLink = `https://wa.me/${whatsappDigits}?text=${waMessage}`;
+
+const benefits = [
+  {
+    title: "Contesta en segundos, a cualquier hora",
+    body: "Las 11 de la noche, domingo, mientras estás con una clienta — tu asistente responde al instante. La clienta que escribe a deshoras ya no se va con la competencia.",
+  },
+  {
+    title: "Responde precios y servicios con TU información",
+    body: "Entrenado con tus servicios, tus precios y tu forma de hablar. Contesta las mismas preguntas de siempre — '¿cuánto cuesta?', '¿tienen espacio mañana?' — sin que tú levantes el teléfono.",
+  },
+  {
+    title: "Agenda la cita en la misma conversación",
+    body: "No solo contesta: guía a la clienta a reservar. Menos idas y vueltas, más citas confirmadas.",
+  },
+  {
+    title: "Te avisa cuando alguien está lista",
+    body: "Cuando una clienta quiere algo especial o está lista para reservar, te llega un mensaje a TU WhatsApp con su nombre y lo que busca. Tú cierras; el asistente hace el resto.",
+  },
+  {
+    title: "Habla como tu salón, en español de México",
+    body: "Nada de respuestas robóticas ni de 'no entendí tu mensaje'. Suena natural, cálido y profesional — como lo dirías tú.",
+  },
+];
+
+const included = [
+  {
+    title: "Asistente conversacional con IA, 24/7",
+    desc: "En Facebook, Instagram y WhatsApp. Contesta, resuelve dudas y agenda — el corazón del servicio.",
+  },
+  {
+    title: "Recordatorios automáticos por WhatsApp",
+    desc: "Confirma y recuerda cada cita. Menos cancelaciones, menos huecos en tu agenda.",
+  },
+  {
+    title: "Respuestas a tus reseñas de Google",
+    desc: "Redactamos una respuesta profesional a cada reseña — y tú la apruebas antes de publicarse. Tu reputación, cuidada y con tu voz.",
+  },
+  {
+    title: "Aviso al instante a tu WhatsApp",
+    desc: "Cuando llega una clienta lista para reservar, te avisamos de inmediato con todos sus datos.",
+  },
+];
+
+const steps = [
+  {
+    n: "1",
+    title: "Diagnóstico gratis",
+    desc: "Revisamos tu página y cómo agendas hoy. Sin compromiso, sin tecnicismos.",
+  },
+  {
+    n: "2",
+    title: "Lo configuramos por ti",
+    desc: "Lo dejamos trabajando en pocos días. Tú no mueves un dedo — nosotros hacemos todo.",
+  },
+  {
+    n: "3",
+    title: "Prueba gratis de 2 semanas",
+    desc: "Lo ves ganar clientas. Si no se gana su lugar, nos despedimos como amigos.",
+  },
+];
+
+const faqs = [
+  {
+    q: "¿Necesito saber de tecnología?",
+    a: "Para nada. Nosotros lo configuramos, lo entrenamos y lo mantenemos. Tú solo atiendes a las clientas que te llegan listas.",
+  },
+  {
+    q: "Ya uso Booksy / una app de citas. ¿Esto para qué me sirve?",
+    a: "Esas apps mandan recordatorios, pero no contestan los mensajes de tus clientas. Cuando alguien te escribe por Instagram o Facebook preguntando precios o pidiendo cita, esa app no responde — tu asistente sí. Nosotros llenamos justo ese hueco.",
+  },
+  {
+    q: "¿El asistente suena robótico?",
+    a: "No. Habla con la voz de tu salón, en español de México, de forma natural y cálida. Lo entrenamos con tu información para que conteste como lo harías tú.",
+  },
+  {
+    q: "¿Y si no me funciona?",
+    a: "Tienes 2 semanas de prueba gratis y no hay contratos. Si no te trae más clientas, lo cancelas cuando quieras.",
+  },
+  {
+    q: "¿Cómo les pago y me dan factura?",
+    a: "Pagas por SPEI u OXXO, lo que te sea más fácil. Te entregamos factura (CFDI) sin costo extra.",
+  },
+  {
+    q: "¿Qué necesitan de mí para empezar?",
+    a: "Solo acceso a tu página de Facebook/Instagram y tu lista de servicios y precios. Del resto nos encargamos nosotros.",
+  },
+];
+---
+
+<LandingLayout
+  title="Recepción Digital para Salones y Spas | CushLabs"
+  description="Tu recepcionista con IA contesta Facebook, Instagram y WhatsApp al instante y agenda citas. Para salones y spas en México. Prueba gratis de 2 semanas."
+>
+  <!-- ── Hero ───────────────────────────────────────────────────── -->
+  <section class="relative overflow-hidden pt-16 pb-20 md:pt-24 md:pb-28">
+    <div class="absolute inset-0 -z-10">
+      <div
+        class="absolute top-0 left-1/4 w-[500px] h-[500px] bg-cush-orange/15 rounded-full blur-[120px]"
+      >
+      </div>
+      <div
+        class="absolute bottom-0 right-1/4 w-[400px] h-[400px] bg-cush-orange/10 rounded-full blur-[100px]"
+      >
+      </div>
+    </div>
+
+    <div class="max-w-4xl mx-auto px-6 text-center">
+      <div
+        class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-cush-orange/10 border border-cush-orange/20 text-cush-orange text-sm font-semibold mb-8"
+      >
+        Para salones de belleza y spas
+      </div>
+
+      <h1
+        class="font-display text-fluid-4xl font-bold mb-6 leading-tight tracking-tight"
+      >
+        Nunca pierdas otra clienta por un mensaje sin contestar
+      </h1>
+
+      <p
+        class="text-fluid-lg text-gray-600 dark:text-gray-300 mb-4 max-w-3xl mx-auto leading-relaxed"
+      >
+        Tu recepcionista con IA contesta Facebook, Instagram y WhatsApp al
+        instante — responde precios, agenda la cita y te avisa cuando alguien
+        está lista para reservar.
+      </p>
+      <p
+        class="text-fluid-base text-gray-500 dark:text-gray-400 mb-10 max-w-2xl mx-auto leading-relaxed"
+      >
+        Las 24 horas. Aunque estés con una clienta, manejando o dormida.
+      </p>
+
+      <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
+        <a
+          href={whatsappLink}
+          target="_blank"
+          rel="noopener"
+          class="group inline-flex items-center gap-2 px-8 py-4 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-all duration-300 shadow-lg shadow-cush-orange/25 hover:shadow-xl text-lg"
+        >
+          Quiero mi diagnóstico gratis
+          <svg
+            class="w-5 h-5 transition-transform group-hover:translate-x-1"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M17 8l4 4m0 0l-4 4m4-4H3"></path>
+          </svg>
+        </a>
+      </div>
+      <p class="mt-6 text-sm text-gray-500 dark:text-gray-400">
+        Sin instalación · Sin contratos · Prueba gratis de 2 semanas
+      </p>
+    </div>
+  </section>
+
+  <!-- ── El problema ────────────────────────────────────────────── -->
+  <section
+    class="py-20 md:py-28 bg-gray-50 dark:bg-gray-900/30 border-y border-gray-100 dark:border-gray-800"
+  >
+    <div class="max-w-3xl mx-auto px-6">
+      <h2
+        class="font-display font-bold text-3xl md:text-4xl mb-8 leading-tight tracking-tight"
+      >
+        El mensaje que no contestaste ya se fue a otro salón
+      </h2>
+      <div
+        class="space-y-6 text-lg text-gray-600 dark:text-gray-400 leading-relaxed"
+      >
+        <p>
+          Mientras estás peinando o atendiendo, llegan tres mensajes por
+          Instagram preguntando precios y horarios. Cuando por fin los ves, ya es
+          tarde — la clienta encontró otro salón que le contestó primero.
+        </p>
+        <p>
+          La mayoría de los mensajes son las mismas preguntas de siempre: cuánto
+          cuesta, qué horario tienes, si hay espacio mañana. Contestarlas una por
+          una te roba tiempo que deberías estar cobrando.
+        </p>
+        <p class="font-medium text-gray-900 dark:text-white">
+          8 de cada 10 clientas prefieren agendar por mensaje antes que llamar.
+          Si nadie contesta a tiempo, esa cita simplemente no sucede.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── La solución ────────────────────────────────────────────── -->
+  <section class="py-20 md:py-28">
+    <div class="max-w-4xl mx-auto px-6">
+      <div class="text-center max-w-3xl mx-auto mb-14">
+        <h2
+          class="font-display font-bold text-3xl md:text-5xl mb-4 leading-tight tracking-tight"
+        >
+          Una recepcionista que nunca duerme ni se satura
+        </h2>
+        <p class="text-xl text-cush-orange font-medium leading-relaxed">
+          Contesta cada mensaje, en cada plataforma, al instante.
+        </p>
+      </div>
+
+      <div class="space-y-6 max-w-2xl mx-auto">
+        {
+          benefits.map((item) => (
+            <div class="flex gap-4">
+              <svg
+                class="w-6 h-6 text-cush-orange shrink-0 mt-0.5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+              <div>
+                <strong class="font-display font-semibold text-gray-900 dark:text-white">
+                  {item.title}.
+                </strong>{" "}
+                <span class="text-gray-600 dark:text-gray-400 leading-relaxed">
+                  {item.body}
+                </span>
+              </div>
+            </div>
+          ))
+        }
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Qué incluye ────────────────────────────────────────────── -->
+  <section
+    class="py-20 md:py-28 bg-gray-50 dark:bg-gray-900/30 border-y border-gray-100 dark:border-gray-800"
+  >
+    <div class="max-w-4xl mx-auto px-6">
+      <h2
+        class="font-display font-bold text-3xl md:text-4xl mb-4 text-center leading-tight tracking-tight"
+      >
+        Todo incluido en un solo precio
+      </h2>
+      <p
+        class="text-center text-gray-600 dark:text-gray-400 mb-12 max-w-2xl mx-auto"
+      >
+        Lo configuramos, lo entrenamos y lo cuidamos por ti. Tú solo atiendes a
+        las clientas que te llegan listas.
+      </p>
+
+      <div class="grid md:grid-cols-2 gap-6">
+        {
+          included.map((item) => (
+            <div class="bg-white dark:bg-gray-800/50 rounded-2xl p-6 border border-gray-100 dark:border-gray-800">
+              <h3 class="font-display font-semibold text-lg text-gray-900 dark:text-white mb-2">
+                {item.title}
+              </h3>
+              <p class="text-gray-600 dark:text-gray-400 text-sm leading-relaxed">
+                {item.desc}
+              </p>
+            </div>
+          ))
+        }
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Precio ─────────────────────────────────────────────────── -->
+  <section class="py-20 md:py-28">
+    <div class="max-w-xl mx-auto px-6">
+      <div
+        class="bg-gray-900 dark:bg-gray-800 rounded-3xl p-10 text-center shadow-xl"
+      >
+        <p
+          class="font-display font-semibold text-white/70 uppercase text-xs tracking-wider mb-4"
+        >
+          Todo incluido
+        </p>
+        <div class="flex items-baseline justify-center gap-2 mb-2">
+          <span class="font-display text-5xl md:text-6xl font-bold text-white"
+            >$1,990</span
+          >
+          <span class="text-xl text-white/70">MXN/mes</span>
+        </div>
+        <p class="text-white/70 mb-6">
+          Sin cuota de instalación. Sin contratos. Cancela cuando quieras.
+        </p>
+        <p class="text-sm text-white/60 mb-8">
+          Pago con SPEI u OXXO · Factura (CFDI) incluida
+        </p>
+        <a
+          href={whatsappLink}
+          target="_blank"
+          rel="noopener"
+          class="block w-full px-6 py-4 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-colors duration-300 text-lg"
+        >
+          Empieza tu prueba gratis de 2 semanas
+        </a>
+      </div>
+
+      <!-- ROI -->
+      <div class="mt-12 text-center max-w-lg mx-auto">
+        <p
+          class="font-display font-bold text-2xl md:text-3xl text-gray-900 dark:text-white mb-3 leading-snug"
+        >
+          Una sola clienta al mes que no se te escape ya pagó el servicio.
+        </p>
+        <p class="text-gray-600 dark:text-gray-400 leading-relaxed">
+          Entre las citas que recuperas de mensajes a deshoras y las que dejan de
+          cancelarse con los recordatorios, el servicio se paga solo varias
+          veces. Todo lo demás es ganancia.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Cómo empezamos ─────────────────────────────────────────── -->
+  <section
+    class="py-20 md:py-28 bg-gray-50 dark:bg-gray-900/30 border-y border-gray-100 dark:border-gray-800"
+  >
+    <div class="max-w-4xl mx-auto px-6">
+      <h2
+        class="font-display font-bold text-3xl md:text-4xl mb-12 text-center leading-tight tracking-tight"
+      >
+        Cómo empezamos
+      </h2>
+      <div class="grid md:grid-cols-3 gap-8">
+        {
+          steps.map((step) => (
+            <div class="text-center">
+              <div class="inline-flex items-center justify-center w-12 h-12 rounded-full bg-cush-orange text-white font-display font-bold text-lg mb-5">
+                {step.n}
+              </div>
+              <h3 class="font-display font-semibold text-lg text-gray-900 dark:text-white mb-2">
+                {step.title}
+              </h3>
+              <p class="text-gray-600 dark:text-gray-400 text-sm leading-relaxed">
+                {step.desc}
+              </p>
+            </div>
+          ))
+        }
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Preguntas frecuentes ───────────────────────────────────── -->
+  <section class="py-20 md:py-28">
+    <div class="max-w-3xl mx-auto px-6">
+      <h2
+        class="font-display font-bold text-3xl md:text-4xl mb-12 text-center leading-tight tracking-tight"
+      >
+        Preguntas frecuentes
+      </h2>
+      <div class="space-y-4">
+        {
+          faqs.map((faq) => (
+            <details class="group bg-gray-50 dark:bg-gray-800/50 rounded-xl border border-gray-100 dark:border-gray-800 p-6">
+              <summary class="flex items-center justify-between cursor-pointer font-display font-semibold text-gray-900 dark:text-white list-none">
+                {faq.q}
+                <svg
+                  class="w-5 h-5 text-cush-orange shrink-0 transition-transform group-open:rotate-45"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M12 4v16m8-8H4"
+                  />
+                </svg>
+              </summary>
+              <p class="mt-4 text-gray-600 dark:text-gray-400 leading-relaxed">
+                {faq.a}
+              </p>
+            </details>
+          ))
+        }
+      </div>
+    </div>
+  </section>
+
+  <!-- ── CTA final ──────────────────────────────────────────────── -->
+  <section
+    class="py-20 md:py-28 bg-gray-50 dark:bg-gray-900/30 border-t border-gray-100 dark:border-gray-800"
+  >
+    <div class="max-w-2xl mx-auto px-6 text-center">
+      <h2
+        class="font-display font-bold text-3xl md:text-4xl mb-6 leading-tight tracking-tight"
+      >
+        ¿Lista para dejar de perder clientas?
+      </h2>
+      <p class="text-lg text-gray-600 dark:text-gray-400 mb-10">
+        Escríbeme por WhatsApp y te hago tu diagnóstico gratis hoy mismo.
+      </p>
+      <a
+        href={whatsappLink}
+        target="_blank"
+        rel="noopener"
+        class="inline-flex items-center gap-2 px-8 py-4 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-all duration-300 shadow-lg shadow-cush-orange/25 hover:shadow-xl text-lg"
+      >
+        <svg
+          class="w-6 h-6"
+          fill="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.71.306 1.263.489 1.694.625.712.227 1.36.195 1.872.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z"
+          ></path>
+        </svg>
+        Escríbeme por WhatsApp
+      </a>
+      <p class="mt-6 text-sm text-gray-500 dark:text-gray-400">
+        Respondo en menos de 24 horas
+      </p>
+    </div>
+  </section>
+
+  <!-- FAQPage structured data -->
+  <script
+    type="application/ld+json"
+    is:inline
+    set:html={JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      mainEntity: faqs.map((f) => ({
+        "@type": "Question",
+        name: f.q,
+        acceptedAnswer: { "@type": "Answer", text: f.a },
+      })),
+    })}
+  />
+</LandingLayout>


### PR DESCRIPTION
## What

First cold-outreach landing page for the **MX salon beachhead** — the conversational-AI repositioning made concrete.

- **`/salones/`** — es-MX landing page. Headline leads with the real white space (**"nunca pierdas otra clienta por un mensaje sin contestar"** — the two-way conversational AI that Booksy/Fresha structurally can't do). Reminders + Google-review-approval positioned as *included bonuses*, not the pitch. `$1,990 MXN/mes`, ROI section, objection-handling FAQ + FAQPage schema, WhatsApp CTA.
- **`LandingLayout.astro`** — reusable stripped layout: no global header/footer (they link to the old US pricing), no demo widget, `noindex` by default. The **dental LP will reuse it**.
- **Sitemap exclusion** — `/salones` (and future `/clinicas-dentales`) kept out of the sitemap so these `noindex` DM-driven pages don't dent the 100/100 Ahrefs score.
- **Docs** — strategy doc updated; new outreach playbook (`docs/outreach/salones-outreach-es.md`) with DM sequence, objection bank, and go-live checklist.

## Why a stripped es-only page
Deliberate exception to the EN/ES parity rule: this is a DM-driven outreach page, not organic SEO. Documented in the strategy doc.

## Verification
- `npm run build` clean; **all meta-description/SEO gates pass**.
- Confirmed `/salones/` is `noindex` and excluded from the sitemap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)