### PR TITLE
fix(messenger-assistant): accurate OAuth outcome copy (cancel is not an error)

### DIFF
--- a/src/pages/es/messenger-assistant/connected.astro
+++ b/src/pages/es/messenger-assistant/connected.astro
@@ -82,7 +82,7 @@ import Container from "../../../components/layout/Container.astro";
           </svg>
         </div>
 
-        <h2 class="font-display text-fluid-3xl font-bold text-gray-900 dark:text-white mb-4 leading-tight tracking-tight">
+        <h2 id="error-heading" class="font-display text-fluid-3xl font-bold text-gray-900 dark:text-white mb-4 leading-tight tracking-tight">
           La conexión no se completó
         </h2>
 
@@ -122,19 +122,66 @@ import Container from "../../../components/layout/Container.astro";
 
       loading.hidden = true;
 
+      // Códigos de error estables del callback OAuth del Worker
+      // (cushlabs-messenger-bot src/lib/oauth.ts). Cancelar a propósito no es
+      // un error y no debe leerse como uno. Códigos desconocidos usan el
+      // texto de Facebook.
+      const ERROR_COPY = {
+        user_cancelled: {
+          heading: "No se hizo ningún cambio",
+          message:
+            "Cancelaste la conexión con Facebook, así que no se modificó nada en tu página. Si querías conectarla, puedes intentarlo de nuevo cuando gustes.",
+          neutral: true,
+        },
+        session_expired: {
+          heading: "Tu enlace de conexión expiró",
+          message:
+            "Las sesiones seguras de conexión duran unos 10 minutos. Vuelve a empezar y completa los pasos de Facebook de una sola vez.",
+        },
+        no_pages: {
+          heading: "No encontramos una página para conectar",
+          message:
+            "Facebook no mostró ninguna página en la cuenta con la que iniciaste sesión — normalmente significa que esa cuenta no es administradora de la página del negocio. Inicia sesión con la cuenta administradora o revisa los roles de tu página en Meta Business Suite.",
+        },
+        missing_params: {
+          heading: "La conexión no se completó",
+          message:
+            "No recibimos los datos de autorización de Facebook. Intenta de nuevo desde el inicio.",
+        },
+        token_exchange_failed: {
+          heading: "La conexión no se completó",
+          message:
+            "Facebook aceptó la conexión, pero no pudimos terminar de configurarla de nuestro lado. Intenta de nuevo — si pasa dos veces, contáctanos y lo resolvemos.",
+        },
+        pages_fetch_failed: {
+          heading: "La conexión no se completó",
+          message:
+            "Facebook aceptó la conexión, pero no pudimos terminar de configurarla de nuestro lado. Intenta de nuevo — si pasa dos veces, contáctanos y lo resolvemos.",
+        },
+        server_misconfigured: {
+          heading: "Algo falló de nuestro lado",
+          message:
+            "Esto es cosa nuestra, no tuya. Contáctanos y lo arreglamos de inmediato.",
+        },
+      };
+
       if (!error && (pageName || pageId)) {
         if (pageName) {
           document.getElementById("page-name").textContent = pageName;
         }
         success.hidden = false;
       } else {
-        if (error) {
+        const copy = error && ERROR_COPY[error];
+        if (copy) {
+          document.getElementById("error-heading").textContent = copy.heading;
+          document.getElementById("error-message").textContent = copy.message;
+        } else if (error) {
           document.getElementById("error-message").textContent =
             'Facebook respondió: "' + error + '". Esto pasa a veces si se cancela la autorización o si la sesión expira.';
         }
         if (bgGlow) {
           bgGlow.classList.remove("bg-green-500/10");
-          bgGlow.classList.add("bg-amber-500/10");
+          bgGlow.classList.add(copy && copy.neutral ? "bg-gray-400/10" : "bg-amber-500/10");
         }
         errorEl.hidden = false;
       }

--- a/src/pages/messenger-assistant/connected.astro
+++ b/src/pages/messenger-assistant/connected.astro
@@ -86,7 +86,7 @@ import Container from "../../components/layout/Container.astro";
             </svg>
         </div>
 
-        <h2 class="font-display text-fluid-3xl font-bold text-gray-900 dark:text-white mb-4 leading-tight tracking-tight">
+        <h2 id="error-heading" class="font-display text-fluid-3xl font-bold text-gray-900 dark:text-white mb-4 leading-tight tracking-tight">
           Connection didn't complete
         </h2>
 
@@ -126,19 +126,66 @@ import Container from "../../components/layout/Container.astro";
 
       loading.hidden = true;
 
+      // Stable error codes set by the Worker's OAuth callback
+      // (cushlabs-messenger-bot src/lib/oauth.ts). A deliberate cancel is
+      // not a failure and must not read like one. Unknown codes fall back
+      // to quoting Facebook's text.
+      const ERROR_COPY = {
+        user_cancelled: {
+          heading: "No changes were made",
+          message:
+            "You canceled the Facebook connection, so nothing on your page was changed. If you meant to connect it, you can start again anytime.",
+          neutral: true,
+        },
+        session_expired: {
+          heading: "Your connection link expired",
+          message:
+            "Secure connection sessions are valid for about 10 minutes. Start again and complete the Facebook steps in one sitting.",
+        },
+        no_pages: {
+          heading: "We couldn't find a page to connect",
+          message:
+            "Facebook didn't list any pages for the account you logged in with — usually that account isn't an admin of the business page. Log in with the page admin account, or check your page roles in Meta Business Suite.",
+        },
+        missing_params: {
+          heading: "Connection didn't complete",
+          message:
+            "We didn't receive the authorization details from Facebook. Please try again from the start.",
+        },
+        token_exchange_failed: {
+          heading: "Connection didn't complete",
+          message:
+            "Facebook accepted the connection, but we couldn't finish setting it up on our side. Please try again — if it happens twice, contact us and we'll sort it out.",
+        },
+        pages_fetch_failed: {
+          heading: "Connection didn't complete",
+          message:
+            "Facebook accepted the connection, but we couldn't finish setting it up on our side. Please try again — if it happens twice, contact us and we'll sort it out.",
+        },
+        server_misconfigured: {
+          heading: "Something's wrong on our side",
+          message:
+            "This one is on us, not you. Please contact us and we'll fix it right away.",
+        },
+      };
+
       if (!error && (pageName || pageId)) {
         if (pageName) {
           document.getElementById("page-name").textContent = pageName;
         }
         success.hidden = false;
       } else {
-        if (error) {
+        const copy = error && ERROR_COPY[error];
+        if (copy) {
+          document.getElementById("error-heading").textContent = copy.heading;
+          document.getElementById("error-message").textContent = copy.message;
+        } else if (error) {
           document.getElementById("error-message").textContent =
             'Facebook returned: "' + error + '". This sometimes happens if you cancel the authorization or if the session times out.';
         }
         if (bgGlow) {
           bgGlow.classList.remove("bg-green-500/10");
-          bgGlow.classList.add("bg-amber-500/10");
+          bgGlow.classList.add(copy && copy.neutral ? "bg-gray-400/10" : "bg-amber-500/10");
         }
         errorEl.hidden = false;
       }


### PR DESCRIPTION
Clicking "Not Now" in the Facebook dialog showed an alarming
'Connection didn't complete / Facebook returned: "Permissions error"'
even though the user deliberately canceled and nothing went wrong.

The Worker callback now sends stable error codes; both EN and es-MX
pages map them to accurate copy:
- user_cancelled -> calm "No changes were made" (neutral glow, not amber)
- session_expired -> explains the 10-minute link window
- no_pages -> explains the page-admin requirement
- token_exchange_failed / pages_fetch_failed / server_misconfigured /
  missing_params -> honest our-side vs your-side framing
Unknown codes still fall back to quoting Facebook's text.

Pairs with cushlabs-messenger-bot PR (classifyFacebookOAuthError).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
