### PR TITLE
feat(messenger-assistant): proof bullets in "Why CushLabs" section

### DIFF
--- a/src/pages/es/messenger-assistant.astro
+++ b/src/pages/es/messenger-assistant.astro
@@ -442,6 +442,28 @@ const themes = [
             Ya resolvimos los problemas difíciles: soporte bilingüe, respuestas precisas basadas en el contenido real de tu negocio, transferencia elegante a humanos, uptime 24/7 con monitoreo de errores. No nos pagas para que lo descubramos — ya lo descubrimos.
           </p>
         </div>
+
+        <div class="mt-10 grid sm:grid-cols-2 gap-x-8 gap-y-5 text-left">
+          {[
+            { title: "Hecho por nosotros, no por ti", body: "Lo construimos, entrenamos, conectamos y monitoreamos. Tú nunca tocas un panel." },
+            { title: "Respuestas desde tu contenido real", body: "Basadas en tus servicios, precios y voz — no inventa nada." },
+            { title: "Verdaderamente bilingüe (EN/ES)", body: "Cambia al idioma de tu cliente automáticamente — sin menús, sin configurar nada." },
+            { title: "Traspaso elegante a un humano", body: "Se hace a un lado cuando se necesita una persona y te resume con todo el contexto." },
+            { title: "Disponibilidad 24/7 monitoreada", body: "El monitoreo de errores y la confiabilidad corren por nuestra cuenta — no es algo más que administras." },
+            { title: "Activo en páginas reales de Facebook hoy", body: "No es un beta. Está en producción, atendiendo clientes reales ahora mismo." },
+          ].map(item => (
+            <div class="flex gap-3">
+              <svg class="w-5 h-5 text-green-500 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+              </svg>
+              <div>
+                <strong class="text-gray-900 dark:text-white font-semibold">{item.title}</strong>
+                <span class="block text-sm text-gray-600 dark:text-gray-400 leading-relaxed mt-0.5">{item.body}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+
         <div class="mt-10">
           <a
             href="/es/reservar/"

--- a/src/pages/messenger-assistant.astro
+++ b/src/pages/messenger-assistant.astro
@@ -442,6 +442,28 @@ const themes = [
             We've already solved the hard problems: bilingual support, accurate answers grounded in your actual business content, graceful handover to humans, 24/7 uptime with error monitoring. You don't pay for us to figure it out — we've already figured it out.
           </p>
         </div>
+
+        <div class="mt-10 grid sm:grid-cols-2 gap-x-8 gap-y-5 text-left">
+          {[
+            { title: "Done-for-you, not do-it-yourself", body: "We build, train, connect, and monitor it. You never touch a dashboard." },
+            { title: "Answers from your real content", body: "Grounded in your services, pricing, and voice — it won't make things up." },
+            { title: "Truly bilingual (EN/ES)", body: "Switches to your customer's language automatically — no menus, no settings." },
+            { title: "Graceful human handover", body: "It steps aside when a person is needed and briefs you with full context." },
+            { title: "24/7 monitored uptime", body: "Error monitoring and reliability are on us — not another thing you manage." },
+            { title: "Live on real Facebook pages today", body: "Not a beta. It's in production, handling real customers right now." },
+          ].map(item => (
+            <div class="flex gap-3">
+              <svg class="w-5 h-5 text-green-500 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+              </svg>
+              <div>
+                <strong class="text-gray-900 dark:text-white font-semibold">{item.title}</strong>
+                <span class="block text-sm text-gray-600 dark:text-gray-400 leading-relaxed mt-0.5">{item.body}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+
         <div class="mt-10">
           <a
             href="/consultation/"


### PR DESCRIPTION
Adds six scannable value bullets (EN + ES) to the **Why CushLabs over a generic chatbot platform** section on `/messenger-assistant/`, between the two narrative paragraphs and the "Start Your Free 2-Week Trial" CTA.

## Bullets (each grounded in a verified live capability — List 1)
- **Done-for-you, not do-it-yourself** — we build/train/connect/monitor; you never touch a dashboard
- **Answers from your real content** — RAG-grounded, won't invent
- **Truly bilingual (EN/ES)** — auto language switch
- **Graceful human handover** — Meta handover + full context
- **24/7 monitored uptime** — Sentry error monitoring is on us
- **Live on real Facebook pages today** — in production now, not a beta

## Why here
The dominant journey to this page is **Home → Solution Overview "See the live demo" card → here**. Visitors arrive knowing "24/7 bilingual Messenger assistant" and are looking for proof + specifics. This section is the closer; the bullets make the proof scannable right above the CTA. Full EN + ES parity (Mexican Professional Spanish).

## Verification
- `npm run build` passes; meta-description-gate green (108 pages, 0 violations)
- `projects.generated.json` kept out of the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)