### PR TITLE
feat: edge-case operating policies + billing/cancellation terms

### DIFF
--- a/docs/strategy/MEXICO-GTM-STRATEGY.md
+++ b/docs/strategy/MEXICO-GTM-STRATEGY.md
@@ -251,6 +251,51 @@ Cold DM → landing page → **"Diagnóstico gratis"** → qualify & route:
 
 ---
 
+## 11. Edge Cases & Operating Policies
+
+Decided 2026-07-01. These drive how we quote and bill — keep consistent across deals. Most are internal policy; only **currency** (pricing-page note) and **billing/cancellation** (Terms page) surface publicly.
+
+### Multi-location chains (5+ locations)
+
+- **No free trial and no setup fee for chains — start with a paid pilot on 1–2 locations, then expand.** They pay standard price from day 1 of the pilot (covers onboarding labor), prove value on 2 locations, then roll out the rest at +$690/location. Land-and-expand — lower risk for both sides.
+- **Fallback lever:** if a chain insists on all locations live at once and won't pilot, quote a one-time onboarding fee instead. Not the default.
+- Keeps "no setup fee" + "2-week free trial" universally true on the public site (they apply to standard 1–2 location accounts, which is ~95% of the market).
+
+### Setup fee
+
+- **Standard accounts (1–2 locations): none, ever — it's a headline conversion lever.** Complex/chain onboarding is handled by the paid-pilot model above, not a published fee.
+
+### Free trial
+
+- **2-week free trial applies to standard single- or two-location plans only.** Multi-location rollouts begin with a paid pilot.
+
+### US / international leads (currency) — DEFERRED
+
+- **Full US/global pricing alignment is a separate later pass (Robert, 2026-07-01). Do not publish USD pricing yet.**
+- Interim: pricing page shows _"Prices in MXN · US or international? Let's talk,"_ routing US leads to a custom conversation.
+- **Never auto-convert MXN↔USD** — US willingness-to-pay is independent. Working starting point for the later pass: ~**$100 USD/mo** for Basic (up to 2 locations). Note this is ~parity with the peso price (so it reads as the same price in the customer's currency, not two-tiered) and is likely **conservative** for the US market — US SMBs pay $100–500/mo for managed services. Revisit before quoting US at scale.
+
+### Google review-response volume
+
+- Covered by per-location pricing (more reviews ≈ more locations ≈ more revenue); within one location, volume is naturally bounded. **Fair-use, internal threshold ~50 responses/mo per location** (far above normal). No public copy.
+
+### Billing, proration & cancellation (now on the Terms page)
+
+- Billed **monthly in advance**, per business, includes up to 2 locations.
+- **Added locations / upgrades:** effective next billing cycle. **Removals / downgrades:** effective next billing cycle.
+- **"Cancel anytime" = effective at the end of the current paid month; no partial refunds** for the current period.
+
+### Additional languages
+
+- **EN/ES included** (core bilingual value). A 3rd language (e.g. tourist-market French) = custom add-on on request, scoped per case.
+
+### Franchise vs. corporate buyer
+
+- Multi-location pricing assumes **one owner buying for all their locations.**
+- Independent franchisees = **separate standard accounts** (separate businesses). Franchise-HQ-buys-for-all = **enterprise / custom quote.**
+
+---
+
 ## Source Notes
 
 Research conducted 2026-06-28 via web search. Strongest (government/peer-reviewed): INEGI Censo Económico 2024 & DENUE/DataMéxico; IFT digital-adoption; Banxico SPEI; DataReportal/Statista WhatsApp penetration (~92%); Meta/WhatsApp developer docs. Directional (vendor-grade): clinic/salon behavior, no-show rates, ticket prices, and most competitor pricing (Kosmo, Booksy, Fresha, AgendaPro, Dentalink, Doctoralia, Neural IA, Dentiqa, Leadsales, Whaticket). **Key evidence gap:** no public survey quantifies software-penetration vs. manual operation in either niche — the manual tail is plausibly large but unmeasured; outreach is the validation.

--- a/src/components/pricing/PricingSection.astro
+++ b/src/components/pricing/PricingSection.astro
@@ -63,6 +63,8 @@ const copy = {
       "Every plan includes up to 2 locations · additional locations +$690 MXN/mo each",
     notes:
       "No setup fee · No contracts · 2-week free trial · Unlimited conversations (fair use) · Pay via SPEI or OXXO · CFDI invoice included",
+    geo: "Prices in MXN. In the US or elsewhere?",
+    geoLink: "Let's talk",
     footerQ: "Need something custom?",
     footerLink: "Let's talk",
     footerHref: "/contact/",
@@ -118,6 +120,8 @@ const copy = {
       "Todos los planes incluyen hasta 2 sucursales · sucursales adicionales +$690 MXN/mes cada una",
     notes:
       "Sin cuota de instalación · Sin contratos · Prueba gratis de 2 semanas · Conversaciones ilimitadas (uso justo) · Pago con SPEI u OXXO · Factura (CFDI) incluida",
+    geo: "Precios en MXN. ¿En EE.UU. u otro país?",
+    geoLink: "Hablemos",
     footerQ: "¿Necesitas algo a la medida?",
     footerLink: "Hablemos",
     footerHref: "/es/contact/",
@@ -233,6 +237,14 @@ const t = copy[locale];
     <!-- Notes -->
     <p class="text-center text-sm text-gray-500 dark:text-gray-400 mt-3">
       {t.notes}
+    </p>
+    <p class="text-center text-sm text-gray-500 dark:text-gray-400 mt-3">
+      {t.geo}{" "}
+      <a
+        href={t.footerHref}
+        class="text-cush-orange font-semibold underline underline-offset-4 hover:opacity-80"
+        >{t.geoLink}</a
+      >
     </p>
     <p class="text-center text-sm text-gray-600 dark:text-gray-300 mt-4">
       {t.footerQ}{" "}

--- a/src/pages/es/terms.astro
+++ b/src/pages/es/terms.astro
@@ -8,7 +8,7 @@ const content = {
   title: "Términos de Servicio | CushLabs.ai",
   description: "Términos y condiciones de consultoría de IA y desarrollo de software de CushLabs.ai. Expectativas claras para proyectos y clientes.",
   heading: "Términos de Servicio",
-  lastUpdated: "Última actualización: Febrero 2026",
+  lastUpdated: "Última actualización: Julio 2026",
   sections: [
     {
       title: "Aceptación de Términos",
@@ -29,6 +29,10 @@ const content = {
     {
       title: "Términos de Pago",
       content: "Los términos de pago se especificarán en los acuerdos de servicio individuales. A menos que se acuerde lo contrario, las facturas vencen dentro de los 30 días posteriores a su recepción."
+    },
+    {
+      title: "Suscripciones, Facturación y Cancelación",
+      content: "Los planes de suscripción se facturan por mes, de forma anticipada. El precio es por negocio e incluye hasta 2 sucursales; las sucursales adicionales se facturan a la tarifa publicada vigente. Las sucursales agregadas y las mejoras de plan aplican a partir del siguiente ciclo de facturación; las reducciones y bajas de plan también aplican a partir del siguiente ciclo. Puede cancelar en cualquier momento — la cancelación surte efecto al final del mes ya pagado y no se emiten reembolsos parciales por el periodo en curso. La prueba gratis de 2 semanas aplica a planes estándar de una o dos sucursales; los despliegues de múltiples sucursales inician con un piloto pagado en lugar de prueba gratis."
     },
     {
       title: "Limitación de Responsabilidad",

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -5,7 +5,7 @@ const content = {
   title: "Terms of Service | CushLabs.ai",
   description: "Terms and conditions for CushLabs.ai AI consulting and software development services. Clear expectations for projects, deliverables, and client relationships.",
   heading: "Terms of Service",
-  lastUpdated: "Last updated: February 2026",
+  lastUpdated: "Last updated: July 2026",
   sections: [
     {
       title: "Acceptance of Terms",
@@ -26,6 +26,10 @@ const content = {
     {
       title: "Payment Terms",
       content: "Payment terms will be specified in individual service agreements. Unless otherwise agreed, invoices are due within 30 days of receipt."
+    },
+    {
+      title: "Subscriptions, Billing & Cancellation",
+      content: "Subscription plans are billed monthly, in advance. Pricing is per business and includes up to 2 locations; additional locations are billed at the current published rate. Added locations and plan upgrades take effect from the next billing cycle; removals and plan downgrades also take effect from the next billing cycle. You may cancel at any time — cancellation takes effect at the end of the current paid month, and no partial refunds are issued for the current period. The 2-week free trial applies to standard single- or two-location plans; multi-location rollouts begin with a paid pilot rather than a free trial."
     },
     {
       title: "Limitation of Liability",


### PR DESCRIPTION
Flushes out the remaining pricing edge cases (decided 2026-07-01). Mostly policy/documentation; two light public touches.

## Public copy
- **Pricing page** (EN + ES): new line — *"Prices in MXN · US or international? Let's talk"* → routes US/international leads to contact.
- **Terms page** (EN + ES): new **Subscriptions, Billing & Cancellation** section so "cancel anytime" has teeth — billed monthly in advance, adds/removes take effect next cycle, cancel = end of current paid month, no partial refunds, free trial = standard 1–2 location plans (chains get a paid pilot). Date bumped to July 2026.

## Decisions (documented in strategy §11)
- **Chains (5+):** no free trial / no setup fee → **paid pilot on 1–2 locations, then expand.** Keeps "no setup fee" + "free trial" universally true for standard accounts.
- **US pricing:** **deferred** to a later pass. Never auto-convert MXN↔USD; ~\$100/mo parity captured as the working starting point (likely conservative for the US).
- **Review-response volume:** fair-use, internal ~50/mo/location. **Languages:** EN/ES included, 3rd = custom. **Franchise:** one owner = one account; independent franchisees = separate accounts; HQ-wide = enterprise quote.

## Verification
- `npm run build` clean, meta-description gate PASS (108 pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)