### PR TITLE
feat: multi-location pricing + fair-use cap on unlimited conversations

### DIFF
--- a/docs/strategy/MEXICO-GTM-STRATEGY.md
+++ b/docs/strategy/MEXICO-GTM-STRATEGY.md
@@ -113,14 +113,31 @@ Good-Better-Best, all MXN/month, subscription, **no setup fee, no contract.** Ev
 | ----------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Basic**   | **$1,990/mo** | AI assistant on Facebook Messenger (24/7) · Google review management (with approval) · Owner lead alerts · Fully managed (es-MX, CFDI, SPEI/OXXO) |
 | **Premium** | **$3,490/mo** | Everything in Basic · Website chatbot · Weekly local SEO & competitor report                                                                      |
-| **Ultra**   | **$5,490/mo** | Everything in Premium · AI Voice Agent (inbound calls, 300 min, $8.50/min overage) · Priority support · Industry tuning                           |
+| **Ultra**   | **$5,490/mo** | Everything in Premium · AI Voice Agent (inbound calls, 300 answered min **per location**, $8.50/min overage) · Priority support · Industry tuning |
 
 **Deliverable-now audit:** only WhatsApp features + Instagram DMs are gated on Meta approval. Facebook Messenger (approved), Google reviews, lead alerts, website chatbot, local SEO report, and Voice Agent are all live-capable today.
+
+### Multi-location pricing — LOCKED 2026-07-01
+
+The published price is **per business, and includes up to 2 locations**. Additional locations are a **flat +$690 MXN/mo each, across all tiers**.
+
+- **Mental model:** ~$1,000/location, first two bundled. `$690` fits the `…90` price aesthetic.
+- **Why "up to 2" (not 1, not 4):** two locations is the most common "bigger than solo" case (salon + spa, or a second shop). The marginal delivery cost of a 2nd location is tiny (same AI brain, one account manager, one more Google profile), so bundling it buys goodwill cheaply. "First 4" was rejected — it gave away the _expensive_ locations; "up to 2" gives away the cheap one.
+- **Why $690 (not $990):** marginal work per extra location is genuinely low (we know it; the client doesn't). The add-on is a **land-grab / chain-capture lever**, not cost recovery. `$490` is the floor — below that, location 3 drops to ~half the effective rate of the bundled first two, which invites "so why am I paying $1,990 for the first two?", and it underprices recurring review-management labor.
+- **The formula scales cleanly, no brackets:** a 9-location Basic account = `$1,990 + 7 × $690 = $6,820/mo` (~$380 USD to run 9 locations). Chains get a fair auto-price; use "custom / let's talk" only when a shared-vs-per-location Facebook-page split justifies a discount (e.g. 9 locations on ONE shared FB page = ~1× Messenger workload → room to come down to ~$7,900 on higher tiers).
+- **Voice minutes are per location** (Ultra): 300 answered min **per location**/mo, $8.50/min overage. A shared pool across a chain would vanish instantly — per-location is the honest structure.
+
+### Fair-use policy on "unlimited conversations" — LOCKED 2026-07-01
+
+"Unlimited conversations" now always reads **"unlimited conversations (fair use)"** on the site. Reason: every message carries a metered LLM cost, and unbounded "unlimited" in front of a per-call cost is the exact failure mode the global rate-limit rule guards against (a viral post → surprise Anthropic/OpenAI bill that lands on Robert).
+
+- **Public copy:** "unlimited conversations (fair use)" — the marketing punch stays, the exposure is capped.
+- **Internal threshold (not published):** ~**1,000 conversations/mo per location**. Normal SMBs never approach this. Beyond it we right-size the plan — never a silent surprise charge. Keep the number internal to avoid "I'm at 999, gotcha" gaming.
 
 ### Voice Agent — positioning & margin (validated 2026-07-01, 2nd-opinion analysis)
 
 - **Sell it as a call-capture layer** — missed calls, after-hours inquiries, basic questions, lead qualification. **NOT** "replaces your receptionist." Lower trust friction, easier to deliver, and honest given voice is new to us.
-- **Copy:** "300 **answered** minutes/month; extra at $8.50 MXN/min." ("Answered" makes the usage boundary clear.)
+- **Copy:** "300 **answered** minutes per location/month; extra at $8.50 MXN/min." ("Answered" makes the usage boundary clear; **per location** — see Multi-location pricing above.)
 - **Margin is healthy:** break-even ≈ $0.38 USD/min on the included 300 min; realistic all-in cost ~$0.10–0.18/min → **50–79% margin** on the $2,000 Premium→Ultra uplift. Overage ($8.50/min ≈ $0.49 USD) is healthy, not underpriced.
 - **CAVEAT (confidence 80%):** those costs are estimated — we haven't built a voice agent yet. **Build one and measure real per-minute cost before selling Ultra voice heavily.** Break-even room is large, so the risk is low.
 - **Real constraint is operational, not margin:** trust friction (misunderstandings, transfers, angry callers, recordings). Mitigate with human-transfer + call recordings + the narrow call-capture framing.

--- a/src/components/pricing/PricingSection.astro
+++ b/src/components/pricing/PricingSection.astro
@@ -52,15 +52,17 @@ const copy = {
         featured: false,
         features: [
           "Everything in Premium",
-          "AI Voice Agent — 300 answered min/mo ($8.50 MXN/min overage)",
+          "AI Voice Agent — 300 answered min per location/mo ($8.50 MXN/min overage)",
           "Priority support",
           "Industry tuning (e.g. healthcare)",
         ],
         cta: "Get started",
       },
     ],
