### PR TITLE
fix(pricing): truthful Basic-tier lead-alert copy (no premature WhatsApp claim)

### DIFF
--- a/src/components/pricing/PricingSection.astro
+++ b/src/components/pricing/PricingSection.astro
@@ -38,7 +38,7 @@ const copy = {
         features: [
           "AI assistant on Facebook Messenger (24/7)",
           "Google review management — with your approval",
-          "Owner lead alerts",
+          "Lead capture + owner notifications (instant WhatsApp alerts on the way)",
           "Fully managed: setup, training, ongoing support",
         ],
         cta: "Get started",
@@ -103,7 +103,7 @@ const copy = {
         features: [
           "Asistente con IA en Facebook Messenger (24/7)",
           "Gestión de reseñas de Google — con tu aprobación",
-          "Avisos de clientes listos para comprar",
+          "Captura de leads + avisos al dueño (alertas por WhatsApp muy pronto)",
           "Todo gestionado: configuración, entrenamiento y soporte",
         ],
         cta: "Empieza",


### PR DESCRIPTION
The Basic ($1,990) pricing card advertised **"Owner lead alerts"** — implying a live proactive alert, specifically the Meta **WhatsApp** ping Mexican SMB clients expect. That channel is **blocked on the in-progress Meta App Review** (submitted 2026-07-06), so the alert isn't deliverable yet. Verified against the bot's code (`cushlabs-messenger-bot/src/lib/alert.ts` is built but dormant; WhatsApp path is List-2 roadmap).

Reworded to keep the benefit and **pre-sell** the WhatsApp feature without over-claiming it as live:
- **EN:** "Lead capture + owner notifications (instant WhatsApp alerts on the way)"
- **ES:** "Captura de leads + avisos al dueño (alertas por WhatsApp muy pronto)"

es-MX audited clean. `astro check` 0 errors; build 110 pages, meta-gate pass.

Context + full reconciliation: `docs/strategy/ADVERTISED-COMMITMENTS.md` §11.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)