### PR TITLE
fix: align homepage/about/taglines to "live in days, not weeks"

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -9,7 +9,7 @@ const { locale } = Astro.props;
 
 const content = {
   en: {
-    tagline: "AI chatbots, voice agents, and workflow automation built for small business teams in the US and Mexico. Bilingual EN/ES. Live in 2–6 weeks.",
+    tagline: "AI chatbots, voice agents, and workflow automation built for small business teams in the US and Mexico. Bilingual EN/ES. Live in days, not weeks.",
     valueProp: "Fully Bilingual EN/ES • Serving US & Mexico",
     services: {
       title: "Services",
@@ -53,7 +53,7 @@ const content = {
     copyrightSuffix: "All rights reserved.",
   },
   es: {
-    tagline: "Chatbots de IA, agentes de voz y automatización de procesos para equipos de pequeñas empresas en EE.UU. y México. Bilingüe EN/ES. En vivo en 2–6 semanas.",
+    tagline: "Chatbots de IA, agentes de voz y automatización de procesos para equipos de pequeñas empresas en EE.UU. y México. Bilingüe EN/ES. En vivo en días, no semanas.",
     valueProp: "Totalmente Bilingüe EN/ES • Sirviendo EE.UU. y México",
     services: {
       title: "Servicios",

--- a/src/components/home2/FAQ.astro
+++ b/src/components/home2/FAQ.astro
@@ -17,7 +17,7 @@ const content = {
       },
       {
         q: "How long does implementation take?",
-        a: "Most projects launch in 2–6 weeks depending on scope. A focused chatbot can be live in 2–3 weeks. More complex systems (document processing, custom tools) typically take 4–6 weeks. I show you progress weekly."
+        a: "Most productized setups — Messenger assistant, website chatbot, reviews — go live within days of your completed intake form. More complex custom builds (document processing, custom integrations) can take a few weeks. Either way, I show you progress the whole way."
       },
       {
         q: "What if the AI gives wrong answers?",
@@ -48,7 +48,7 @@ const content = {
       },
       {
         q: "¿Cuánto tiempo toma la implementación?",
-        a: "La mayoría de los proyectos se lanzan en 2–6 semanas dependiendo del alcance. Un chatbot enfocado puede estar en vivo en 2–3 semanas. Sistemas más complejos típicamente toman 4–6 semanas. Te muestro el progreso cada semana."
+        a: "La mayoría de las configuraciones productizadas — asistente de Messenger, chatbot para tu sitio, reseñas — entran en vivo pocos días después de completar tu formulario. Los desarrollos a la medida más complejos (procesamiento de documentos, integraciones personalizadas) pueden tomar unas semanas. En cualquier caso, te muestro el progreso todo el tiempo."
       },
       {
         q: "¿Qué pasa si la IA da respuestas incorrectas?",

--- a/src/components/home2/Hero.astro
+++ b/src/components/home2/Hero.astro
@@ -11,7 +11,7 @@ const content = {
   en: {
     badge: 'AI Engineering for Small Business · Bilingual EN/ES · Guadalajara → U.S.',
     headline: "AI That Answers Customers When You Can't — Day, Night, and Weekends.",
-    subheadline1: 'I build AI systems that answer messages, book appointments, and capture leads while your team sleeps — in English and Spanish, live in 2–6 weeks.',
+    subheadline1: 'I build AI systems that answer messages, book appointments, and capture leads while your team sleeps — in English and Spanish, live in days, not weeks.',
     subheadline2: '',
     trustStrip: [
       '30+ projects shipped',
@@ -26,7 +26,7 @@ const content = {
   es: {
     badge: 'Ingeniería de IA para Pymes · Bilingüe EN/ES · Guadalajara → EE.UU.',
     headline: 'IA Que Atiende a Tus Clientes Cuando Tú No Puedes — Día, Noche y Fines de Semana.',
-    subheadline1: 'Construyo sistemas de IA que contestan mensajes, agendan citas y capturan leads mientras tu equipo duerme — en español e inglés, en vivo en 2 a 6 semanas.',
+    subheadline1: 'Construyo sistemas de IA que contestan mensajes, agendan citas y capturan leads mientras tu equipo duerme — en español e inglés, en vivo en días, no semanas.',
     subheadline2: '',
     trustStrip: [
       '30+ proyectos entregados',

--- a/src/components/home2/HowItWorks.astro
+++ b/src/components/home2/HowItWorks.astro
@@ -9,7 +9,7 @@ const { locale } = Astro.props;
 
 const content = {
   en: {
-    heading: 'How It Works — Your AI Is Live in 2–6 Weeks',
+    heading: 'How It Works — Your AI Is Live in Days, Not Weeks',
     steps: [
       {
         title: 'Step 1: Discovery',
@@ -27,7 +27,7 @@ const content = {
     addon: 'Want ongoing optimization? I offer monthly retainers to keep your systems sharp as your business evolves.'
   },
   es: {
-    heading: 'Cómo Funciona — Tu IA en Vivo en 2–6 Semanas',
+    heading: 'Cómo Funciona — Tu IA en Vivo en Días, No Semanas',
     steps: [
       {
         title: 'Paso 1: Descubrimiento',

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -51,7 +51,7 @@ const content = {
         },
         {
           title: "Fast Delivery",
-          description: "Most projects go live in 2-4 weeks. You'll see working software quickly — not months of planning and meetings.",
+          description: "Most setups go live in days, not weeks. You'll see working software quickly — not months of planning and meetings.",
         },
         {
           title: "You Own Everything",
@@ -131,7 +131,7 @@ const content = {
         },
         {
           title: "Entrega Rápida",
-          description: "La mayoría de proyectos se lanzan en 2-4 semanas. Verás software funcionando rápidamente — no meses de planeación y reuniones.",
+          description: "La mayoría de las configuraciones se lanzan en días, no semanas. Verás software funcionando rápidamente — no meses de planeación y reuniones.",
         },
         {
           title: "Tú Eres Dueño de Todo",

--- a/src/pages/es/about.astro
+++ b/src/pages/es/about.astro
@@ -42,7 +42,7 @@ const content = {
     items: [
       { title: "Práctico Sobre Perfecto", description: "Construyo soluciones que funcionan en el mundo real, no demos impresionantes que fallan en producción. Obtienes herramientas que tu equipo realmente usará." },
       { title: "Precios Mensuales Simples, Sin Sorpresas", description: "Un precio mensual fijo que conoces desde el inicio — sin facturación por hora que se dispara, sin cambios de alcance, sin facturas misteriosas. Empieza con una prueba gratis de 2 semanas antes de comprometerte." },
-      { title: "Entrega Rápida", description: "La mayoría de proyectos se lanzan en 2-4 semanas. Verás software funcionando rápidamente — no meses de planeación y reuniones." },
+      { title: "Entrega Rápida", description: "La mayoría de las configuraciones se lanzan en días, no semanas. Verás software funcionando rápidamente — no meses de planeación y reuniones." },
       { title: "Tú Eres Dueño de Todo", description: "Documentación completa, código limpio, sin dependencia de proveedor. Si nos separamos, te quedas con todo lo que construí." },
     ],
   },

--- a/src/pages/es/faq.astro
+++ b/src/pages/es/faq.astro
@@ -19,7 +19,7 @@ const content = {
         },
         {
           question: "¿Cuánto tiempo toma la implementación? ¿Necesitamos ingenieros?",
-          answer: "La mayoría de los proyectos se entregan en 2-6 semanas dependiendo del alcance. No necesitas ingenieros—solo un punto de contacto que hable inglés (líder de Ops/Ventas/TI) para coordinar. Yo manejo la construcción, integración, pruebas y entrega."
+          answer: "La mayoría de las configuraciones productizadas entran en vivo pocos días después de completar tu formulario; los desarrollos a la medida más complejos pueden tomar unas semanas. No necesitas ingenieros—solo un punto de contacto que hable inglés (líder de Ops/Ventas/TI) para coordinar. Yo manejo la construcción, integración, pruebas y entrega."
         },
         {
           question: "¿Qué está incluido en un proyecto?",

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -15,7 +15,7 @@ import FinalCTA from "../../components/home2/FinalCTA.astro";
 const locale = "es" as const;
 
 const title = "CushLabs.ai — Chatbots de IA y Automatización para Pymes";
-const description = "Chatbots de IA, agentes de voz y automatización de procesos para pequeñas empresas en EE.UU. y México. Bilingüe EN/ES. En vivo en 2–6 semanas.";
+const description = "Chatbots de IA, agentes de voz y automatización de procesos para pequeñas empresas en EE.UU. y México. Bilingüe EN/ES. En vivo en días, no semanas.";
 ---
 
 <BaseLayout title={title} description={description}>

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -16,7 +16,7 @@ const content = {
         },
         {
           question: "How long does implementation take? Do we need engineers?",
-          answer: "Most projects deliver in 2-6 weeks depending on scope. You don't need engineers—just an English-speaking point of contact (Ops/Sales/IT lead) to coordinate. I handle the build, integration, testing, and handoff."
+          answer: "Most productized setups go live within days of your completed intake form; more complex custom builds can take a few weeks. You don't need engineers—just an English-speaking point of contact (Ops/Sales/IT lead) to coordinate. I handle the build, integration, testing, and handoff."
         },
         {
           question: "What's included in a project?",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,11 +18,11 @@ const locale = (Astro.currentLocale === "es" ? "es" : "en") as "en" | "es";
 const meta = {
   en: {
     title: "CushLabs.ai — AI Chatbots & Automation for SMBs",
-    description: "AI chatbots, voice agents, and workflow automation built for small business teams in the US and Mexico. Bilingual EN/ES. Live in 2–6 weeks.",
+    description: "AI chatbots, voice agents, and workflow automation built for small business teams in the US and Mexico. Bilingual EN/ES. Live in days, not weeks.",
   },
   es: {
     title: "CushLabs.ai — Chatbots de IA y Automatización para Pequeñas Empresas",
-    description: "Chatbots de IA, agentes de voz y automatización de procesos para pequeñas empresas en EE.UU. y México. Bilingüe EN/ES. En vivo en 2–6 semanas.",
+    description: "Chatbots de IA, agentes de voz y automatización de procesos para pequeñas empresas en EE.UU. y México. Bilingüe EN/ES. En vivo en días, no semanas.",
   },
 };
 ---


### PR DESCRIPTION
Follow-up to #147 (Robert chose **A** — align the broader brand copy too). The productized-service speed now reads consistently site-wide; before, home/about/footer/meta said "2–6 weeks" while the service pages said "days."

## Changes
- **home2 Hero** subheadline + **HowItWorks** heading: "2–6 weeks" → "days, not weeks" (EN + ES)
- **Footer** taglines + **index.astro** meta descriptions (EN + ES): same
- **about.astro** + **es/about.astro** "Fast Delivery": "2-4 weeks" → "days, not weeks"
- **FAQ** (home2 section + standalone faq pages, EN + ES): rewritten to lead with *"within days of your intake form"* while keeping the honest caveat that complex custom builds can take a few weeks — no over-promise on bigger work

## Not touched
- Free-trial "2 weeks" copy (trial length).
- Dead `home/` folder (tech-debt #3, not rendered).

## Verification
- `npm run build` clean, meta-description gate PASS (108 pages) — the longer meta descriptions still fit 120–160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)