### PR TITLE
feat(demos): surface /demos/ on homepage hero + product page

### DIFF
--- a/src/components/home2/Hero.astro
+++ b/src/components/home2/Hero.astro
@@ -21,6 +21,7 @@ const content = {
     ],
     ctaPrimary: 'Book a Free 30-min Call',
     ctaSecondary: 'Try the Live Chatbot',
+    ctaDemo: 'See a demo for your industry →',
     scrollHint: 'Scroll to explore',
   },
   es: {
@@ -36,6 +37,7 @@ const content = {
     ],
     ctaPrimary: 'Agendar Llamada Gratis — 30 min',
     ctaSecondary: 'Probar el Chatbot en Vivo',
+    ctaDemo: 'Ve un demo para tu industria →',
     scrollHint: 'Explorar',
   },
 };
@@ -119,6 +121,14 @@ const t = content[locale];
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
           </svg>
         </button>
+      </div>
+
+      <!-- Tertiary link: interactive industry demo gallery (/demos/) -->
+      <div class="mt-5 animate-fade-in-up" style="animation-delay: 0.4s;">
+        <a
+          href={locale === 'es' ? '/es/demos/' : '/demos/'}
+          class="font-display text-sm font-medium text-gray-500 dark:text-gray-400 underline underline-offset-4 decoration-gray-300 hover:decoration-cush-orange hover:text-gray-900 dark:hover:text-white transition-all"
+        >{t.ctaDemo}</a>
       </div>
     </div>
   </Container>

--- a/src/pages/es/messenger-assistant.astro
+++ b/src/pages/es/messenger-assistant.astro
@@ -234,6 +234,19 @@ const themes = [
       <p class="text-center text-sm text-gray-500 dark:text-gray-500 mt-8 max-w-2xl mx-auto">
         Ambos abren Facebook Messenger, donde estas mismas preguntas aparecen como sugerencias para tocar — en español automáticamente si tu Facebook está en español. Escribe en el idioma que quieras y el asistente te sigue. Pide "hablar con una persona" y mira cómo funciona el traspaso a un humano.
       </p>
+
+      <!-- Puente a la galería interactiva de demos por industria (/es/demos/) -->
+      <div class="text-center mt-10">
+        <a
+          href="/es/demos/"
+          class="group inline-flex items-center gap-2 px-6 py-3 rounded-lg border-2 border-gray-300 dark:border-gray-700 text-gray-800 dark:text-gray-200 font-display font-semibold hover:border-cush-orange hover:text-cush-orange dark:hover:border-cush-orange dark:hover:text-cush-orange transition-all duration-300"
+        >
+          Ve un demo para tu industria
+          <svg class="w-5 h-5 transition-transform group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+          </svg>
+        </a>
+      </div>
     </Container>
   </section>
 

--- a/src/pages/messenger-assistant.astro
+++ b/src/pages/messenger-assistant.astro
@@ -234,6 +234,19 @@ const themes = [
       <p class="text-center text-sm text-gray-500 dark:text-gray-500 mt-8 max-w-2xl mx-auto">
         Both open Facebook Messenger, where these exact questions appear as tappable suggestions — in Spanish automatically if that's the language your Facebook is set to. Write in either language and the assistant follows you. Say "talk to a human" and watch the human handoff work, too.
       </p>
+
+      <!-- Bridge to the interactive industry demo gallery (/demos/) -->
+      <div class="text-center mt-10">
+        <a
+          href="/demos/"
+          class="group inline-flex items-center gap-2 px-6 py-3 rounded-lg border-2 border-gray-300 dark:border-gray-700 text-gray-800 dark:text-gray-200 font-display font-semibold hover:border-cush-orange hover:text-cush-orange dark:hover:border-cush-orange dark:hover:text-cush-orange transition-all duration-300"
+        >
+          See a demo for your industry
+          <svg class="w-5 h-5 transition-transform group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+          </svg>
+        </a>
+      </div>
     </Container>
   </section>
 


### PR DESCRIPTION
Puts the industry demo gallery where visitors actually are:

- **Homepage hero** — subtle tertiary link "See a demo for your industry →" / "Ve un demo para tu industria →" under the CTAs (both locales).
- **Messenger-assistant page** — contextual CTA closing the "Live demos" section (message a real bot → browse by your industry). EN → `/demos/`, ES → `/es/demos/`.

Adds to the header-nav + footer links already shipped. Local build: 113 pages, meta-description gate PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)