### PR TITLE
fix: generalize service delivery timelines (drop hard "live in 2 weeks")

### DIFF
--- a/src/components/services2/HowIWork.astro
+++ b/src/components/services2/HowIWork.astro
@@ -10,7 +10,7 @@ const { locale } = Astro.props;
 const content = {
   en: {
     heading: "How I Work",
-    subheading: "From first call to live system in as little as 2 weeks. Here's the process:",
+    subheading: "From first call to a live system fast — often within days. Here's the process:",
     steps: [
       {
         title: "Step 1: Free Discovery Call (30 min)",
@@ -34,7 +34,7 @@ const content = {
   },
   es: {
     heading: "Cómo Trabajo",
-    subheading: "De la primera llamada a un sistema en vivo en tan solo 2 semanas. Así es el proceso:",
+    subheading: "De la primera llamada a un sistema en vivo rápido — a menudo en pocos días. Así es el proceso:",
     steps: [
       {
         title: "Paso 1: Llamada de Descubrimiento Gratis (30 min)",

--- a/src/components/services2/ServiceBlock.astro
+++ b/src/components/services2/ServiceBlock.astro
@@ -31,7 +31,7 @@ const data = {
         "Integration with custom CRMs or ERPs (scoped separately if needed)",
         "Generating new content — the assistant surfaces YOUR existing knowledge, it doesn't create marketing copy"
       ],
-      timeline: "Live in 2–4 weeks. Discovery call → training → testing → launch.",
+      timeline: "Fast setup — often live within days of your intake form. Discovery call → training → testing → launch.",
       investment: "Included in every plan — from **$1,990 MXN/mo**. Unlimited conversations (fair use), fully managed. Includes setup, training, weekly reports, and monthly tuning. No setup fee. No contract.",
       investmentDisclaimer: "Free 2-week trial. Cancel anytime.",
       bestFor: [
@@ -60,7 +60,7 @@ const data = {
         "Integración con CRMs/ERPs personalizados (se cotiza aparte)",
         "Creación de contenido nuevo — el asistente surte TU conocimiento existente, no crea texto de marketing"
       ],
-      timeline: "En vivo en 2–4 semanas. Llamada → entrenamiento → pruebas → lanzamiento.",
+      timeline: "Configuración rápida — en vivo pocos días después de tu formulario. Llamada → entrenamiento → pruebas → lanzamiento.",
       investment: "Incluido en todos los planes — desde **$1,990 MXN/mes**. Conversaciones ilimitadas (uso justo), totalmente gestionado. Incluye configuración, entrenamiento, reportes semanales y ajuste mensual. Sin cuota de instalación. Sin contrato.",
       investmentDisclaimer: "Prueba gratis de 2 semanas. Cancela cuando quieras.",
       bestFor: [
@@ -93,7 +93,7 @@ const data = {
         "Generating new marketing content — the assistant uses YOUR voice and YOUR products",
         "Paid Facebook ad management or social posting"
       ],
-      timeline: "Live in 2 weeks. Discovery call → training → testing → launch.",
+      timeline: "Fast setup — often live within days of your intake form. Discovery call → training → testing → launch.",
       investment: "Included in every plan — from **$1,990 MXN/mo**. Single page, unlimited conversations (fair use), fully managed. Includes setup, training, weekly reports, and monthly tuning. No setup fee. No contract.",
       investmentDisclaimer: "Free 2-week trial. Cancel anytime.",
       bestFor: [
@@ -122,7 +122,7 @@ const data = {
         "Generación de contenido nuevo de marketing — el asistente usa TU voz y TUS productos",
         "Gestión de anuncios de Facebook o publicaciones en redes sociales"
       ],
-      timeline: "En vivo en 2 semanas. Llamada de descubrimiento → entrenamiento → pruebas → lanzamiento.",
+      timeline: "Configuración rápida — en vivo pocos días después de tu formulario. Llamada de descubrimiento → entrenamiento → pruebas → lanzamiento.",
       investment: "Incluido en todos los planes — desde **$1,990 MXN/mes**. Una sola página, conversaciones ilimitadas (uso justo), totalmente gestionado. Incluye configuración, entrenamiento, reportes semanales y ajuste mensual. Sin cuota de instalación. Sin contrato.",
       investmentDisclaimer: "Prueba gratis de 2 semanas. Cancela cuando quieras.",
       bestFor: [
@@ -218,7 +218,7 @@ const data = {
         "Integration with enterprise phone systems (PBX, Cisco, etc. — scoped separately)",
         "Call recording storage beyond 30 days"
       ],
-      timeline: "Live in 1–2 weeks. Discovery call → voice setup → testing → launch.",
+      timeline: "Fast setup — live soon after your intake form. Discovery call → voice setup → testing → launch.",
       investment: "Included in the **Ultra plan — $5,490 MXN/mo**. 300 answered minutes, setup, training, and monthly reports. Overage at $8.50 MXN/min. No setup fee. No contract.",
       investmentDisclaimer: "Free 2-week trial. Cancel anytime.",
       bestFor: [
@@ -248,7 +248,7 @@ const data = {
         "Integración con sistemas telefónicos empresariales (PBX, Cisco — se cotiza aparte)",
         "Almacenamiento de grabaciones más allá de 30 días"
       ],
-      timeline: "En vivo en 1–2 semanas. Llamada → configuración de voz → pruebas → lanzamiento.",
+      timeline: "Configuración rápida — en vivo poco después de tu formulario. Llamada → configuración de voz → pruebas → lanzamiento.",
       investment: "Incluido en el **plan Ultra — $5,490 MXN/mes**. 300 minutos contestados, configuración, entrenamiento y reportes mensuales. Excedente a $8.50 MXN/min. Sin cuota de instalación. Sin contrato.",
       investmentDisclaimer: "Prueba gratis de 2 semanas. Cancela cuando quieras.",
       bestFor: [

--- a/src/components/services2/WhoItIsFor.astro
+++ b/src/components/services2/WhoItIsFor.astro
@@ -17,7 +17,7 @@ const content = {
         "**Businesses handling significant volume** — 500+ support inquiries/month, teams spending 10+ hours/week on manual work, or local businesses competing for Google Maps visibility",
         "**Companies with existing business knowledge** — you have docs, SOPs, FAQs, or policies that can be structured and leveraged",
         "**Teams serving bilingual customers** (English/Spanish) across US and Mexico/LATAM markets",
-        "**Decision-makers who can commit to a 30-minute discovery call** and a 2–8 week implementation timeline",
+        "**Decision-makers who can commit to a 30-minute discovery call** and a short implementation timeline (days to a few weeks)",
         "**People who value transparency** — I show my work, document everything, and give you honest assessments, including when AI isn't the answer"
       ]
     },
@@ -28,7 +28,7 @@ const content = {
         "You're looking for the cheapest possible option — I compete on quality and outcomes, not price",
         "You want a science project — I build production systems tied to business results, not experimental AI that might work someday",
         "Your project requires deep integration with proprietary enterprise systems (SAP, Oracle, etc.) — I can advise, but implementation at that scale needs a larger team",
-        "You need it live tomorrow — my fastest delivery is 2 weeks. If you need something by Friday, I'm not your person"
+        "You need it live today — I move fast (often days once I have your intake), but not same-day. If you need it up and running this afternoon, I'm not your person"
       ]
     }
   },
@@ -41,7 +41,7 @@ const content = {
         "**Negocios con volumen real** — más de 500 consultas de soporte al mes, equipos que dedican más de 10 horas a la semana a trabajo manual, o negocios locales que compiten por visibilidad en Google Maps",
         "**Empresas con conocimiento de negocio ya documentado** — tienes manuales, procedimientos, preguntas frecuentes o políticas que se pueden estructurar y aprovechar",
         "**Equipos que atienden a clientes bilingües** (inglés/español) en los mercados de EE.UU. y México/LatAm",
-        "**Tomadores de decisiones que pueden comprometerse a una llamada de descubrimiento de 30 minutos** y a un plazo de implementación de 2 a 8 semanas",
+        "**Tomadores de decisiones que pueden comprometerse a una llamada de descubrimiento de 30 minutos** y a un plazo de implementación corto (de días a unas semanas)",
         "**Personas que valoran la transparencia** — muestro mi trabajo, documento todo y te doy una evaluación honesta, incluso cuando la IA no es la respuesta"
       ]
     },
@@ -52,7 +52,7 @@ const content = {
         "Buscas la opción más barata posible — compito por calidad y resultados, no por precio",
         "Quieres un proyecto experimental — construyo sistemas en producción atados a resultados de negocio, no IA experimental que tal vez funcione algún día",
         "Tu proyecto requiere integración profunda con sistemas empresariales propietarios (SAP, Oracle, etc.) — puedo asesorarte, pero implementar a esa escala requiere un equipo más grande",
-        "Lo necesitas listo para mañana — mi entrega más rápida es de 2 semanas. Si lo necesitas para el viernes, no soy tu persona"
+        "Lo necesitas listo hoy mismo — trabajo rápido (a menudo en días una vez que tengo tu formulario), pero no en el mismo día. Si lo necesitas funcionando esta tarde, no soy tu persona"
       ]
     }
   }

--- a/src/pages/es/messenger-assistant.astro
+++ b/src/pages/es/messenger-assistant.astro
@@ -173,7 +173,7 @@ const bestFor = [
           <div class="bg-gray-900 dark:bg-gray-800 rounded-2xl p-8 shadow-xl text-gray-300">
             <div class="mb-6 pb-6 border-b border-gray-700">
               <h4 class="font-display font-semibold text-white mb-2 uppercase text-xs tracking-wider">Línea de Tiempo</h4>
-              <div class="text-lg text-white font-medium">En vivo en 2 semanas. Llamada → entrenamiento → pruebas → lanzamiento.</div>
+              <div class="text-lg text-white font-medium">Configuración rápida — en vivo pocos días después de tu formulario. Llamada → entrenamiento → pruebas → lanzamiento.</div>
             </div>
             <div class="mb-4">
               <h4 class="font-display font-semibold text-white mb-2 uppercase text-xs tracking-wider">Inversión</h4>

--- a/src/pages/es/voice-agent.astro
+++ b/src/pages/es/voice-agent.astro
@@ -57,7 +57,7 @@ const bestFor = [
           Un agente de voz con IA disponible 24/7 que contesta el teléfono de tu negocio con voz natural — agenda citas, captura leads y nunca manda a un cliente al buzón.
         </p>
         <p class="text-fluid-base text-gray-500 dark:text-gray-400 mb-10 max-w-2xl mx-auto leading-relaxed">
-          Bilingüe EN/ES. Totalmente gestionado. En vivo en 1–2 semanas. Prueba gratis de 2 semanas.
+          Bilingüe EN/ES. Totalmente gestionado. Configuración rápida. Prueba gratis de 2 semanas.
         </p>
 
         <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
@@ -193,7 +193,7 @@ const bestFor = [
           <div class="bg-gray-900 dark:bg-gray-800 rounded-2xl p-8 shadow-xl text-gray-300">
             <div class="mb-6 pb-6 border-b border-gray-700">
               <h4 class="font-display font-semibold text-white mb-2 uppercase text-xs tracking-wider">Línea de Tiempo</h4>
-              <div class="text-lg text-white font-medium">En vivo en 1–2 semanas. Llamada → configuración de voz → pruebas → lanzamiento.</div>
+              <div class="text-lg text-white font-medium">Configuración rápida — en vivo poco después de tu formulario. Llamada → configuración de voz → pruebas → lanzamiento.</div>
             </div>
             <div class="mb-4">
               <h4 class="font-display font-semibold text-white mb-2 uppercase text-xs tracking-wider">Inversión</h4>

--- a/src/pages/messenger-assistant.astro
+++ b/src/pages/messenger-assistant.astro
@@ -173,7 +173,7 @@ const bestFor = [
           <div class="bg-gray-900 dark:bg-gray-800 rounded-2xl p-8 shadow-xl text-gray-300">
             <div class="mb-6 pb-6 border-b border-gray-700">
               <h4 class="font-display font-semibold text-white mb-2 uppercase text-xs tracking-wider">Timeline</h4>
-              <div class="text-lg text-white font-medium">Live in 2 weeks. Discovery call → training → testing → launch.</div>
+              <div class="text-lg text-white font-medium">Fast setup — often live within days of your intake form. Discovery call → training → testing → launch.</div>
             </div>
             <div class="mb-4">
               <h4 class="font-display font-semibold text-white mb-2 uppercase text-xs tracking-wider">Investment</h4>

--- a/src/pages/voice-agent.astro
+++ b/src/pages/voice-agent.astro
@@ -57,7 +57,7 @@ const bestFor = [
           A 24/7 AI voice agent that answers your business phone with a natural, conversational voice — books appointments, captures leads, and never sends a caller to voicemail.
         </p>
         <p class="text-fluid-base text-gray-500 dark:text-gray-400 mb-10 max-w-2xl mx-auto leading-relaxed">
-          Bilingual EN/ES. Fully managed. Live in 1–2 weeks. Free 2-week trial.
+          Bilingual EN/ES. Fully managed. Fast setup. Free 2-week trial.
         </p>
 
         <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
@@ -193,7 +193,7 @@ const bestFor = [
           <div class="bg-gray-900 dark:bg-gray-800 rounded-2xl p-8 shadow-xl text-gray-300">
             <div class="mb-6 pb-6 border-b border-gray-700">
               <h4 class="font-display font-semibold text-white mb-2 uppercase text-xs tracking-wider">Timeline</h4>
-              <div class="text-lg text-white font-medium">Live in 1–2 weeks. Discovery call → voice setup → testing → launch.</div>
+              <div class="text-lg text-white font-medium">Fast setup — live soon after your intake form. Discovery call → voice setup → testing → launch.</div>
             </div>
             <div class="mb-4">
               <h4 class="font-display font-semibold text-white mb-2 uppercase text-xs tracking-wider">Investment</h4>


### PR DESCRIPTION
The hard **"Live in 2 weeks"** on the service blocks both undersold actual speed and set a rigid SLA. Delivery is fast once the client's intake form is in — so timelines now key off that: general, honest, no hard week-count.

## Changes (service surfaces only)
- **ServiceBlock timelines** (messenger, support, voice — EN + ES): "Live in X weeks" → *"Fast setup — often live within days of your intake form."* Voice kept more measured (*"live soon after your intake form"*) since it's newer to us. Monitoring's *"first report in 1 week"* left as-is (a positive deliverable).
- **messenger-assistant + voice-agent pages**: Timeline callouts + the voice hero line.
- **HowIWork** subheading: *"in as little as 2 weeks"* → *"fast — often within days."*
- **WhoItIsFor**: reconciled the now-contradictory *"my fastest delivery is 2 weeks"* and *"2–8 week timeline"* to the faster reality (EN + ES).

## Intentionally NOT touched
- **Free-trial "2 weeks"** copy everywhere (that's the trial length, not delivery time).
- **Homepage / FAQ / about "2–6 weeks"** — broader brand/project copy; flagged for a separate decision (do we want the homepage to also promise "days"?).

## Verification
- `npm run build` clean, meta-description gate PASS (108 pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)