### PR TITLE
feat(home): expose Messenger Assistant page from homepage + footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -14,6 +14,7 @@ const content = {
     services: {
       title: "Services",
       links: [
+        { label: "AI Messenger Assistant", href: "/messenger-assistant/" },
         { label: "Recepción Digital", href: "/pricing/" },
         { label: "AI Voice Agent", href: "/services/#voice-agent" },
         { label: "Pricing", href: "/pricing/" },
@@ -58,6 +59,7 @@ const content = {
     services: {
       title: "Servicios",
       links: [
+        { label: "Asistente de Messenger IA", href: "/es/messenger-assistant/" },
         { label: "Recepción Digital", href: "/es/precios/" },
         { label: "Agente de Voz IA", href: "/es/services/#voice-agent" },
         { label: "Precios", href: "/es/precios/" },

--- a/src/components/home2/SolutionOverview.astro
+++ b/src/components/home2/SolutionOverview.astro
@@ -7,7 +7,25 @@ interface Props {
 
 const { locale } = Astro.props;
 
-const content = {
+interface Pillar {
+  title: string;
+  desc: string;
+  icon: string;
+  href?: string;
+  linkLabel?: string;
+  badge?: string;
+}
+
+interface LocaleContent {
+  heading: string;
+  body: string;
+  pillars: Pillar[];
+  differentiator: string;
+  cta: string;
+  ctaLink: string;
+}
+
+const content: Record<'en' | 'es', LocaleContent> = {
   en: {
     heading: 'Three AI Systems. One Goal: Your Business Running Smarter.',
     body: "Unanswered Facebook messages, no idea where you stand on Google Maps, phones ringing while you're with a customer. These aren't small annoyances — they're revenue walking out the door. I fix all three with AI systems built around your specific business.",
@@ -15,7 +33,10 @@ const content = {
       {
         title: "AI Assistant on Facebook Messenger",
         desc: "Answers every customer message in seconds — prices, availability, appointments — in English and Spanish. 24/7. Trained on your products and your voice.",
-        icon: "M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"
+        icon: "M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z",
+        href: "/messenger-assistant/",
+        linkLabel: "See the live demo",
+        badge: "Live now"
       },
       {
         title: "Competitive Intelligence + Weekly Action Plan",
@@ -39,7 +60,10 @@ const content = {
       {
         title: "Asistente de IA en Facebook Messenger",
         desc: "Contesta cada mensaje de cliente en segundos — precios, disponibilidad, citas — en español e inglés. 24/7. Entrenado con tus productos y tu voz.",
-        icon: "M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"
+        icon: "M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z",
+        href: "/es/messenger-assistant/",
+        linkLabel: "Ver la demo en vivo",
+        badge: "En vivo"
       },
       {
         title: "Inteligencia Competitiva + Plan de Acción Semanal",
@@ -101,8 +125,27 @@ const t = content[locale];
             </div>
             <div>
               <p class="text-lg text-gray-700 dark:text-gray-300 leading-relaxed">
-                <strong class="font-semibold text-gray-900 dark:text-white block sm:inline">{pillar.title}</strong> {pillar.desc}
+                <strong class="font-semibold text-gray-900 dark:text-white block sm:inline">
+                  {pillar.title}
+                  {pillar.badge && (
+                    <span class="inline-flex items-center gap-1.5 ml-2 px-2 py-0.5 rounded-full bg-green-500/10 border border-green-500/20 text-green-600 dark:text-green-400 text-xs font-semibold align-middle whitespace-nowrap">
+                      <span class="w-1.5 h-1.5 rounded-full bg-green-500 animate-pulse"></span>
+                      {pillar.badge}
+                    </span>
+                  )}
+                </strong> {pillar.desc}
               </p>
+              {pillar.href && (
+                <a
+                  href={pillar.href}
+                  class="inline-flex items-center gap-1.5 mt-2 font-display text-sm font-semibold text-cush-orange hover:text-cush-orange/80 transition-colors group/link"
+                >
+                  {pillar.linkLabel}
+                  <svg class="w-4 h-4 transition-transform group-hover/link:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+                  </svg>
+                </a>
+              )}
             </div>
           </div>
         ))}


### PR DESCRIPTION
## Why

The `/messenger-assistant/` page — our best-converting asset, with live `m.me` demos and the "already live with a real client — in production now" social proof — was reachable from **exactly one place**: a small "Full service details →" text link inside the Messenger block on `/services/`. It was **not** linked from the homepage, header nav, or footer. The flagship, revenue-generating product was effectively orphaned 2–3 clicks deep.

## What changed

**1. `SolutionOverview` (homepage "Three AI Systems" section)**
- The Messenger pillar now links to `/messenger-assistant/` with a green **"Live now"** badge and a **"See the live demo →"** affordance.
- Only the Messenger pillar gets the link/badge — it's the only one of the three in production with a live demo. The asymmetry is intentional: it signals maturity and quietly elevates Messenger above Competitive Intelligence and Voice without demoting them.
- Contextual placement (peak-intent moment, right after the reader learns what it does) instead of a competing CTA in the hero — keeps the disciplined two-CTA hero intact.

**2. `Footer`**
- Added **"AI Messenger Assistant"** as the flagship first link in the Services column (`/messenger-assistant/`). Fixes a near-orphaned, high-value indexable page — a UX and SEO win.

## Parity & quality
- Full EN/ES parity. Spanish badge ("En vivo"), link label ("Ver la demo en vivo"), and footer label ("Asistente de Messenger IA") follow Mexican Professional Spanish — no Iberian markers.
- `astro check`: 0 errors. `tsc --noEmit`: clean. Full build: 110 pages, meta-description gate passed.
- Verified rendered links + badges present in both `dist/index.html` and `dist/es/index.html`.

Routes to the dedicated page (not directly to `m.me`) so visitors see the offer, proof, and discovery-call CTA before leaving the site — funnel, not leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)