### PR TITLE
fix: align advertised channels with Meta-approved reality

### DIFF
--- a/src/components/services2/FAQ.astro
+++ b/src/components/services2/FAQ.astro
@@ -21,7 +21,7 @@ const content = {
       },
       {
         q: "What's included in the plans?",
-        a: "Everything. An AI assistant on the channel of your choice (website, WhatsApp, Facebook, Instagram, or Telegram), Google Maps competitive monitoring with a weekly action plan, AI-generated product photos for social media, weekly performance reports, monthly tuning, and email support (24-hour response). No hidden fees. No surprise charges."
+        a: "It depends on the plan. Basic includes an AI assistant on Facebook Messenger, Google review management (with your approval), and owner lead alerts. Premium adds a website chatbot and a weekly local SEO and competitor report. Ultra adds the AI Voice Agent, priority support, and industry tuning. Every plan is fully managed — setup, training, weekly reports, and monthly tuning — with no setup fee and no contract. See the Pricing page for the full breakdown."
       },
       {
         q: "What if the AI voice agent goes over 300 minutes?",
@@ -58,7 +58,7 @@ const content = {
       },
       {
         q: "¿Qué incluyen los planes?",
-        a: "Todo. Un asistente de IA en el canal de tu preferencia (sitio web, WhatsApp, Facebook, Instagram o Telegram), monitoreo competitivo en Google Maps con plan de acción semanal, fotos de producto con IA para redes sociales, reportes semanales de desempeño, ajuste mensual y soporte por email (respuesta en 24 horas). Sin cuotas ocultas. Sin sorpresas."
+        a: "Depende del plan. Básico incluye un asistente con IA en Facebook Messenger, gestión de reseñas de Google (con tu aprobación) y avisos de clientes listos para comprar. Premium agrega un chatbot para tu sitio web y un reporte semanal de SEO local y competencia. Ultra agrega el Agente de Voz con IA, soporte prioritario y personalización por industria. Todos los planes son totalmente gestionados — configuración, entrenamiento, reportes semanales y ajuste mensual — sin cuota de instalación y sin contrato. Consulta la página de Precios para el desglose completo."
       },
       {
         q: "¿Qué pasa si el agente de voz supera los 300 minutos?",

--- a/src/components/services2/ServiceBlock.astro
+++ b/src/components/services2/ServiceBlock.astro
@@ -25,7 +25,7 @@ const data = {
         { title: "Lead capture and qualification", desc: "After-hours visitors get engaged immediately. Contact info captured, intent qualified, routed to your sales process" },
         { title: "Weekly performance report", desc: "What customers are asking, where they get stuck, what content is missing, and how the assistant is performing" },
         { title: "Monthly tuning", desc: "I refine the assistant as your business evolves — new products, new pricing, new seasons" },
-        { title: "Deployment on your website, WhatsApp, or both", desc: "Full operational documentation so your team can manage it" }
+        { title: "Deployment on your website or Facebook Messenger", desc: "Full operational documentation so your team can manage it" }
       ],
       notIncluded: [
         "Integration with custom CRMs or ERPs (scoped separately if needed)",
@@ -54,7 +54,7 @@ const data = {
         { title: "Captura y calificación de leads", desc: "Los visitantes fuera de horario reciben atención de inmediato. Se captura su información de contacto, se califica su intención y se enruta a tu proceso de ventas" },
         { title: "Reporte semanal de desempeño", desc: "Qué preguntan los clientes, dónde se atoran, qué contenido falta y cómo está desempeñándose el asistente" },
         { title: "Ajuste mensual", desc: "Refino el asistente conforme tu negocio evoluciona — nuevos productos, nuevos precios, nuevas temporadas" },
-        { title: "Instalación en tu sitio web, WhatsApp, o ambos", desc: "Documentación operativa completa para que tu equipo pueda gestionarlo" }
+        { title: "Instalación en tu sitio web o Facebook Messenger", desc: "Documentación operativa completa para que tu equipo pueda gestionarlo" }
       ],
       notIncluded: [
         "Integración con CRMs/ERPs personalizados (se cotiza aparte)",
@@ -98,7 +98,7 @@ const data = {
       investmentDisclaimer: "Free 2-week trial. Cancel anytime.",
       bestFor: [
         "Local businesses losing leads to slow response times",
-        "Owners drowning in repeat questions on Messenger and Instagram",
+        "Owners drowning in repeat questions on Facebook Messenger",
         "Businesses with bilingual customers (Spanish + English)",
         "Anyone whose competitors are responding faster than they are"
       ]
@@ -127,7 +127,7 @@ const data = {
       investmentDisclaimer: "Prueba gratis de 2 semanas. Cancela cuando quieras.",
       bestFor: [
         "Negocios locales perdiendo clientes por respuestas lentas",
-        "Dueños ahogados en preguntas repetitivas en Messenger e Instagram",
+        "Dueños ahogados en preguntas repetitivas en Facebook Messenger",
         "Negocios con clientes bilingües (español + inglés)",
         "Cualquiera cuyos competidores están respondiendo más rápido"
       ]


### PR DESCRIPTION
## What
Removes customer-facing deployment claims for channels we can't yet deliver, so the site copy matches reality.

**Approved / available today:** Facebook Messenger (customer chat) + website chatbot.
**Not yet:** WhatsApp (awaiting Meta review), Instagram (needs separate App Review), Telegram (not offered).

## Changes
- `ServiceBlock.astro` — "deploy on website, WhatsApp, or both" → "website or Facebook Messenger"; audience line "Messenger and Instagram" → "Facebook Messenger" (EN + ES)
- `services2/FAQ.astro` — "What's included in the plans?" answer no longer offers a website/WhatsApp/Facebook/Instagram/Telegram channel menu, and no longer describes a flat "everything" bundle. Rewritten to the real Basic/Premium/Ultra tier breakdown (EN + ES)

## Intentionally kept
- Owner-facing WhatsApp: lead alerts, weekly report delivery, contact/privacy/data-deletion contact
- Content-source mentions ("audit your WhatsApp threads")
- Honest "coming soon / próximamente" WhatsApp + Instagram copy on `/salones`

## Verification
- `npm run build` clean, meta-description gate PASS (108 pages)
- Grep confirms zero remaining customer-facing Instagram/Telegram deployment claims

🤖 Generated with [Claude Code](https://claude.com/claude-code)