### PR TITLE
fix: give chains the free trial too (scoped to 1-2 locations)

### DIFF
--- a/docs/strategy/MEXICO-GTM-STRATEGY.md
+++ b/docs/strategy/MEXICO-GTM-STRATEGY.md
@@ -257,17 +257,18 @@ Decided 2026-07-01. These drive how we quote and bill — keep consistent across
 
 ### Multi-location chains (5+ locations)
 
-- **No free trial and no setup fee for chains — start with a paid pilot on 1–2 locations, then expand.** They pay standard price from day 1 of the pilot (covers onboarding labor), prove value on 2 locations, then roll out the rest at +$690/location. Land-and-expand — lower risk for both sides.
-- **Fallback lever:** if a chain insists on all locations live at once and won't pilot, quote a one-time onboarding fee instead. Not the default.
-- Keeps "no setup fee" + "2-week free trial" universally true on the public site (they apply to standard 1–2 location accounts, which is ~95% of the market).
+- **Chains get the standard 2-week free trial — scoped to 1–2 locations — then expand to the rest (paid, +$690/location).** They evaluate risk-free on 1–2 locations; your free-build exposure is capped at 2 setups no matter how big they eventually are. Land-and-expand. (Revised 2026-07-01 — the LTV math wins: a 9-location Basic chain is ~$82k MXN/yr, so eating 2 free setups to land it is a trivial CAC. Denying the highest-LTV customers the best conversion tool was backwards.)
+- **No setup fee for chains** — onboarding labor during the free period is capped at the 1–2 trial locations; the remaining locations are built only after they commit and pay.
+- **Paid-pilot fallback:** only if a chain refuses a scoped trial and demands all locations live at once during the free period — that's the genuinely heavy, walk-away-risky case. Then quote a paid pilot / one-time onboarding fee. Not the default.
+- Keeps "no setup fee" + "2-week free trial" universally true on the public site.
 
 ### Setup fee
 
-- **Standard accounts (1–2 locations): none, ever — it's a headline conversion lever.** Complex/chain onboarding is handled by the paid-pilot model above, not a published fee.
+- **None, ever, on the published plans — it's a headline conversion lever.** Chain onboarding stays free because the free period is scoped to 1–2 locations; the rest is built only after they commit. Paid pilot / onboarding fee is the fallback only if a chain demands all locations live during the free trial.
 
 ### Free trial
 
-- **2-week free trial applies to standard single- or two-location plans only.** Multi-location rollouts begin with a paid pilot.
+- **Every new plan gets the 2-week free trial, scoped to up to 2 locations** — including chains, which trial on 1–2 locations then expand to the rest (paid). Paid pilot only as the fallback (see chains).
 
 ### US / international leads (currency) — DEFERRED
 

--- a/src/pages/es/terms.astro
+++ b/src/pages/es/terms.astro
@@ -32,7 +32,7 @@ const content = {
     },
     {
       title: "Suscripciones, Facturación y Cancelación",
-      content: "Los planes de suscripción se facturan por mes, de forma anticipada. El precio es por negocio e incluye hasta 2 sucursales; las sucursales adicionales se facturan a la tarifa publicada vigente. Las sucursales agregadas y las mejoras de plan aplican a partir del siguiente ciclo de facturación; las reducciones y bajas de plan también aplican a partir del siguiente ciclo. Puede cancelar en cualquier momento — la cancelación surte efecto al final del mes ya pagado y no se emiten reembolsos parciales por el periodo en curso. La prueba gratis de 2 semanas aplica a planes estándar de una o dos sucursales; los despliegues de múltiples sucursales inician con un piloto pagado en lugar de prueba gratis."
+      content: "Los planes de suscripción se facturan por mes, de forma anticipada. El precio es por negocio e incluye hasta 2 sucursales; las sucursales adicionales se facturan a la tarifa publicada vigente. Las sucursales agregadas y las mejoras de plan aplican a partir del siguiente ciclo de facturación; las reducciones y bajas de plan también aplican a partir del siguiente ciclo. Puede cancelar en cualquier momento — la cancelación surte efecto al final del mes ya pagado y no se emiten reembolsos parciales por el periodo en curso. Todo plan nuevo incluye una prueba gratis de 2 semanas en hasta dos sucursales; los despliegues de múltiples sucursales realizan la prueba primero en una o dos sucursales y luego agregan las demás sucursales al continuar."
     },
     {
       title: "Limitación de Responsabilidad",

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -29,7 +29,7 @@ const content = {
     },
     {
       title: "Subscriptions, Billing & Cancellation",
-      content: "Subscription plans are billed monthly, in advance. Pricing is per business and includes up to 2 locations; additional locations are billed at the current published rate. Added locations and plan upgrades take effect from the next billing cycle; removals and plan downgrades also take effect from the next billing cycle. You may cancel at any time — cancellation takes effect at the end of the current paid month, and no partial refunds are issued for the current period. The 2-week free trial applies to standard single- or two-location plans; multi-location rollouts begin with a paid pilot rather than a free trial."
+      content: "Subscription plans are billed monthly, in advance. Pricing is per business and includes up to 2 locations; additional locations are billed at the current published rate. Added locations and plan upgrades take effect from the next billing cycle; removals and plan downgrades also take effect from the next billing cycle. You may cancel at any time — cancellation takes effect at the end of the current paid month, and no partial refunds are issued for the current period. Every new plan includes a 2-week free trial on up to two locations; larger multi-location rollouts run the free trial on one or two locations first, then expand to the remaining locations once you continue."
     },
     {
       title: "Limitation of Liability",


### PR DESCRIPTION
Reverses the prior "chains get no free trial / paid pilot" default (shipped in #145).

**Why:** the setup-weight concern only holds if the free trial covers *all* of a chain's locations. Scoped to 1–2, your free-build exposure is identical to any standard customer. And the LTV math is lopsided — a 9-location Basic chain is ~\$82k MXN/yr, so eating 2 free setups to land it is a trivial CAC. Denying the highest-LTV customers the best conversion tool was backwards.

**New policy:** every new plan gets the 2-week free trial on up to 2 locations, **including chains** (trial on 1–2, then expand paid at +\$690/location). Paid pilot drops to a **fallback** — only if a chain demands all locations live at once during the free period.

## Changes
- `terms.astro` + `es/terms.astro` — updated the free-trial sentence (EN + ES)
- `MEXICO-GTM-STRATEGY.md §11` — chains / setup fee / free trial subsections

## Verification
- `npm run build` clean, meta-description gate PASS (108 pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)