+    locations:
+      "Every plan includes up to 2 locations · additional locations +$690 MXN/mo each",
     notes:
-      "No setup fee · No contracts · 2-week free trial · Pay via SPEI or OXXO · CFDI invoice included",
+      "No setup fee · No contracts · 2-week free trial · Unlimited conversations (fair use) · Pay via SPEI or OXXO · CFDI invoice included",
     footerQ: "Need something custom?",
     footerLink: "Let's talk",
     footerHref: "/contact/",
@@ -105,15 +107,17 @@ const copy = {
         featured: false,
         features: [
           "Todo lo de Premium",
-          "Agente de Voz con IA — 300 minutos contestados/mes (excedente $8.50 MXN/min)",
+          "Agente de Voz con IA — 300 minutos contestados por sucursal/mes (excedente $8.50 MXN/min)",
           "Soporte prioritario",
           "Personalización por industria (p. ej. salud)",
         ],
         cta: "Empieza",
       },
     ],
+    locations:
+      "Todos los planes incluyen hasta 2 sucursales · sucursales adicionales +$690 MXN/mes cada una",
     notes:
-      "Sin cuota de instalación · Sin contratos · Prueba gratis de 2 semanas · Pago con SPEI u OXXO · Factura (CFDI) incluida",
+      "Sin cuota de instalación · Sin contratos · Prueba gratis de 2 semanas · Conversaciones ilimitadas (uso justo) · Pago con SPEI u OXXO · Factura (CFDI) incluida",
     footerQ: "¿Necesitas algo a la medida?",
     footerLink: "Hablemos",
     footerHref: "/es/contact/",
@@ -219,8 +223,15 @@ const t = copy[locale];
       }
     </div>
 
+    <!-- Multi-location -->
+    <p
+      class="text-center text-sm font-medium text-gray-700 dark:text-gray-200 mt-10"
+    >
+      {t.locations}
+    </p>
+
     <!-- Notes -->
-    <p class="text-center text-sm text-gray-500 dark:text-gray-400 mt-10">
+    <p class="text-center text-sm text-gray-500 dark:text-gray-400 mt-3">
       {t.notes}
     </p>
     <p class="text-center text-sm text-gray-600 dark:text-gray-300 mt-4">

--- a/src/components/services2/ServiceBlock.astro
+++ b/src/components/services2/ServiceBlock.astro
@@ -32,7 +32,7 @@ const data = {
         "Generating new content — the assistant surfaces YOUR existing knowledge, it doesn't create marketing copy"
       ],
       timeline: "Live in 2–4 weeks. Discovery call → training → testing → launch.",
