### PR TITLE
fix(demos): nudge sample dress price off $1,990 plan-tier collision

### DIFF
--- a/src/components/demos/IndustryMessengerDemo.astro
+++ b/src/components/demos/IndustryMessengerDemo.astro
@@ -74,7 +74,7 @@ const CATALOG = [
       title: "She messages at 10 p.m. You still make the sale.",
       desc: "70% of questions are the same: sizes, prices, availability. Your assistant answers them instantly and shows the pieces to reserve — so you don't lose the sale by missing a message.",
       cards: [
-        { t: 'Long "Marbella" dress', tag: "New", p: "$1,890", b: "Reserve" },
+        { t: 'Long "Marbella" dress', tag: "New", p: "$2,150", b: "Reserve" },
         { t: "Linen set", p: "$1,240", b: "Reserve" },
         { t: "Fitted blazer", p: "$980", b: "See more" },
       ],
@@ -87,7 +87,7 @@ const CATALOG = [
       title: "La clienta pregunta a las 10 de la noche. Tú vendes igual.",
       desc: "El 70% de las dudas son las mismas: tallas, precios, disponibilidad. Tu asistente las contesta al instante y muestra las prendas para apartar, sin que pierdas la venta por no ver el mensaje a tiempo.",
       cards: [
-        { t: 'Vestido largo "Marbella"', tag: "Nuevo", p: "$1,890", b: "Apartar" },
+        { t: 'Vestido largo "Marbella"', tag: "Nuevo", p: "$2,150", b: "Apartar" },
         { t: "Conjunto de lino", p: "$1,240", b: "Apartar" },
         { t: "Blazer entallado", p: "$980", b: "Ver más" },
       ],


### PR DESCRIPTION
## What

The demo boutique's sample dress was priced `$1,890` — one digit off the **$1,990 MXN Basic plan**. The founder momentarily read the demo product price as our subscription price; a cold prospect would too. Moved it to `$2,150` in both EN and ES so no illustrative demo product price sits near a plan tier ($1,990 / $3,490 / $5,490).

## Why it's safe

Pure copy value change, two lines, no logic touched. All other demo prices are already clear of plan tiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)