### PR TITLE
fix: external-audit items — project count, ES portfolio localization, pronoun voice

### DIFF
--- a/src/components/home2/SocialProof.astro
+++ b/src/components/home2/SocialProof.astro
@@ -38,7 +38,7 @@ const content = {
       label: "What You Can Verify",
       stats: [
         { value: "AI-native", label: "Enterprise IT roots" },
-        { value: "30+", label: "Projects Shipped" },
+        { value: "35+", label: "Projects Shipped" },
         { value: "2–6 wks", label: "Time to Live" },
         { value: "100%", label: "Bilingual EN/ES" },
       ],
@@ -74,7 +74,7 @@ const content = {
       label: "Lo Que Puedes Verificar",
       stats: [
         { value: "Nativo en IA", label: "Raíces en TI empresarial" },
-        { value: "30+", label: "Proyectos entregados" },
+        { value: "35+", label: "Proyectos entregados" },
         { value: "2–6 sem", label: "Tiempo al lanzamiento" },
         { value: "100%", label: "Bilingüe EN/ES" },
       ],

--- a/src/pages/es/messenger-assistant.astro
+++ b/src/pages/es/messenger-assistant.astro
@@ -51,7 +51,7 @@ const liveDemos = [
   {
     badge: "Cliente real en producción",
     name: "New York English",
-    tagline: "Coaching de inglés ejecutivo — nuestro primer cliente en producción",
+    tagline: "Coaching de inglés ejecutivo — mi primer cliente en producción",
     copy: "Atiende clientes reales en español e inglés desde abril. Pregunta precios, horarios o cómo reservar y mira cómo responde con los datos del propio negocio — la pregunta de confianza incluso llega con una mini-lección en imagen.",
     questions: [
       "¿Cómo me ayudan con la confianza al hablar inglés?",
@@ -108,7 +108,7 @@ const themes = [
   },
   {
     title: "Está construido como un producto de verdad",
-    promise: "No es un chatbot de fin de semana — es un sistema de producción monitoreado y reforzado que operamos por ti.",
+    promise: "No es un chatbot de fin de semana — es un sistema de producción monitoreado y reforzado que opero por ti.",
     icon: "M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z",
     points: [
       "Le avisa a cada nuevo cliente desde el inicio que está hablando con una IA",
@@ -201,7 +201,7 @@ const themes = [
           Demos en vivo — sin registro, sin simulaciones
         </div>
         <h2 class="font-display font-bold text-3xl md:text-4xl text-gray-900 dark:text-white mb-4 leading-tight tracking-tight">
-          No confíes en nuestra palabra — habla con uno ahora mismo
+          No confíes en mi palabra — habla con uno ahora mismo
         </h2>
         <p class="text-lg text-gray-600 dark:text-gray-400 leading-relaxed">
           No son demos con guion. Son los asistentes reales en producción, contestando hoy en páginas de Facebook reales. Abre uno en Messenger y pregúntale lo que quieras.
@@ -277,7 +277,7 @@ const themes = [
               <div class="text-gray-900 dark:text-gray-200 bg-cush-orange/5 border-l-4 border-cush-orange pl-6 py-4 rounded-r-lg space-y-3">
                 <p>Un asistente de IA a la medida que vive en tu Facebook Messenger y realmente conoce tu negocio. Un asistente entrenado con tus servicios, tus precios, tu voz — que contesta como lo harías tú, a cualquier hora, en el idioma que hablan tus clientes.</p>
                 <p>Recomienda el producto correcto. Agenda la cita. Contesta las preguntas frecuentes cien veces al día sin quejarse. Y cuando se necesita un humano de verdad, te pasa la conversación con todo el contexto ya levantado.</p>
-                <p>Ya lo desplegamos para un cliente real. Está activo, en producción, manejando consultas ahora mismo mientras el dueño del negocio duerme.</p>
+                <p>Ya lo desplegué para un cliente real. Está activo, en producción, manejando consultas ahora mismo mientras el dueño del negocio duerme.</p>
               </div>
             </div>
           </div>
@@ -436,20 +436,20 @@ const themes = [
         </h2>
         <div class="space-y-6 text-lg text-gray-600 dark:text-gray-400 leading-relaxed text-left">
           <p>
-            Las plataformas genéricas te dan un constructor. CushLabs te da un asistente desplegado y listo para producción — construido, configurado, probado y monitoreado. Nosotros manejamos la configuración, la ingesta de contenido, la integración con Facebook y la confiabilidad continua. Tú obtienes los resultados.
+            Las plataformas genéricas te dan un constructor. CushLabs te da un asistente desplegado y listo para producción — construido, configurado, probado y monitoreado. Yo manejo la configuración, la ingesta de contenido, la integración con Facebook y la confiabilidad continua. Tú obtienes los resultados.
           </p>
           <p>
-            Ya resolvimos los problemas difíciles: soporte bilingüe, respuestas precisas basadas en el contenido real de tu negocio, transferencia elegante a humanos, uptime 24/7 con monitoreo de errores. No nos pagas para que lo descubramos — ya lo descubrimos.
+            Ya resolví los problemas difíciles: soporte bilingüe, respuestas precisas basadas en el contenido real de tu negocio, transferencia elegante a humanos, uptime 24/7 con monitoreo de errores. No me pagas para que lo descubra — ya lo descubrí.
           </p>
         </div>
 
         <div class="mt-10 grid sm:grid-cols-2 gap-x-8 gap-y-5 text-left">
           {[
-            { title: "Hecho por nosotros, no por ti", body: "Lo construimos, entrenamos, conectamos y monitoreamos. Tú nunca tocas un panel." },
+            { title: "Hecho por mí, no por ti", body: "Lo construyo, entreno, conecto y monitoreo. Tú nunca tocas un panel." },
             { title: "Respuestas desde tu contenido real", body: "Basadas en tus servicios, precios y voz — no inventa nada." },
             { title: "Verdaderamente bilingüe (EN/ES)", body: "Cambia al idioma de tu cliente automáticamente — sin menús, sin configurar nada." },
             { title: "Traspaso elegante a un humano", body: "Se hace a un lado cuando se necesita una persona y te resume con todo el contexto." },
-            { title: "Disponibilidad 24/7 monitoreada", body: "El monitoreo de errores y la confiabilidad corren por nuestra cuenta — no es algo más que administras." },
+            { title: "Disponibilidad 24/7 monitoreada", body: "El monitoreo de errores y la confiabilidad corren por mi cuenta — no es algo más que administras." },
             { title: "Activo en páginas reales de Facebook hoy", body: "No es un beta. Está en producción, atendiendo clientes reales ahora mismo." },
           ].map(item => (
             <div class="flex gap-3">
@@ -492,13 +492,13 @@ const themes = [
         "@type": "HowToStep",
         "position": 1,
         "name": "Agenda una llamada de descubrimiento gratuita",
-        "text": "Dedicamos 20 minutos a conocer tu negocio: las preguntas más frecuentes de tus clientes, tus servicios y precios, y el tono que quieres que use el asistente. Sin compromiso."
+        "text": "Dedico 20 minutos a conocer tu negocio: las preguntas más frecuentes de tus clientes, tus servicios y precios, y el tono que quieres que use el asistente. Sin compromiso."
       },
       {
         "@type": "HowToStep",
         "position": 2,
-        "name": "Construimos y entrenamos tu asistente de IA",
-        "text": "Tu asistente de Messenger se entrena con el conocimiento específico de tu negocio y se conecta a tu página de Facebook. Nos encargamos de toda la configuración técnica. Tiempo de entrega típico: 5–7 días hábiles."
+        "name": "Construyo y entreno tu asistente de IA",
+        "text": "Tu asistente de Messenger se entrena con el conocimiento específico de tu negocio y se conecta a tu página de Facebook. Me encargo de toda la configuración técnica. Tiempo de entrega típico: 5–7 días hábiles."
       },
       {
         "@type": "HowToStep",

--- a/src/pages/es/portfolio.astro
+++ b/src/pages/es/portfolio.astro
@@ -9,6 +9,22 @@ import { getEsCardCopy } from "../../data/projectCardsEs";
 const projects = projectsData.projects.filter(p => p.priority < 99);
 const allCategories = [...new Set(projects.flatMap(p => p.categories).filter(Boolean))].sort();
 
+// Spanish display labels for the (English-keyed) portfolio categories. The
+// filter logic still keys off the English category string (data-categories /
+// data-filter), so only the visible label is localized. Falls back to the raw
+// English category if a new one appears before it's translated here.
+const categoryEs: Record<string, string> = {
+  "AI Automation": "Automatización con IA",
+  "Client Work": "Proyectos de Cliente",
+  "Creative": "Creativo",
+  "Developer Tools": "Herramientas de Desarrollo",
+  "Games": "Juegos",
+  "Marketing": "Marketing",
+  "Templates": "Plantillas",
+  "Tools": "Herramientas",
+};
+const catEs = (cat: string): string => categoryEs[cat] ?? cat;
+
 function getThumbnail(project: typeof projects[number]): string {
   const override = getProjectDetailOverride(project.name);
   if (override?.thumbnail) return override.thumbnail;
@@ -118,7 +134,7 @@ const t = {
         <button class="filter-btn active px-4 py-2 rounded-lg border border-cush-orange bg-cush-orange/10 font-display text-sm font-semibold text-cush-orange transition-all" data-filter="featured">{t.filters.featured}</button>
         <button class="filter-btn px-4 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-transparent font-display text-sm font-semibold text-gray-600 dark:text-gray-400 hover:border-cush-orange hover:text-cush-orange transition-all" data-filter="all">{t.filters.all}</button>
         {allCategories.map(cat => (
-          <button class="filter-btn px-4 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-transparent font-display text-sm font-semibold text-gray-600 dark:text-gray-400 hover:border-cush-orange hover:text-cush-orange transition-all" data-filter={`cat:${cat}`}>{cat}</button>
+          <button class="filter-btn px-4 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-transparent font-display text-sm font-semibold text-gray-600 dark:text-gray-400 hover:border-cush-orange hover:text-cush-orange transition-all" data-filter={`cat:${cat}`}>{catEs(cat)}</button>
         ))}
       </div>
 
@@ -136,7 +152,7 @@ const t = {
           const category = project.categories[0] || null;
           const techBadges = project.stack.slice(0, 4);
           // Index both the Spanish display copy and the original English so search works in either language.
-          const searchText = [displayTitle, project.title, tagline, project.tagline, category, ...project.stack, ...project.tags].filter(Boolean).join(" ").toLowerCase();
+          const searchText = [displayTitle, project.title, tagline, project.tagline, category, category ? catEs(category) : null, ...project.stack, ...project.tags].filter(Boolean).join(" ").toLowerCase();
 
           return (
             <article
@@ -163,7 +179,7 @@ const t = {
               <div class="flex flex-col flex-1 p-5">
                 <div class="flex items-center gap-2 mb-3 flex-wrap">
                   {category && (
-                    <span class="px-2 py-0.5 bg-cush-orange/10 text-cush-orange text-xs font-display font-semibold rounded">{category}</span>
+                    <span class="px-2 py-0.5 bg-cush-orange/10 text-cush-orange text-xs font-display font-semibold rounded">{catEs(category)}</span>
                   )}
                   {project.status && (
                     <span class:list={[
@@ -172,7 +188,7 @@ const t = {
                       project.status === "Demo" ? "bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400" :
                       "bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400"
                     ]}>
-                      {project.status === "Production" ? "Produccion" :
+                      {project.status === "Production" ? "Producción" :
                        project.status === "Demo" ? "Demo" :
                        project.status === "Archived" ? "Archivado" :
                        project.status}

--- a/src/pages/es/projects/[slug].astro
+++ b/src/pages/es/projects/[slug].astro
@@ -178,7 +178,9 @@ const relatedProjects = scored.slice(0, 3).map(s => s.project);
             {
               project.status && (
                 <span class="px-2 py-1 text-xs font-display font-semibold rounded uppercase tracking-wide bg-canvas/40 border border-border text-muted">
-                  {project.status}
+                  {project.status === "Production" ? "Producción" :
+                   project.status === "Archived" ? "Archivado" :
+                   project.status}
                 </span>
               )
             }

--- a/src/pages/messenger-assistant.astro
+++ b/src/pages/messenger-assistant.astro
@@ -51,7 +51,7 @@ const liveDemos = [
   {
     badge: "Live client deployment",
     name: "New York English",
-    tagline: "Executive English coaching — our first production client",
+    tagline: "Executive English coaching — my first production client",
     copy: "Answering real customers in English and Spanish since April. Ask about pricing, hours, or booking and watch it answer from the business's own data — the confidence question even comes back with a mini-lesson image.",
     questions: [
       "How do you help with confidence when speaking English?",
@@ -108,7 +108,7 @@ const themes = [
   },
   {
     title: "It's built like a real product",
-    promise: "Not a weekend chatbot — a monitored, hardened, production system we run for you.",
+    promise: "Not a weekend chatbot — a monitored, hardened, production system I run for you.",
     icon: "M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z",
     points: [
       "Tells every new customer up front that they're chatting with an AI",
@@ -201,7 +201,7 @@ const themes = [
           Live demos — no signup, no sandbox
         </div>
         <h2 class="font-display font-bold text-3xl md:text-4xl text-gray-900 dark:text-white mb-4 leading-tight tracking-tight">
-          Don't take our word for it — talk to one right now
+          Don't take my word for it — talk to one right now
         </h2>
         <p class="text-lg text-gray-600 dark:text-gray-400 leading-relaxed">
           These aren't scripted demos. They're the real production assistants, answering on real Facebook pages today. Open one in Messenger and ask it anything.
@@ -277,7 +277,7 @@ const themes = [
               <div class="text-gray-900 dark:text-gray-200 bg-cush-orange/5 border-l-4 border-cush-orange pl-6 py-4 rounded-r-lg space-y-3">
                 <p>A custom AI assistant that lives in your Facebook Messenger and actually knows your business. An assistant trained on your services, your pricing, your voice — that answers the way you would, at any hour, in any language your customers speak.</p>
                 <p>It recommends the right product. It books the appointment. It handles the FAQ a hundred times a day without complaining. And when a real human is needed, it hands the conversation off to you with the context already gathered.</p>
-                <p>We've already deployed this for a real client. It's live, it's in production, and it's handling inquiries right now while the business owner sleeps.</p>
+                <p>I've already deployed this for a real client. It's live, it's in production, and it's handling inquiries right now while the business owner sleeps.</p>
               </div>
             </div>
           </div>
@@ -436,20 +436,20 @@ const themes = [
         </h2>
         <div class="space-y-6 text-lg text-gray-600 dark:text-gray-400 leading-relaxed text-left">
           <p>
-            Generic platforms give you a builder. CushLabs gives you a deployed, production-ready assistant — built, configured, tested, and monitored. We handle the setup, the content ingestion, the Facebook integration, and the ongoing reliability. You get the results.
+            Generic platforms give you a builder. CushLabs gives you a deployed, production-ready assistant — built, configured, tested, and monitored. I handle the setup, the content ingestion, the Facebook integration, and the ongoing reliability. You get the results.
           </p>
           <p>
-            We've already solved the hard problems: bilingual support, accurate answers grounded in your actual business content, graceful handover to humans, 24/7 uptime with error monitoring. You don't pay for us to figure it out — we've already figured it out.
+            I've already solved the hard problems: bilingual support, accurate answers grounded in your actual business content, graceful handover to humans, 24/7 uptime with error monitoring. You don't pay for me to figure it out — I've already figured it out.
           </p>
         </div>
 
         <div class="mt-10 grid sm:grid-cols-2 gap-x-8 gap-y-5 text-left">
           {[
-            { title: "Done-for-you, not do-it-yourself", body: "We build, train, connect, and monitor it. You never touch a dashboard." },
+            { title: "Done-for-you, not do-it-yourself", body: "I build, train, connect, and monitor it. You never touch a dashboard." },
             { title: "Answers from your real content", body: "Grounded in your services, pricing, and voice — it won't make things up." },
             { title: "Truly bilingual (EN/ES)", body: "Switches to your customer's language automatically — no menus, no settings." },
             { title: "Graceful human handover", body: "It steps aside when a person is needed and briefs you with full context." },
-            { title: "24/7 monitored uptime", body: "Error monitoring and reliability are on us — not another thing you manage." },
+            { title: "24/7 monitored uptime", body: "Error monitoring and reliability are on me — not another thing you manage." },
             { title: "Live on real Facebook pages today", body: "Not a beta. It's in production, handling real customers right now." },
           ].map(item => (
             <div class="flex gap-3">
@@ -492,13 +492,13 @@ const themes = [
         "@type": "HowToStep",
         "position": 1,
         "name": "Schedule a free discovery call",
-        "text": "We spend 20 minutes learning your business: your most common customer questions, your services and pricing, and the tone you want the AI to use. No commitment required."
+        "text": "I spend 20 minutes learning your business: your most common customer questions, your services and pricing, and the tone you want the AI to use. No commitment required."
       },
       {
         "@type": "HowToStep",
         "position": 2,
-        "name": "We build and train your AI assistant",
-        "text": "Your Messenger AI is trained on your specific business knowledge and connected to your Facebook page. We handle all the technical setup. Typical turnaround: 5–7 business days."
+        "name": "I build and train your AI assistant",
+        "text": "Your Messenger AI is trained on your specific business knowledge and connected to your Facebook page. I handle all the technical setup. Typical turnaround: 5–7 business days."
       },
       {
         "@type": "HowToStep",

--- a/src/pages/portfolio.astro
+++ b/src/pages/portfolio.astro
@@ -320,7 +320,7 @@ const t = content[locale];
                         "bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400"
                       ]}
                     >
-                      {project.status === "Production" ? (locale === "es" ? "Produccion" : "Production") :
+                      {project.status === "Production" ? (locale === "es" ? "Producción" : "Production") :
                        project.status === "Demo" ? "Demo" :
                        project.status === "Archived" ? (locale === "es" ? "Archivado" : "Archived") :
                        project.status}


### PR DESCRIPTION
Acts on a thorough external site audit. Each item was verified against the code before fixing.

## Fixes

**1. Project-count inconsistency (trust)**
Home hero says "35+ projects shipped" but the "What You Can Verify" stat block said "30+" — two numbers for one claim on a page built on "don't take my word for it, verify it." 36 projects exist, so standardized the stat block to **35+** (EN + ES).

**2. ES portfolio localization bugs**
- Category filter pills + card badges were rendering **raw English** data strings on the Spanish page → added a `categoryEs` display map (Automatización con IA, Proyectos de Cliente, Juegos, Plantillas, Herramientas, etc.). Filter logic still keys off the English string, so only the visible label changed.
- **"Produccion" → "Producción"** accent fix (ES portfolio card badge + the dead es-branch in `portfolio.astro`).
- Localized the **status badge on the ES project-detail page** (was showing "Production" in English).

**3. Pronoun voice consistency**
The Messenger page slid between "we" and "I" while the rest of the site is uniformly solo-founder **"I"** — which is the deliberate positioning ("you work directly with me, not an account exec"). Standardized to "I" across the Messenger body, the "Why CushLabs" block, and the HowTo schema (EN + ES). Left the two **mocked generic-autoresponder quotes** ("We'll get back to you shortly") as-is — those are supposed to be plural.

## Not included (needs your call)
- **Hiding hobby portfolio categories** (Games / Templates / Tools) for the B2B audience — that's hiding your own work, a positioning decision. Flagged separately.
- Labeling the EN Services page example figures explicitly as USD — minor, can fold in later.

## Verification
- `npm run build` passes; meta-description-gate green (108 pages, 0 violations)
- `projects.generated.json` kept out of the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)