-      investment: "Included in every plan — from **$1,990 MXN/mo**. Unlimited conversations, fully managed. Includes setup, training, weekly reports, and monthly tuning. No setup fee. No contract.",
+      investment: "Included in every plan — from **$1,990 MXN/mo**. Unlimited conversations (fair use), fully managed. Includes setup, training, weekly reports, and monthly tuning. No setup fee. No contract.",
       investmentDisclaimer: "Free 2-week trial. Cancel anytime.",
       bestFor: [
         "Customer support teams handling 500+ inquiries/month",
@@ -61,7 +61,7 @@ const data = {
         "Creación de contenido nuevo — el asistente surte TU conocimiento existente, no crea texto de marketing"
       ],
       timeline: "En vivo en 2–4 semanas. Llamada → entrenamiento → pruebas → lanzamiento.",
-      investment: "Incluido en todos los planes — desde **$1,990 MXN/mes**. Conversaciones ilimitadas, totalmente gestionado. Incluye configuración, entrenamiento, reportes semanales y ajuste mensual. Sin cuota de instalación. Sin contrato.",
+      investment: "Incluido en todos los planes — desde **$1,990 MXN/mes**. Conversaciones ilimitadas (uso justo), totalmente gestionado. Incluye configuración, entrenamiento, reportes semanales y ajuste mensual. Sin cuota de instalación. Sin contrato.",
       investmentDisclaimer: "Prueba gratis de 2 semanas. Cancela cuando quieras.",
       bestFor: [
         "Equipos de atención al cliente que manejan más de 500 consultas al mes",
@@ -94,7 +94,7 @@ const data = {
         "Paid Facebook ad management or social posting"
       ],
       timeline: "Live in 2 weeks. Discovery call → training → testing → launch.",
-      investment: "Included in every plan — from **$1,990 MXN/mo**. Single page, unlimited conversations, fully managed. Includes setup, training, weekly reports, and monthly tuning. No setup fee. No contract.",
+      investment: "Included in every plan — from **$1,990 MXN/mo**. Single page, unlimited conversations (fair use), fully managed. Includes setup, training, weekly reports, and monthly tuning. No setup fee. No contract.",
       investmentDisclaimer: "Free 2-week trial. Cancel anytime.",
       bestFor: [
         "Local businesses losing leads to slow response times",
@@ -123,7 +123,7 @@ const data = {
         "Gestión de anuncios de Facebook o publicaciones en redes sociales"
       ],
       timeline: "En vivo en 2 semanas. Llamada de descubrimiento → entrenamiento → pruebas → lanzamiento.",
-      investment: "Incluido en todos los planes — desde **$1,990 MXN/mes**. Una sola página, conversaciones ilimitadas, totalmente gestionado. Incluye configuración, entrenamiento, reportes semanales y ajuste mensual. Sin cuota de instalación. Sin contrato.",
+      investment: "Incluido en todos los planes — desde **$1,990 MXN/mes**. Una sola página, conversaciones ilimitadas (uso justo), totalmente gestionado. Incluye configuración, entrenamiento, reportes semanales y ajuste mensual. Sin cuota de instalación. Sin contrato.",
       investmentDisclaimer: "Prueba gratis de 2 semanas. Cancela cuando quieras.",
       bestFor: [
         "Negocios locales perdiendo clientes por respuestas lentas",

--- a/src/pages/es/messenger-assistant.astro
+++ b/src/pages/es/messenger-assistant.astro
@@ -178,7 +178,7 @@ const bestFor = [
             <div class="mb-4">
               <h4 class="font-display font-semibold text-white mb-2 uppercase text-xs tracking-wider">Inversión</h4>
               <div class="text-base leading-relaxed">
-                Incluido en <span class="text-white font-bold">todos los planes — desde $1,990 MXN/mes</span>. Una sola página, conversaciones ilimitadas, totalmente gestionado. Incluye configuración, entrenamiento, reportes semanales y ajuste mensual. Sin cuota de instalación. Sin contrato.
+                Incluido en <span class="text-white font-bold">todos los planes — desde $1,990 MXN/mes</span>. Una sola página, conversaciones ilimitadas (uso justo), totalmente gestionado. Incluye configuración, entrenamiento, reportes semanales y ajuste mensual. Sin cuota de instalación. Sin contrato.
               </div>
             </div>
             <p class="text-xs text-cush-orange font-medium mt-4 italic">Prueba gratis de 2 semanas. Cancela cuando quieras.</p>

--- a/src/pages/messenger-assistant.astro
+++ b/src/pages/messenger-assistant.astro
@@ -178,7 +178,7 @@ const bestFor = [
             <div class="mb-4">
               <h4 class="font-display font-semibold text-white mb-2 uppercase text-xs tracking-wider">Investment</h4>
               <div class="text-base leading-relaxed">
-                Included in <span class="text-white font-bold">every plan — from $1,990 MXN/mo</span>. Single page, unlimited conversations, fully managed. Includes setup, training, weekly reports, and monthly tuning. No setup fee. No contract.
+                Included in <span class="text-white font-bold">every plan — from $1,990 MXN/mo</span>. Single page, unlimited conversations (fair use), fully managed. Includes setup, training, weekly reports, and monthly tuning. No setup fee. No contract.
               </div>
             </div>
             <p class="text-xs text-cush-orange font-medium mt-4 italic">Free 2-week trial. Cancel anytime.</p>


### PR DESCRIPTION
## Multi-location pricing (LOCKED 2026-07-01)
- Published price is **per business, includes up to 2 locations**
- Additional locations: **+\$690 MXN/mo each, flat across all tiers**
- Voice minutes (Ultra) are now **per location** — 300 answered min per location/mo
- Formula scales cleanly, no brackets: 9-location Basic = 1,990 + 7×690 = **\$6,820/mo**

New callout line on the pricing chart (EN + ES); voice feature updated to "per location."

## Fair-use cap on "unlimited conversations"
- "unlimited conversations" → **"unlimited conversations (fair use)"** everywhere (EN + ES)
- Unbounded "unlimited" in front of a metered LLM cost is the exact failure mode the global rate-limit rule guards against (viral post → surprise Anthropic/OpenAI bill)
- Internal, **unpublished** threshold ~1,000 conversations/mo per location; beyond it we right-size — never a silent surprise charge
- Fixed in ServiceBlock (4 lines) + both messenger pages (2), plus fair-use added to the pricing-page notes strip

## Docs
- `docs/strategy/MEXICO-GTM-STRATEGY.md` — new Multi-location pricing + Fair-use policy sections; voice copy updated to "per location"

## Verification
- `npm run build` clean, meta-description gate PASS (108 pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)