### PR TITLE
fix(messenger-assistant): demo cards match the real Messenger ice breakers

### DIFF
--- a/src/pages/es/messenger-assistant.astro
+++ b/src/pages/es/messenger-assistant.astro
@@ -29,15 +29,19 @@ const bestFor = [
 ];
 
 // Asistentes reales en producción, accesibles por enlaces m.me — el demo ES
-// producción. Las preguntas sugeridas reflejan los ice breakers de cada página.
+// producción. Las preguntas listadas son los ice breakers EXACTOS que cada
+// bot muestra en Messenger (versión en español — Facebook la muestra
+// automáticamente a quien tiene Facebook en español). Mantener en sync con
+// cushlabs-messenger-bot/scripts/set-messenger-profile.ts.
 const liveDemos = [
   {
     badge: "El producto, vendiéndose solo",
     name: "CushLabs",
     tagline: "Empresa de software — la página de la que estás leyendo",
-    copy: "El mismo asistente que describe esta página, trabajando en la propia página de Facebook de CushLabs. Conoce los servicios, maneja las preguntas de precio con honestidad y pasa la conversación a Robert cuando debe hacerlo.",
+    copy: "El mismo asistente que describe esta página, trabajando en la propia página de Facebook de CushLabs. Conoce los servicios, maneja las preguntas de precio con honestidad y pasa la conversación a Robert cuando debe hacerlo. Pregunta cómo se ve en acción y responde con un visual.",
     questions: [
       "¿Qué servicios ofrecen?",
+      "¿Cómo se ve en acción?",
       "¿Cuánto cuesta?",
       "Tengo un salón — ¿cómo me pueden ayudar?",
     ],
@@ -48,11 +52,12 @@ const liveDemos = [
     badge: "Cliente real en producción",
     name: "New York English",
     tagline: "Coaching de inglés ejecutivo — nuestro primer cliente en producción",
-    copy: "Atiende clientes reales en español e inglés desde abril. Pregunta precios, horarios o cómo reservar y mira cómo responde con los datos del propio negocio — luego pide hablar con una persona y observa el traspaso.",
+    copy: "Atiende clientes reales en español e inglés desde abril. Pregunta precios, horarios o cómo reservar y mira cómo responde con los datos del propio negocio — la pregunta de confianza incluso llega con una mini-lección en imagen.",
     questions: [
+      "¿Cómo me ayudan con la confianza al hablar inglés?",
       "¿Cuánto cuesta una sesión?",
       "¿Cuál es el horario?",
-      "¿Cómo agendo una clase?",
+      "¿Cómo agendo una consulta gratis?",
     ],
     href: "https://m.me/nyenglishteacher",
     cta: "Escribir a New York English",
@@ -148,7 +153,7 @@ const liveDemos = [
       </div>
 
       <p class="text-center text-sm text-gray-500 dark:text-gray-500 mt-8 max-w-2xl mx-auto">
-        Ambos abren Facebook Messenger. Escribe en español o inglés — cambian automáticamente. Pide "hablar con una persona" y mira cómo funciona el traspaso a un humano.
+        Ambos abren Facebook Messenger, donde estas mismas preguntas aparecen como sugerencias para tocar — en español automáticamente si tu Facebook está en español. Escribe en el idioma que quieras y el asistente te sigue. Pide "hablar con una persona" y mira cómo funciona el traspaso a un humano.
       </p>
     </Container>
   </section>

--- a/src/pages/messenger-assistant.astro
+++ b/src/pages/messenger-assistant.astro
@@ -29,17 +29,20 @@ const bestFor = [
 ];
 
 // Live production assistants reachable via m.me deep links — the demo IS
-// production. No sandbox to maintain; Messenger opens straight into the
-// real bot. Suggested questions mirror each page's ice breakers.
+// production. The questions listed are the EXACT tappable ice breakers each
+// bot shows in Messenger (English set — Facebook automatically shows the
+// Spanish set to visitors whose Facebook is in Spanish). Keep in sync with
+// cushlabs-messenger-bot/scripts/set-messenger-profile.ts.
 const liveDemos = [
   {
     badge: "The product, selling itself",
     name: "CushLabs",
     tagline: "Software company — the page you're reading right now",
-    copy: "The exact assistant this page describes, running on CushLabs' own Facebook page. It knows the services, handles pricing questions the honest way, and hands off to Robert when it should.",
+    copy: "The exact assistant this page describes, running on CushLabs' own Facebook page. It knows the services, handles pricing questions the honest way, and hands off to Robert when it should. Ask what it looks like in action and it replies with a visual.",
     questions: [
       "What services do you offer?",
-      "¿Cuánto cuesta?",
+      "What does it look like in action?",
+      "How much does it cost?",
       "I have a salon — how can you help me?",
     ],
     href: "https://m.me/cushlabs",
@@ -49,11 +52,12 @@ const liveDemos = [
     badge: "Live client deployment",
     name: "New York English",
     tagline: "Executive English coaching — our first production client",
-    copy: "Answering real customers in English and Spanish since April. Ask about pricing, hours, or booking and watch it answer from the business's own data — then ask for a human and watch the handoff.",
+    copy: "Answering real customers in English and Spanish since April. Ask about pricing, hours, or booking and watch it answer from the business's own data — the confidence question even comes back with a mini-lesson image.",
     questions: [
+      "How do you help with confidence when speaking English?",
       "How much does a session cost?",
-      "¿Cuál es el horario?",
-      "How do I book a class?",
+      "What are your hours?",
+      "How do I book a free consultation?",
     ],
     href: "https://m.me/nyenglishteacher",
     cta: "Message New York English",
@@ -149,7 +153,7 @@ const liveDemos = [
       </div>
 
       <p class="text-center text-sm text-gray-500 dark:text-gray-500 mt-8 max-w-2xl mx-auto">
-        Both open Facebook Messenger. Write in English or Spanish — they switch automatically. Say "talk to a human" and watch the human handoff work, too.
+        Both open Facebook Messenger, where these exact questions appear as tappable suggestions — in Spanish automatically if that's the language your Facebook is set to. Write in either language and the assistant follows you. Say "talk to a human" and watch the human handoff work, too.
       </p>
     </Container>
   </section>


### PR DESCRIPTION
The "Try asking" chips were a hand-mixed EN/ES sample that did not match
the real tappable bubbles. Now: EN page lists the exact 4-question
English set per bot, ES page the exact Spanish set (Facebook shows each
visitor the set matching their own Facebook language — footnote explains
this). Includes the new media-demo bubbles ("What does it look like in
action?" / confidence question) that reply with an image attached.
Keep in sync with cushlabs-messenger-bot/scripts/set-messenger-profile.ts.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
