### PR TITLE
feat(blog): bilingual hybrid blog engine (MVP)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,4 +1,7 @@
 import { defineConfig } from "astro/config";
+import fs from "node:fs";
+import path from "node:path";
+import matter from "gray-matter";
 import tailwindcss from "@tailwindcss/vite";
 import sitemap from "@astrojs/sitemap";
 import sentry from "@sentry/astro";
@@ -22,10 +25,36 @@ for (const [enPath, esSlug] of Object.entries(routePairs)) {
   hreflangMap.set(esUrl, enUrl);
 }
 
+// Blog cornerstone (bilingual) pairs — derived from EN post frontmatter, the
+// single source of truth (ES posts link back via translations.en). Only posts
+// with a reciprocal translations.es become a pair; single-language posts are
+// intentionally absent, so the sitemap emits self-referencing hreflang for them
+// (the hybrid model — docs/strategy/BLOG-HYBRID-ARCHITECTURE-PROPOSAL.md).
+const blogEnDir = path.resolve("./src/content/blog/en");
+if (fs.existsSync(blogEnDir)) {
+  for (const file of fs.readdirSync(blogEnDir)) {
+    if (!file.endsWith(".md")) continue;
+    const { data } = matter(
+      fs.readFileSync(path.join(blogEnDir, file), "utf-8"),
+    );
+    const esTwin = data?.translations?.es;
+    if (!esTwin) continue;
+    const esSlug = esTwin.startsWith("/")
+      ? esTwin.split("/").filter(Boolean).pop()
+      : esTwin;
+    const enUrl = `${SITE}/blog/${file.replace(/\.md$/, "")}/`;
+    const esUrl = `${SITE}/es/blog/${esSlug}/`;
+    hreflangMap.set(enUrl, esUrl);
+    hreflangMap.set(esUrl, enUrl);
+  }
+}
+
 // ── Priority rules by URL pattern ───────────────────────────────────
 function getPriority(url) {
   const path = url.replace(SITE, "");
   if (path === "/" || path === "/es/" || path === "/es") return 1.0;
+  if (/^\/(es\/)?blog\/?$/.test(path)) return 0.7;
+  if (/^\/(es\/)?blog\//.test(path)) return 0.6;
   if (/^\/(es\/)?services/.test(path)) return 0.9;
   if (/^\/(es\/)?portfolio/.test(path)) return 0.8;
   if (/^\/(es\/)?projects\//.test(path)) return 0.7;
@@ -41,6 +70,7 @@ function getPriority(url) {
 function getChangefreq(url) {
   const path = url.replace(SITE, "");
   if (path === "/" || path === "/es/" || path === "/es") return "weekly";
+  if (/^\/(es\/)?blog/.test(path)) return "weekly";
   if (/^\/(es\/)?(terms|privacy)/.test(path)) return "yearly";
   return "monthly";
 }

--- a/docs/strategy/BLOG-HYBRID-ARCHITECTURE-PROPOSAL.md
+++ b/docs/strategy/BLOG-HYBRID-ARCHITECTURE-PROPOSAL.md
@@ -1,9 +1,11 @@
 # CushLabs Bilingual Blog — Hybrid Content Architecture (Proposal)
 
-**Status:** Proposal — no code yet. React to the shape before anything is built.
+**Status:** Decisions locked 2026-07-07 (see §8) — Phase-1 MVP build in progress.
 **Created:** 2026-07-07
-**Reference implementation:** `C:\Users\Robert Cushman\Projects\ny-eng\docs\BLOG-SYSTEM-PLAYBOOK.md` (the NY English blog — the proven system we port from)
-**Governs:** a re-introduced blog on cushlabs.ai (the blog was removed pre-launch for "no content strategy" — this doc _is_ the strategy).
+
+> **Decisions locked (2026-07-07):** Primary goal = **sales enablement + repurposing** (SEO is a bonus). Primary track = **Spanish/MX first** (EN lighter). Cadence = **aggressive, 1–2 posts/week** — held to a hard per-piece quality bar because posts are client-facing (AI does research/outline/draft/translation; a real CushLabs result or opinion goes in every post). Author = **Robert Cushman, named** (Person schema). Defaults accepted: `/blog/` + `/es/blog/` with Spanish slugs, pure Markdown for v1, add Bing + RSS.
+> **Reference implementation:** `C:\Users\Robert Cushman\Projects\ny-eng\docs\BLOG-SYSTEM-PLAYBOOK.md` (the NY English blog — the proven system we port from)
+> **Governs:** a re-introduced blog on cushlabs.ai (the blog was removed pre-launch for "no content strategy" — this doc _is_ the strategy).
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@astrojs/check": "^0.9.8",
+        "@astrojs/rss": "^4.0.19",
         "@astrojs/sitemap": "^3.7.2",
         "@sentry/astro": "^10.48.0",
         "@sentry/node": "^10.47.0",
+        "@tailwindcss/typography": "^0.5.20",
         "@tailwindcss/vite": "^4.2.2",
         "@vercel/analytics": "^2.0.1",
         "astro": "^6.4.8",
@@ -154,6 +156,17 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.19.tgz",
+      "integrity": "sha512-e+z5wYeYtffQdHQO8c2tkSd2JEBdAuRXJV4ZEU5IxkYeE6e39woDd7nw1PH1Kk2tEYNCYuKdylnnbhGmt61awA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.7",
+        "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/sitemap": {
@@ -2706,7 +2719,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
       "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5389,6 +5401,31 @@
         "node": ">= 20"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.20.tgz",
+      "integrity": "sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@tailwindcss/vite": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.2.tgz",
@@ -7072,7 +7109,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -8266,7 +8302,6 @@
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.9.tgz",
       "integrity": "sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8282,7 +8317,6 @@
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
       "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11650,7 +11684,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
       "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -12942,7 +12975,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
       "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13686,7 +13718,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vfile": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "SEE LICENSE IN LICENSE",
   "scripts": {
     "dev": "astro dev",
-    "build": "npm run generate-projects && astro build && node scripts/seo/meta-description-gate.mjs",
+    "build": "npm run generate-projects && node scripts/validate-blog-translations.mjs && astro build && node scripts/seo/meta-description-gate.mjs",
     "start": "astro preview",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
@@ -28,9 +28,11 @@
   },
   "dependencies": {
     "@astrojs/check": "^0.9.8",
+    "@astrojs/rss": "^4.0.19",
     "@astrojs/sitemap": "^3.7.2",
     "@sentry/astro": "^10.48.0",
     "@sentry/node": "^10.47.0",
+    "@tailwindcss/typography": "^0.5.20",
     "@tailwindcss/vite": "^4.2.2",
     "@vercel/analytics": "^2.0.1",
     "astro": "^6.4.8",

--- a/scripts/validate-blog-translations.mjs
+++ b/scripts/validate-blog-translations.mjs
@@ -1,0 +1,73 @@
+// Fails the build if any cornerstone (bilingual) blog post has a broken or
+// non-reciprocal translation link. Single-language posts (no `translations`)
+// are valid by design — the hybrid model. See
+// docs/strategy/BLOG-HYBRID-ARCHITECTURE-PROPOSAL.md.
+import fs from "node:fs";
+import path from "node:path";
+import matter from "gray-matter";
+
+const ROOT = path.resolve("./src/content/blog");
+
+function read(dir) {
+  const d = path.join(ROOT, dir);
+  if (!fs.existsSync(d)) return [];
+  return fs
+    .readdirSync(d)
+    .filter((f) => f.endsWith(".md"))
+    .map((f) => {
+      const { data } = matter(fs.readFileSync(path.join(d, f), "utf-8"));
+      return { slug: f.replace(/\.md$/, ""), data, file: `${dir}/${f}` };
+    });
+}
+
+const bare = (v) =>
+  v ? (v.startsWith("/") ? v.split("/").filter(Boolean).pop() : v) : null;
+
+const en = read("en");
+const es = read("es");
+const enBySlug = new Map(en.map((p) => [p.slug, p]));
+const esBySlug = new Map(es.map((p) => [p.slug, p]));
+const errors = [];
+
+for (const p of en) {
+  const twin = bare(p.data?.translations?.es);
+  if (!twin) continue;
+  const esPost = esBySlug.get(twin);
+  if (!esPost) {
+    errors.push(
+      `EN ${p.file} → translations.es "${twin}" but es/${twin}.md is missing`,
+    );
+    continue;
+  }
+  const back = bare(esPost.data?.translations?.en);
+  if (back !== p.slug)
+    errors.push(
+      `Non-reciprocal: EN ${p.file} ↔ es/${twin}.md (ES translations.en = "${back ?? "missing"}", expected "${p.slug}")`,
+    );
+}
+
+for (const p of es) {
+  const twin = bare(p.data?.translations?.en);
+  if (!twin) continue;
+  const enPost = enBySlug.get(twin);
+  if (!enPost) {
+    errors.push(
+      `ES ${p.file} → translations.en "${twin}" but en/${twin}.md is missing`,
+    );
+    continue;
+  }
+  const back = bare(enPost.data?.translations?.es);
+  if (back !== p.slug)
+    errors.push(
+      `Non-reciprocal: ES ${p.file} ↔ en/${twin}.md (EN translations.es = "${back ?? "missing"}", expected "${p.slug}")`,
+    );
+}
+
+if (errors.length) {
+  console.error("❌ blog translation validation FAILED:");
+  for (const e of errors) console.error("  - " + e);
+  process.exit(1);
+}
+console.log(
+  `✅ blog translations OK — ${en.length} EN + ${es.length} ES posts; all cornerstone links reciprocal.`,
+);

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -24,6 +24,7 @@ const content = {
       title: "Company",
       links: [
         { label: "About", href: "/about/" },
+        { label: "Blog", href: "/blog/" },
         { label: "Portfolio", href: "/portfolio/" },
         { label: "Industry Demos", href: "/demos/" },
         { label: "Watch", href: "/video/" },
@@ -70,6 +71,7 @@ const content = {
       title: "Empresa",
       links: [
         { label: "Acerca", href: "/es/about/" },
+        { label: "Blog", href: "/es/blog/" },
         { label: "Portafolio", href: "/es/portfolio/" },
         { label: "Demos por Industria", href: "/es/demos/" },
         { label: "Ver Video", href: "/es/video/" },

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -22,6 +22,7 @@ const navLinks = [
   { href: locale === "es" ? "/es/demos/" : "/demos/", label: "Demos" },
   { href: locale === "es" ? "/es/precios/" : "/pricing/", label: locale === "es" ? "Precios" : "Pricing" },
   { href: locale === "es" ? "/es/portfolio/" : "/portfolio/", label: locale === "es" ? "Portafolio" : "Portfolio" },
+  { href: locale === "es" ? "/es/blog/" : "/blog/", label: "Blog" },
   { href: locale === "es" ? "/es/contact/" : "/contact/", label: dict.nav.contact },
 ];
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -5,13 +5,16 @@ import { getLocalizedPath, t } from "../i18n";
 interface Props {
   locale: Locale;
   pathname: string;
+  // Override language-switch targets where the twin isn't a prefix-swap
+  // (single-language blog posts route to the other blog index, not a 404).
+  altLocaleHref?: { en?: string; es?: string };
 }
 
-const { locale, pathname } = Astro.props;
+const { locale, pathname, altLocaleHref } = Astro.props;
 const dict = t(locale);
 
-const toEn = getLocalizedPath(pathname, "en");
-const toEs = getLocalizedPath(pathname, "es");
+const toEn = altLocaleHref?.en ?? getLocalizedPath(pathname, "en");
+const toEs = altLocaleHref?.es ?? getLocalizedPath(pathname, "es");
 
 const navLinks = [
   { href: locale === "es" ? "/es/about/" : "/about/", label: dict.nav.about },

--- a/src/components/blog/ArticleSchema.astro
+++ b/src/components/blog/ArticleSchema.astro
@@ -1,0 +1,35 @@
+---
+// Article JSON-LD. Author/publisher reference the global Person/Organization
+// nodes emitted by BaseLayout's @graph (by @id) so Google sees one connected
+// entity, not three unrelated blobs.
+interface Props {
+  title: string;
+  description: string;
+  url: string; // absolute
+  image?: string; // absolute
+  publishDate: Date;
+  modifiedDate?: Date;
+  locale: "en" | "es";
+  categories?: string[];
+}
+const { title, description, url, image, publishDate, modifiedDate, locale, categories = [] } =
+  Astro.props;
+
+const SITE = "https://www.cushlabs.ai";
+const schema = {
+  "@context": "https://schema.org",
+  "@type": "Article",
+  headline: title,
+  description,
+  ...(image ? { image } : {}),
+  datePublished: publishDate.toISOString(),
+  dateModified: (modifiedDate ?? publishDate).toISOString(),
+  inLanguage: locale === "es" ? "es-MX" : "en-US",
+  ...(categories.length ? { articleSection: categories[0], keywords: categories.join(", ") } : {}),
+  author: { "@id": `${SITE}/#person` },
+  publisher: { "@id": `${SITE}/#organization` },
+  mainEntityOfPage: { "@type": "WebPage", "@id": url },
+};
+---
+
+<script type="application/ld+json" is:inline set:html={JSON.stringify(schema)} />

--- a/src/components/blog/BlogCard.astro
+++ b/src/components/blog/BlogCard.astro
@@ -1,0 +1,59 @@
+---
+import { Image } from "astro:assets";
+import type { BlogPost } from "../../lib/blog";
+import { postLang, postSlug, postUrl } from "../../lib/blog";
+import { categoryLabel } from "../../data/blogCategories";
+
+interface Props {
+  post: BlogPost;
+}
+const { post } = Astro.props;
+const locale = postLang(post);
+const href = postUrl(locale, postSlug(post));
+const cat = post.data.categories[0];
+const dateStr = post.data.publishDate.toLocaleDateString(
+  locale === "es" ? "es-MX" : "en-US",
+  { year: "numeric", month: "short", day: "numeric" },
+);
+---
+
+<article
+  class="group flex flex-col overflow-hidden rounded-2xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900/40 transition-all duration-300 hover:-translate-y-1 hover:border-cush-orange/50 hover:shadow-lg"
+>
+  <a href={href} class="block">
+    <div class="aspect-[16/9] overflow-hidden bg-gradient-to-br from-cush-orange/15 to-cush-orange/5 dark:from-cush-orange/20 dark:to-transparent">
+      {post.data.featuredImage ? (
+        <Image
+          src={post.data.featuredImage}
+          alt={post.data.imageAlt ?? post.data.title}
+          width={760}
+          height={428}
+          class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+        />
+      ) : (
+        <div class="flex h-full w-full items-center justify-center">
+          <span class="font-display text-3xl font-bold text-cush-orange/40">CushLabs</span>
+        </div>
+      )}
+    </div>
+  </a>
+  <div class="flex flex-1 flex-col p-6">
+    <div class="mb-3 flex items-center gap-3 text-xs">
+      {cat && (
+        <span class="rounded bg-cush-orange/10 px-2 py-0.5 font-display font-semibold text-cush-orange">
+          {categoryLabel(cat, locale)}
+        </span>
+      )}
+      <time class="text-gray-500 dark:text-gray-400">{dateStr}</time>
+      {post.data.readingTime && (
+        <span class="text-gray-500 dark:text-gray-400">· {post.data.readingTime}</span>
+      )}
+    </div>
+    <h2 class="mb-2 font-display text-lg font-bold leading-snug text-gray-900 dark:text-white">
+      <a href={href} class="transition-colors hover:text-cush-orange">{post.data.title}</a>
+    </h2>
+    <p class="line-clamp-3 text-sm leading-relaxed text-gray-600 dark:text-gray-400">
+      {post.data.excerpt}
+    </p>
+  </div>
+</article>

--- a/src/components/blog/BlogIndex.astro
+++ b/src/components/blog/BlogIndex.astro
@@ -41,7 +41,12 @@ const copy = {
 }[locale];
 ---
 
-<BaseLayout title={copy.title} description={copy.description} canonical={canonical}>
+<BaseLayout
+  title={copy.title}
+  description={copy.description}
+  canonical={canonical}
+  rssHref={locale === "es" ? "/es/blog/rss.xml" : "/blog/rss.xml"}
+>
   <section class="relative overflow-hidden pt-24 pb-10 md:pt-32">
     <div class="absolute inset-0 -z-10">
       <div class="absolute left-1/3 top-0 h-[400px] w-[400px] rounded-full bg-cush-orange/10 blur-[120px]"></div>

--- a/src/components/blog/BlogIndex.astro
+++ b/src/components/blog/BlogIndex.astro
@@ -1,0 +1,137 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import Container from "../layout/Container.astro";
+import BlogCard from "./BlogCard.astro";
+import type { BlogPost } from "../../lib/blog";
+import { postLang, postSlug } from "../../lib/blog";
+import { categoryLabel } from "../../data/blogCategories";
+
+interface Props {
+  locale: "en" | "es";
+  posts: BlogPost[];
+  categoriesInUse: string[];
+  page?: { current: number; last: number; prevUrl?: string; nextUrl?: string };
+  canonical: string;
+}
+const { locale, posts, categoriesInUse, page, canonical } = Astro.props;
+
+const copy = {
+  en: {
+    title: "The CushLabs Blog | AI & Growth for Local Business",
+    description:
+      "Practical guides on AI chatbots, Facebook Messenger, local SEO, and lead generation for small and local businesses. Written by CushLabs.",
+    heading: "The CushLabs Blog",
+    sub: "AI, automation, and local growth for small businesses — in plain language.",
+    all: "All",
+    empty: "No posts yet — check back soon.",
+    prev: "← Newer",
+    next: "Older →",
+  },
+  es: {
+    title: "Blog de CushLabs | IA y Crecimiento para Negocios Locales",
+    description:
+      "Guías prácticas sobre chatbots con IA, Facebook Messenger, SEO local y generación de leads para negocios pequeños y locales. Escrito por CushLabs.",
+    heading: "Blog de CushLabs",
+    sub: "IA, automatización y crecimiento local para negocios pequeños — en palabras simples.",
+    all: "Todo",
+    empty: "Aún no hay artículos — vuelve pronto.",
+    prev: "← Más nuevos",
+    next: "Más antiguos →",
+  },
+}[locale];
+---
+
+<BaseLayout title={copy.title} description={copy.description} canonical={canonical}>
+  <section class="relative overflow-hidden pt-24 pb-10 md:pt-32">
+    <div class="absolute inset-0 -z-10">
+      <div class="absolute left-1/3 top-0 h-[400px] w-[400px] rounded-full bg-cush-orange/10 blur-[120px]"></div>
+    </div>
+    <Container size="lg">
+      <div class="mx-auto max-w-2xl text-center">
+        <h1 class="mb-4 font-display text-fluid-4xl font-bold tracking-tight text-gray-900 dark:text-white">
+          {copy.heading}
+        </h1>
+        <p class="text-fluid-lg leading-relaxed text-gray-600 dark:text-gray-300">{copy.sub}</p>
+      </div>
+    </Container>
+  </section>
+
+  <section class="pb-24">
+    <Container size="lg">
+      {categoriesInUse.length > 0 && (
+        <div class="mb-8 flex flex-wrap justify-center gap-2" data-blog-filters>
+          <button
+            type="button"
+            data-filter="all"
+            class="filter-btn active rounded-lg border border-cush-orange bg-cush-orange/10 px-4 py-2 font-display text-sm font-semibold text-cush-orange"
+          >
+            {copy.all}
+          </button>
+          {categoriesInUse.map((key) => (
+            <button
+              type="button"
+              data-filter={key}
+              class="filter-btn rounded-lg border border-gray-200 px-4 py-2 font-display text-sm font-semibold text-gray-600 transition-colors hover:border-cush-orange hover:text-cush-orange dark:border-gray-700 dark:text-gray-400"
+            >
+              {categoryLabel(key, locale)}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {posts.length === 0 ? (
+        <p class="text-center text-gray-500 dark:text-gray-400">{copy.empty}</p>
+      ) : (
+        <div class="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3" data-blog-grid>
+          {posts.map((post) => (
+            <div data-categories={post.data.categories.join(",")}>
+              <BlogCard post={post} />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {page && page.last > 1 && (
+        <nav class="mt-12 flex items-center justify-center gap-4 font-display text-sm font-semibold">
+          {page.prevUrl ? (
+            <a href={page.prevUrl} class="text-cush-orange hover:opacity-80">{copy.prev}</a>
+          ) : (
+            <span class="text-gray-300 dark:text-gray-700">{copy.prev}</span>
+          )}
+          <span class="text-gray-500 dark:text-gray-400">{page.current} / {page.last}</span>
+          {page.nextUrl ? (
+            <a href={page.nextUrl} class="text-cush-orange hover:opacity-80">{copy.next}</a>
+          ) : (
+            <span class="text-gray-300 dark:text-gray-700">{copy.next}</span>
+          )}
+        </nav>
+      )}
+    </Container>
+  </section>
+</BaseLayout>
+
+<script>
+  const wrap = document.querySelector("[data-blog-filters]");
+  if (wrap) {
+    const btns = wrap.querySelectorAll(".filter-btn");
+    const cards = document.querySelectorAll("[data-blog-grid] > [data-categories]");
+    wrap.addEventListener("click", (e) => {
+      const btn = (e.target as HTMLElement).closest(".filter-btn");
+      if (!btn) return;
+      const f = btn.getAttribute("data-filter");
+      btns.forEach((b) => {
+        const on = b === btn;
+        b.classList.toggle("active", on);
+        b.classList.toggle("border-cush-orange", on);
+        b.classList.toggle("bg-cush-orange/10", on);
+        b.classList.toggle("text-cush-orange", on);
+        b.classList.toggle("border-gray-200", !on);
+        b.classList.toggle("text-gray-600", !on);
+      });
+      cards.forEach((c) => {
+        const cats = (c.getAttribute("data-categories") || "").split(",");
+        (c as HTMLElement).style.display = f === "all" || cats.includes(f!) ? "" : "none";
+      });
+    });
+  }
+</script>

--- a/src/components/blog/BreadcrumbSchema.astro
+++ b/src/components/blog/BreadcrumbSchema.astro
@@ -1,0 +1,18 @@
+---
+interface Props {
+  items: { name: string; url: string }[]; // urls absolute
+}
+const { items } = Astro.props;
+const schema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: items.map((item, i) => ({
+    "@type": "ListItem",
+    position: i + 1,
+    name: item.name,
+    item: item.url,
+  })),
+};
+---
+
+<script type="application/ld+json" is:inline set:html={JSON.stringify(schema)} />

--- a/src/components/blog/FaqSchema.astro
+++ b/src/components/blog/FaqSchema.astro
@@ -1,0 +1,17 @@
+---
+interface Props {
+  faqs: { question: string; answer: string }[];
+}
+const { faqs } = Astro.props;
+const schema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: faqs.map((f) => ({
+    "@type": "Question",
+    name: f.question,
+    acceptedAnswer: { "@type": "Answer", text: f.answer },
+  })),
+};
+---
+
+<script type="application/ld+json" is:inline set:html={JSON.stringify(schema)} />

--- a/src/components/blog/PostLayout.astro
+++ b/src/components/blog/PostLayout.astro
@@ -1,0 +1,142 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import Container from "../layout/Container.astro";
+import ArticleSchema from "./ArticleSchema.astro";
+import BreadcrumbSchema from "./BreadcrumbSchema.astro";
+import FaqSchema from "./FaqSchema.astro";
+import ShareBar from "./ShareBar.astro";
+import BlogCard from "./BlogCard.astro";
+import type { BlogPost } from "../../lib/blog";
+import { postLang, postSlug, postUrl, blogIndexUrl } from "../../lib/blog";
+import { categoryLabel } from "../../data/blogCategories";
+
+interface Props {
+  post: BlogPost;
+  url: string; // absolute
+  hreflangAlternates: { lang: string; href: string }[];
+  hreflangXDefault: string;
+  altLocaleHref: { en?: string; es?: string };
+  related: BlogPost[];
+  newer: BlogPost | null;
+  older: BlogPost | null;
+}
+const { post, url, hreflangAlternates, hreflangXDefault, altLocaleHref, related, newer, older } =
+  Astro.props;
+const locale = postLang(post);
+const SITE = "https://www.cushlabs.ai";
+
+const seoTitle = post.data.seo?.title ?? `${post.data.title} | CushLabs.ai`;
+const seoDescription = post.data.seo?.description ?? post.data.excerpt;
+const dateStr = post.data.publishDate.toLocaleDateString(
+  locale === "es" ? "es-MX" : "en-US",
+  { year: "numeric", month: "long", day: "numeric" },
+);
+
+const tt = {
+  en: { home: "Home", blog: "Blog", related: "Keep reading", newer: "← Newer post", older: "Older post →", by: "By Robert Cushman" },
+  es: { home: "Inicio", blog: "Blog", related: "Sigue leyendo", newer: "← Artículo más nuevo", older: "Artículo más antiguo →", by: "Por Robert Cushman" },
+}[locale];
+
+const homeHref = locale === "es" ? "/es/" : "/";
+const idxHref = blogIndexUrl(locale);
+---
+
+<BaseLayout
+  title={seoTitle}
+  description={seoDescription}
+  canonical={url}
+  ogType="article"
+  hreflangAlternates={hreflangAlternates}
+  hreflangXDefault={hreflangXDefault}
+  altLocaleHref={altLocaleHref}
+  articlePublishedTime={post.data.publishDate.toISOString()}
+  articleModifiedTime={(post.data.lastmod ?? post.data.publishDate).toISOString()}
+>
+  <ArticleSchema
+    title={post.data.title}
+    description={post.data.excerpt}
+    url={url}
+    publishDate={post.data.publishDate}
+    modifiedDate={post.data.lastmod}
+    locale={locale}
+    categories={post.data.categories}
+  />
+  <BreadcrumbSchema
+    items={[
+      { name: tt.home, url: `${SITE}${homeHref}` },
+      { name: tt.blog, url: `${SITE}${idxHref}` },
+      { name: post.data.title, url },
+    ]}
+  />
+  {post.data.faq && post.data.faq.length > 0 && <FaqSchema faqs={post.data.faq} />}
+
+  <article class="pt-24 pb-20 md:pt-32">
+    <Container size="md">
+      <!-- Breadcrumb -->
+      <nav class="mb-6 font-display text-sm text-gray-500 dark:text-gray-400">
+        <a href={homeHref} class="hover:text-cush-orange">{tt.home}</a>
+        <span class="mx-2">/</span>
+        <a href={idxHref} class="hover:text-cush-orange">{tt.blog}</a>
+      </nav>
+
+      <!-- Meta -->
+      <div class="mb-4 flex flex-wrap items-center gap-3 text-sm">
+        {post.data.categories[0] && (
+          <span class="rounded bg-cush-orange/10 px-2.5 py-0.5 font-display font-semibold text-cush-orange">
+            {categoryLabel(post.data.categories[0], locale)}
+          </span>
+        )}
+        <time class="text-gray-500 dark:text-gray-400">{dateStr}</time>
+        {post.data.readingTime && (
+          <span class="text-gray-500 dark:text-gray-400">· {post.data.readingTime}</span>
+        )}
+      </div>
+
+      <h1 class="mb-4 font-display text-fluid-4xl font-bold leading-tight tracking-tight text-gray-900 dark:text-white">
+        {post.data.title}
+      </h1>
+      <p class="mb-6 font-display text-sm text-gray-500 dark:text-gray-400">{tt.by}</p>
+
+      <div class="mb-10 border-b border-gray-100 pb-8 dark:border-gray-800">
+        <ShareBar url={url} title={post.data.title} locale={locale} />
+      </div>
+
+      <!-- Body -->
+      <div class="prose prose-lg max-w-none dark:prose-invert prose-headings:font-display prose-a:text-cush-orange prose-a:no-underline hover:prose-a:underline">
+        <slot />
+      </div>
+
+      <div class="mt-12 border-t border-gray-100 pt-8 dark:border-gray-800">
+        <ShareBar url={url} title={post.data.title} locale={locale} />
+      </div>
+
+      <!-- Prev / Next -->
+      {(newer || older) && (
+        <div class="mt-12 flex justify-between gap-4 font-display text-sm font-semibold">
+          {newer ? (
+            <a href={postUrl(locale, postSlug(newer))} class="max-w-[45%] text-cush-orange hover:opacity-80">
+              {tt.newer}<span class="mt-1 block text-gray-600 dark:text-gray-300">{newer.data.title}</span>
+            </a>
+          ) : <span></span>}
+          {older ? (
+            <a href={postUrl(locale, postSlug(older))} class="max-w-[45%] text-right text-cush-orange hover:opacity-80">
+              {tt.older}<span class="mt-1 block text-gray-600 dark:text-gray-300">{older.data.title}</span>
+            </a>
+          ) : <span></span>}
+        </div>
+      )}
+    </Container>
+
+    <!-- Related -->
+    {related.length > 0 && (
+      <Container size="lg">
+        <div class="mt-20">
+          <h2 class="mb-8 text-center font-display text-2xl font-bold text-gray-900 dark:text-white">{tt.related}</h2>
+          <div class="grid grid-cols-1 gap-6 md:grid-cols-3">
+            {related.map((p) => <BlogCard post={p} />)}
+          </div>
+        </div>
+      </Container>
+    )}
+  </article>
+</BaseLayout>

--- a/src/components/blog/PostLayout.astro
+++ b/src/components/blog/PostLayout.astro
@@ -51,6 +51,7 @@ const idxHref = blogIndexUrl(locale);
   altLocaleHref={altLocaleHref}
   articlePublishedTime={post.data.publishDate.toISOString()}
   articleModifiedTime={(post.data.lastmod ?? post.data.publishDate).toISOString()}
+  rssHref={locale === "es" ? "/es/blog/rss.xml" : "/blog/rss.xml"}
 >
   <ArticleSchema
     title={post.data.title}

--- a/src/components/blog/ShareBar.astro
+++ b/src/components/blog/ShareBar.astro
@@ -1,0 +1,56 @@
+---
+interface Props {
+  url: string; // absolute
+  title: string;
+  locale: "en" | "es";
+}
+const { url, title, locale } = Astro.props;
+const enc = encodeURIComponent;
+const label = locale === "es" ? "Compartir" : "Share";
+const copyLabel = locale === "es" ? "Copiar enlace" : "Copy link";
+const links = [
+  { name: "WhatsApp", href: `https://wa.me/?text=${enc(`${title} ${url}`)}` },
+  { name: "Facebook", href: `https://www.facebook.com/sharer/sharer.php?u=${enc(url)}` },
+  { name: "LinkedIn", href: `https://www.linkedin.com/sharing/share-offsite/?url=${enc(url)}` },
+  { name: "X", href: `https://twitter.com/intent/tweet?url=${enc(url)}&text=${enc(title)}` },
+];
+---
+
+<div class="flex flex-wrap items-center gap-2" data-share-bar data-share-url={url}>
+  <span class="mr-1 font-display text-sm font-semibold text-gray-500 dark:text-gray-400">{label}:</span>
+  {links.map((l) => (
+    <a
+      href={l.href}
+      target="_blank"
+      rel="noopener"
+      class="rounded-lg border border-gray-200 px-3 py-1.5 font-display text-xs font-semibold text-gray-700 transition-colors hover:border-cush-orange hover:text-cush-orange dark:border-gray-700 dark:text-gray-300"
+    >
+      {l.name}
+    </a>
+  ))}
+  <button
+    type="button"
+    data-copy-link
+    class="rounded-lg border border-gray-200 px-3 py-1.5 font-display text-xs font-semibold text-gray-700 transition-colors hover:border-cush-orange hover:text-cush-orange dark:border-gray-700 dark:text-gray-300"
+  >
+    {copyLabel}
+  </button>
+</div>
+
+<script>
+  document.querySelectorAll("[data-share-bar]").forEach((bar) => {
+    const url = bar.getAttribute("data-share-url") || location.href;
+    const btn = bar.querySelector("[data-copy-link]");
+    if (!btn) return;
+    btn.addEventListener("click", async () => {
+      try {
+        await navigator.clipboard.writeText(url);
+        const prev = btn.textContent;
+        btn.textContent = "✓";
+        setTimeout(() => (btn.textContent = prev), 1500);
+      } catch {
+        /* clipboard unavailable — no-op */
+      }
+    });
+  });
+</script>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,0 +1,44 @@
+import { defineCollection, z } from "astro:content";
+import { glob } from "astro/loaders";
+
+// One flat `blog` collection. Language is derived from the folder prefix in the
+// post id: "en/<slug>" or "es/<slug>". A post is BILINGUAL (a cornerstone) when
+// it sets a reciprocal `translations` entry; otherwise it is single-language by
+// design (the hybrid model — see docs/strategy/BLOG-HYBRID-ARCHITECTURE-PROPOSAL.md).
+const blog = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/blog" }),
+  schema: ({ image }) =>
+    z.object({
+      title: z.string(),
+      excerpt: z.string(),
+      publishDate: z.string().transform((s) => new Date(s)),
+      lastmod: z
+        .string()
+        .transform((s) => new Date(s))
+        .optional(),
+      publish: z.boolean().optional().default(true),
+      categories: z.array(z.string()).optional().default([]),
+      featuredImage: image().optional(),
+      imageAlt: z.string().optional(),
+      readingTime: z.string().optional(),
+      // Cornerstone cross-link: EN post sets `translations.es`, ES post sets
+      // `translations.en`. Value is the OTHER language's slug (bare or full path).
+      // Presence of a reciprocal entry === bilingual mode.
+      translations: z
+        .object({ en: z.string().optional(), es: z.string().optional() })
+        .optional(),
+      // Optional SEO overrides — enforced by the build gate (title <=60, desc 120-160).
+      seo: z
+        .object({
+          title: z.string().optional(),
+          description: z.string().optional(),
+        })
+        .optional(),
+      // When present -> post emits FAQPage JSON-LD (rich result).
+      faq: z
+        .array(z.object({ question: z.string(), answer: z.string() }))
+        .optional(),
+    }),
+});
+
+export const collections = { blog };

--- a/src/content/blog/en/facebook-leads-after-6pm.md
+++ b/src/content/blog/en/facebook-leads-after-6pm.md
@@ -1,0 +1,45 @@
+---
+title: "Why Your Business Loses Facebook Leads After 6 PM"
+excerpt: "Your best leads arrive when you're closed. Here's why the after-hours gap quietly costs local businesses the most — and the fix that answers in five seconds."
+publishDate: "2026-07-06"
+categories:
+  - "facebook-messenger"
+  - "small-business"
+readingTime: "5 min read"
+seo:
+  description: "Most small businesses lose their best Facebook leads after hours. Here's why the 15-minute response window matters and how to answer in five seconds."
+---
+
+Look at when your Facebook messages actually arrive. A lot of them land after you've closed — evenings, late nights, Sundays. That's not a coincidence. It's when your customers finally have time to think about booking you.
+
+And it's exactly when nobody's there to answer.
+
+## The after-hours gap is where the money leaks
+
+A prospect messages your page at 9 PM: "Do you have anything open this weekend?" You see it at 8 the next morning. By then they've messaged two competitors and booked with whoever replied first. You didn't lose that customer on price or quality. You lost them to an eleven-hour silence.
+
+For local businesses, speed-to-lead is the whole game. The first business to respond wins the conversation most of the time — and "first" increasingly means _within minutes_, not hours.
+
+## Facebook is actively scoring your response time
+
+This isn't just about the individual lead. Facebook shows a **"Very responsive to messages"** badge on pages that reply fast — and pulls it if your median response time creeps past 15 minutes. That badge is a trust signal every visitor sees before they message you. Lose it, and you look slower than the competitor who kept theirs.
+
+So the after-hours gap costs you twice: the leads you miss tonight, and the badge that would have earned you leads tomorrow.
+
+## The generic autoresponder is not the fix
+
+You've seen the reflex solution: _"Thanks for reaching out! We'll get back to you shortly."_ That doesn't win the lead — it just timestamps the moment you started losing it. It answers nothing the customer actually asked.
+
+The fix has to do three things a canned reply can't:
+
+- **Answer the real question** — price, availability, location — in seconds.
+- **Do it in the customer's language**, whether they wrote in English or Spanish.
+- **Capture the lead** — name and contact — so you can follow up even if they go quiet.
+
+## The five-second fix
+
+This is what an AI assistant on your Facebook page does. Trained on your business — your prices, hours, services, and tone — it answers every message in under five seconds, 24/7, in English and Spanish. When someone's ready to book, it captures their details and flags it so you can close.
+
+The 9 PM prospect gets a real answer at 9 PM. You keep your badge. And the leads that used to evaporate overnight are still there in the morning — with a name and a number attached.
+
+Curious what that looks like in practice? See the [AI Messenger Assistant](/messenger-assistant/) — it's answering real customers in production right now.

--- a/src/content/blog/en/turn-messenger-into-sales-channel.md
+++ b/src/content/blog/en/turn-messenger-into-sales-channel.md
@@ -1,0 +1,58 @@
+---
+title: "How to Turn Facebook Messenger Into a Sales Channel"
+excerpt: "Most businesses treat Messenger as a support inbox. The ones growing fastest treat it as a sales channel. Here's the practical playbook for making the switch."
+publishDate: "2026-07-05"
+categories:
+  - "facebook-messenger"
+  - "ai-chatbots"
+readingTime: "8 min read"
+translations:
+  es: "messenger-canal-de-ventas"
+seo:
+  description: "A practical playbook for turning Facebook Messenger from a support inbox into a real sales channel: qualify, recommend, capture, and hand off to close."
+faq:
+  - question: "Do I need a website to sell through Messenger?"
+    answer: "No. For many local businesses the Facebook page is the entire storefront. Messenger becomes the front desk and the checkout counter — no website required."
+  - question: "Will an AI assistant replace the personal touch my customers expect?"
+    answer: "It handles the repetitive questions instantly and hands off to you the moment a conversation needs a human, with the context already gathered. Customers get faster answers and still reach a real person to close."
+  - question: "How fast can Messenger start converting?"
+    answer: "The mechanics — instant answers, lead capture, clear next step — can be in place in days. The compounding effect grows as more of your traffic flows through the channel."
+---
+
+Open your Facebook Messenger inbox and ask one question: **is this a support desk or a sales channel?**
+
+For most businesses, it's a support desk by accident. Messages come in, someone answers when they can, and the conversation ends with information delivered — not a sale made. The businesses growing fastest made a deliberate switch: they treat Messenger as the place where buying actually happens.
+
+Here's how to make that switch.
+
+## 1. Answer instantly, or the channel doesn't work
+
+Everything downstream depends on speed. A sales channel where the "salesperson" replies two hours later isn't a sales channel — it's a voicemail. The first move is guaranteeing that every message gets a real, useful answer in seconds, at any hour. That's the foundation; the rest of this playbook assumes it's in place.
+
+## 2. Qualify before you pitch
+
+A good salesperson asks before they sell. In Messenger, that means understanding what the customer actually wants before dumping your whole catalog on them. What service are they after? What's their timeline? Are they price-shopping or ready to book?
+
+A few smart questions turn a vague "how much?" into a qualified opportunity — and let you point them at the _right_ offer instead of the biggest one.
+
+## 3. Recommend, don't list
+
+The fastest way to lose a Messenger sale is to answer "what do you offer?" with a wall of options. Choice paralysis kills conversions. Instead, guide: based on what the customer told you, recommend the one thing that fits. "For what you're describing, most clients go with X — want me to check availability?" That's a salesperson. A list is a brochure.
+
+## 4. Capture the lead every time
+
+This is the step almost everyone skips, and it's the most expensive one to skip. Before the conversation cools, get a name and a way to reach them — phone, WhatsApp, email. A conversation without contact details is a lead you can never follow up with. With them, even a customer who goes quiet is someone you can re-engage.
+
+## 5. Hand off to close — with context
+
+AI and automation should do the heavy lifting: instant answers, qualification, recommendations, capture. But the close often still wants a human. The key is a **clean handoff** — the moment a conversation genuinely needs you, you step in already knowing what the customer wants, what they've asked, and where they are in the decision. No "let me catch up on the thread." Just close.
+
+## 6. Meet customers where they already are
+
+Here's the strategic part. Many local businesses — especially in Mexico — have no website. Their entire presence is their Facebook page. For them, Messenger isn't _another_ channel to manage. It **is** the storefront. Turning it into a sales channel isn't an add-on; it's building the cash register where the customers already are.
+
+## Putting it together
+
+A Messenger sales channel that runs on its own looks like this: instant bilingual answers, smart qualification, the right recommendation, lead capture on every conversation, and a clean handoff when it's time to close. Done by hand, that's a full-time job. Done with an AI assistant trained on your business, it runs 24/7 while you work — or sleep.
+
+That's exactly what the [AI Messenger Assistant](/messenger-assistant/) does: a production-ready assistant that turns your Facebook page into a channel that sells, not just answers.

--- a/src/content/blog/es/mas-citas-desde-facebook.md
+++ b/src/content/blog/es/mas-citas-desde-facebook.md
@@ -1,0 +1,41 @@
+---
+title: "Más citas desde Facebook sin contratar a nadie"
+excerpt: "Tus clientes ya te escriben por Facebook. El problema no es la falta de interés: es la velocidad de respuesta. Así conviertes esos mensajes en citas agendadas."
+publishDate: "2026-07-07"
+categories:
+  - "facebook-messenger"
+  - "lead-generation"
+readingTime: "5 min de lectura"
+seo:
+  description: "Convierte los mensajes de Facebook de tu negocio en citas agendadas sin contratar personal ni vivir pegado al celular. Guía práctica para dueños."
+---
+
+La mayoría de los negocios locales no tienen un problema de interés. Tienen un problema de **velocidad**.
+
+Tu página de Facebook recibe mensajes: "¿Cuánto cuesta?", "¿Tienen lugar el sábado?", "¿Dónde están?". Cada uno es un cliente listo para comprar. Pero contestas cuando puedes —dos horas después, o al día siguiente— y para entonces esa persona ya le escribió a tres competidores y agendó con el que respondió primero.
+
+No perdiste la venta por precio. La perdiste por tiempo.
+
+## El que responde primero gana
+
+En servicios locales —salones, clínicas, talleres, consultorios— la decisión de compra pasa rápido. Quien contesta en segundos casi siempre se queda con la cita. Facebook lo sabe: si tardas más de 15 minutos en responder, te quita la insignia de "responde rápido" que ven tus clientes.
+
+El objetivo no es contestar _mejor_. Es contestar **de inmediato**, aunque estés cortando el cabello de otra clienta o en medio de una consulta.
+
+## Tres cosas que convierten mensajes en citas
+
+1. **Responde en segundos, siempre.** Un "gracias por escribir, en un momento te atiendo" no cuenta: es una forma amable de perder al cliente. La respuesta tiene que resolver algo real de inmediato —precio, disponibilidad, ubicación.
+2. **Pide siempre el dato de contacto.** Antes de que la conversación se enfríe, captura nombre y teléfono o WhatsApp. Un mensaje sin datos es un cliente que no puedes volver a buscar.
+3. **Automatiza lo repetitivo.** El 80% de tus mensajes son las mismas cinco preguntas. Precios, horarios, servicios, cómo llegar, cómo agendar. Todo eso puede contestarse solo, sin que tú levantes el teléfono.
+
+## Dónde entra la IA
+
+Aquí es donde un asistente con inteligencia artificial cambia el juego. En lugar de contestar tú cada mensaje, un asistente entrenado con **tu negocio** —tus precios, tus horarios, tu forma de hablar— responde en menos de cinco segundos, las 24 horas, en español e inglés. Cuando alguien está listo para agendar, captura sus datos y te avisa para que cierres tú.
+
+No es un robot genérico que dice "no entendí tu pregunta". Es tu propio conocimiento contestando por ti mientras atiendes, duermes o descansas.
+
+## En resumen
+
+Ya tienes la demanda. Lo que te falta es no dejarla enfriar. Contesta en segundos, captura el contacto y automatiza lo repetitivo —y las citas que hoy se te escapan empiezan a quedarse contigo.
+
+¿Quieres ver cómo se siente en la práctica? Conoce el [Asistente de IA para Messenger](/es/messenger-assistant/) que ya atiende clientes reales en producción.

--- a/src/content/blog/es/messenger-canal-de-ventas.md
+++ b/src/content/blog/es/messenger-canal-de-ventas.md
@@ -1,0 +1,58 @@
+---
+title: "Cómo Convertir Facebook Messenger en un Canal de Ventas"
+excerpt: "La mayoría de los negocios usan Messenger como bandeja de soporte. Los que más crecen lo usan como canal de ventas. Este es el playbook práctico para lograrlo."
+publishDate: "2026-07-05"
+categories:
+  - "facebook-messenger"
+  - "ai-chatbots"
+readingTime: "8 min de lectura"
+translations:
+  en: "turn-messenger-into-sales-channel"
+seo:
+  description: "Playbook práctico para convertir Facebook Messenger de bandeja de soporte a canal de ventas real: califica, recomienda, captura y pasa al cierre."
+faq:
+  - question: "¿Necesito una página web para vender por Messenger?"
+    answer: "No. Para muchos negocios locales, la página de Facebook es toda la tienda. Messenger se vuelve la recepción y la caja registradora — sin necesidad de sitio web."
+  - question: "¿Un asistente con IA le quita el trato personal a mis clientes?"
+    answer: "Resuelve al instante las preguntas repetitivas y te pasa la conversación en cuanto se necesita una persona, con el contexto ya levantado. El cliente recibe respuestas más rápidas y aun así llega contigo para cerrar."
+  - question: "¿Qué tan rápido empieza a convertir Messenger?"
+    answer: "La mecánica —respuestas al instante, captura de datos, siguiente paso claro— puede quedar lista en pocos días. El efecto compuesto crece conforme más tráfico pasa por el canal."
+---
+
+Abre tu bandeja de Facebook Messenger y hazte una sola pregunta: **¿esto es un área de soporte o un canal de ventas?**
+
+Para la mayoría, es un área de soporte por accidente. Llegan mensajes, alguien contesta cuando puede, y la conversación termina con información entregada —no con una venta cerrada. Los negocios que más crecen hicieron un cambio deliberado: convirtieron Messenger en el lugar donde de verdad se compra.
+
+Así se hace ese cambio.
+
+## 1. Contesta al instante, o el canal no funciona
+
+Todo lo demás depende de la velocidad. Un canal de ventas donde el "vendedor" responde dos horas después no es un canal de ventas —es una contestadora. El primer paso es garantizar que cada mensaje reciba una respuesta real y útil en segundos, a cualquier hora. Esa es la base; el resto del playbook la da por hecha.
+
+## 2. Califica antes de vender
+
+Un buen vendedor pregunta antes de ofrecer. En Messenger, eso significa entender qué quiere realmente el cliente antes de tirarle todo el catálogo encima. ¿Qué servicio busca? ¿Para cuándo? ¿Está comparando precios o listo para agendar?
+
+Unas cuantas preguntas inteligentes convierten un "¿cuánto cuesta?" difuso en una oportunidad calificada —y te dejan ofrecerle lo _correcto_ en vez de lo más caro.
+
+## 3. Recomienda, no enlistes
+
+La forma más rápida de perder una venta en Messenger es contestar "¿qué ofrecen?" con una lista interminable de opciones. La parálisis por exceso de opciones mata las conversiones. En vez de eso, guía: con base en lo que te dijo el cliente, recomienda la opción que le queda. "Por lo que me cuentas, la mayoría elige X —¿te reviso la disponibilidad?" Eso es un vendedor. Una lista es un folleto.
+
+## 4. Captura el dato siempre
+
+Este es el paso que casi todos se saltan, y es el más caro de saltarse. Antes de que la conversación se enfríe, consigue un nombre y una forma de contactarlo —teléfono, WhatsApp, correo. Una conversación sin datos de contacto es un cliente que nunca podrás volver a buscar. Con ellos, hasta quien se queda callado es alguien a quien puedes reactivar.
+
+## 5. Pasa al cierre — con contexto
+
+La IA y la automatización deben hacer el trabajo pesado: respuestas al instante, calificación, recomendaciones, captura. Pero el cierre muchas veces todavía quiere a una persona. La clave es un **traspaso limpio**: en cuanto la conversación de verdad te necesita, entras ya sabiendo qué quiere el cliente, qué preguntó y en qué punto de la decisión está. Nada de "déjame ponerme al día con el chat". Solo cierras.
+
+## 6. Encuentra al cliente donde ya está
+
+Aquí viene la parte estratégica. Muchos negocios locales —sobre todo en México— no tienen página web. Toda su presencia es su página de Facebook. Para ellos, Messenger no es _otro_ canal más que administrar. **Es** la tienda. Convertirlo en canal de ventas no es un extra; es poner la caja registradora donde ya están los clientes.
+
+## Juntándolo todo
+
+Un canal de ventas en Messenger que funciona solo se ve así: respuestas bilingües al instante, calificación inteligente, la recomendación correcta, captura de datos en cada conversación y un traspaso limpio cuando llega el momento de cerrar. Hecho a mano, eso es un trabajo de tiempo completo. Hecho con un asistente de IA entrenado con tu negocio, funciona 24/7 mientras trabajas —o duermes.
+
+Eso es justo lo que hace el [Asistente de IA para Messenger](/es/messenger-assistant/): un asistente listo para producción que convierte tu página de Facebook en un canal que vende, no solo que contesta.

--- a/src/data/blogCategories.ts
+++ b/src/data/blogCategories.ts
@@ -1,0 +1,28 @@
+// Bilingual blog category registry. Post frontmatter uses the canonical `key`;
+// the UI renders the locale-appropriate label. Keep keys stable — they drive
+// filtering and related-post matching.
+export interface BlogCategory {
+  key: string;
+  en: string;
+  es: string;
+}
+
+export const blogCategories: BlogCategory[] = [
+  {
+    key: "facebook-messenger",
+    en: "Facebook & Messenger",
+    es: "Facebook y Messenger",
+  },
+  { key: "ai-chatbots", en: "AI Chatbots", es: "Chatbots con IA" },
+  { key: "local-seo", en: "Local SEO", es: "SEO Local" },
+  { key: "lead-generation", en: "Lead Generation", es: "Generación de Leads" },
+  { key: "small-business", en: "Small Business", es: "Negocios Pequeños" },
+  { key: "automation", en: "Automation", es: "Automatización" },
+];
+
+const byKey = new Map(blogCategories.map((c) => [c.key, c]));
+
+/** Localized label for a category key, falling back to the raw key. */
+export function categoryLabel(key: string, locale: "en" | "es"): string {
+  return byKey.get(key)?.[locale] ?? key;
+}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -23,6 +23,7 @@ interface Props {
   altLocaleHref?: { en?: string; es?: string };
   articlePublishedTime?: string;
   articleModifiedTime?: string;
+  rssHref?: string;
 }
 
 const {
@@ -37,6 +38,7 @@ const {
   altLocaleHref,
   articlePublishedTime,
   articleModifiedTime,
+  rssHref,
 } = Astro.props;
 const pathname = Astro.url.pathname;
 const locale =
@@ -156,6 +158,9 @@ const ogLocaleAlternate = locale === "es" ? "en_US" : "es_MX";
     <link rel="icon" type="image/webp" href="/images/logo/cushlabs-logo.webp" />
     <link rel="apple-touch-icon" href="/images/logo/cushlabs-logo.png" />
     <link rel="manifest" href="/site.webmanifest" />
+    {rssHref && (
+      <link rel="alternate" type="application/rss+xml" title="CushLabs Blog" href={rssHref} />
+    )}
 
     <script
       type="application/ld+json"

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -13,9 +13,31 @@ interface Props {
   ogImage?: string;
   ogType?: string;
   noindex?: boolean;
+  // Blog posts pass explicit hreflang alternates so single-language posts don't
+  // emit a pointer to a non-existent translation (the hybrid model). When set,
+  // these REPLACE the auto EN↔ES pair below.
+  hreflangAlternates?: { lang: string; href: string }[];
+  hreflangXDefault?: string;
+  // Language-switcher targets for pages where the ES/EN twin isn't a simple
+  // prefix swap (e.g. single-language blog posts → route to the other index).
+  altLocaleHref?: { en?: string; es?: string };
+  articlePublishedTime?: string;
+  articleModifiedTime?: string;
 }
 
-const { title, description, canonical, ogImage, ogType = "website", noindex = false } = Astro.props;
+const {
+  title,
+  description,
+  canonical,
+  ogImage,
+  ogType = "website",
+  noindex = false,
+  hreflangAlternates,
+  hreflangXDefault,
+  altLocaleHref,
+  articlePublishedTime,
+  articleModifiedTime,
+} = Astro.props;
 const pathname = Astro.url.pathname;
 const locale =
   (Astro.currentLocale as Locale | undefined) ??
@@ -31,9 +53,10 @@ const ensureTrailingSlash = (p: string) => p === '/' || p.endsWith('/') ? p : `$
 const canonicalPath = ensureTrailingSlash(stripOrigin(canonical || pathname));
 const canonicalURL = new URL(canonicalPath, Astro.site);
 
-// getLocalizedPath already returns trailing slashes
-const enURL = new URL(getLocalizedPath(pathname, "en"), Astro.site);
-const esURL = new URL(getLocalizedPath(pathname, "es"), Astro.site);
+// getLocalizedPath already returns trailing slashes. altLocaleHref overrides
+// the naive prefix-swap for pages whose twin isn't a mirror path (blog posts).
+const enURL = new URL(altLocaleHref?.en ?? getLocalizedPath(pathname, "en"), Astro.site);
+const esURL = new URL(altLocaleHref?.es ?? getLocalizedPath(pathname, "es"), Astro.site);
 
 // OG Image - use custom if provided, otherwise default
 const defaultOgImage = `${Astro.site}images/og/cushlabs-og.png`;
@@ -76,12 +99,32 @@ const ogLocaleAlternate = locale === "es" ? "en_US" : "es_MX";
     <link rel="canonical" href={canonicalURL} />
 
     <!-- Hreflang for bilingual SEO — locale codes match sitemap i18n config (en-US / es-MX) -->
-    <link rel="alternate" hreflang="en-US" href={enURL} />
-    <link rel="alternate" hreflang="es-MX" href={esURL} />
-    <link rel="alternate" hreflang="x-default" href={enURL} />
+    {hreflangAlternates ? (
+      <>
+        {hreflangAlternates.map((a) => (
+          <link rel="alternate" hreflang={a.lang} href={a.href} />
+        ))}
+        <link rel="alternate" hreflang="x-default" href={hreflangXDefault ?? hreflangAlternates[0].href} />
+      </>
+    ) : (
+      <>
+        <link rel="alternate" hreflang="en-US" href={enURL} />
+        <link rel="alternate" hreflang="es-MX" href={esURL} />
+        <link rel="alternate" hreflang="x-default" href={enURL} />
+      </>
+    )}
 
     <!-- Open Graph -->
     <meta property="og:type" content={ogType} />
+    {ogType === "article" && articlePublishedTime && (
+      <meta property="article:published_time" content={articlePublishedTime} />
+    )}
+    {ogType === "article" && articleModifiedTime && (
+      <meta property="article:modified_time" content={articleModifiedTime} />
+    )}
+    {ogType === "article" && (
+      <meta property="article:author" content="Robert Cushman" />
+    )}
     <meta property="og:url" content={canonicalURL} />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
@@ -211,7 +254,7 @@ const ogLocaleAlternate = locale === "es" ? "en_US" : "es_MX";
       {locale === "es" ? "Ir al contenido principal" : "Skip to main content"}
     </a>
 
-    <Header locale={locale} pathname={pathname} />
+    <Header locale={locale} pathname={pathname} altLocaleHref={altLocaleHref} />
     <main id="main-content">
       <slot />
     </main>

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -1,0 +1,120 @@
+import type { CollectionEntry } from "astro:content";
+
+export type BlogPost = CollectionEntry<"blog">;
+export type BlogLocale = "en" | "es";
+
+/** Language of a post, from its id folder prefix ("en/..." | "es/..."). */
+export function postLang(post: BlogPost): BlogLocale {
+  return post.id.startsWith("es/") ? "es" : "en";
+}
+
+/** Bare slug of a post (id without the language folder prefix). */
+export function postSlug(post: BlogPost): string {
+  return post.id.replace(/^(en|es)\//, "");
+}
+
+/** Public URL for a post. EN is unprefixed (`/blog/…`), ES is `/es/blog/…`. */
+export function postUrl(locale: BlogLocale, slug: string): string {
+  return locale === "es" ? `/es/blog/${slug}/` : `/blog/${slug}/`;
+}
+
+/** Blog index URL for a locale. */
+export function blogIndexUrl(locale: BlogLocale): string {
+  return locale === "es" ? "/es/blog/" : "/blog/";
+}
+
+/** Normalize a `translations` value (may be a full path or a bare slug) to a bare slug. */
+export function extractSlug(pathOrSlug?: string): string | null {
+  if (!pathOrSlug) return null;
+  if (pathOrSlug.startsWith("/")) {
+    return pathOrSlug.split("/").filter(Boolean).pop() || null;
+  }
+  return pathOrSlug;
+}
+
+/** Published posts for one locale, newest first. */
+export function postsForLocale(
+  all: BlogPost[],
+  locale: BlogLocale,
+): BlogPost[] {
+  return all
+    .filter((p) => postLang(p) === locale && p.data.publish !== false)
+    .sort(
+      (a, b) => b.data.publishDate.valueOf() - a.data.publishDate.valueOf(),
+    );
+}
+
+/**
+ * Per-post hreflang alternates. Single-language posts emit ONLY themselves
+ * (no pointer to a non-existent twin — this is the hybrid model's core rule).
+ * Cornerstones (with a reciprocal `translations` entry) emit the full EN↔ES pair.
+ * Returns absolute URLs. `xDefault` is the EN href for a pair, else self.
+ */
+export function postHreflangs(
+  post: BlogPost,
+  site: string,
+): { alternates: { lang: string; href: string }[]; xDefault: string } {
+  const siteBase = site.replace(/\/$/, "");
+  const lang = postLang(post);
+  const selfHref = `${siteBase}${postUrl(lang, postSlug(post))}`;
+  const selfLang = lang === "es" ? "es-MX" : "en-US";
+
+  const twinSlug =
+    lang === "en"
+      ? extractSlug(post.data.translations?.es)
+      : extractSlug(post.data.translations?.en);
+
+  if (!twinSlug) {
+    // Single-language: self only, x-default = self.
+    return {
+      alternates: [{ lang: selfLang, href: selfHref }],
+      xDefault: selfHref,
+    };
+  }
+
+  const twinLang: BlogLocale = lang === "en" ? "es" : "en";
+  const twinHref = `${siteBase}${postUrl(twinLang, twinSlug)}`;
+  const enHref = lang === "en" ? selfHref : twinHref;
+
+  return {
+    alternates: [
+      { lang: "en-US", href: lang === "en" ? selfHref : twinHref },
+      { lang: "es-MX", href: lang === "es" ? selfHref : twinHref },
+    ],
+    xDefault: enHref,
+  };
+}
+
+/** Top-N related posts in the SAME language, scored by shared categories. */
+export function relatedPosts(
+  all: BlogPost[],
+  post: BlogPost,
+  n = 3,
+): BlogPost[] {
+  const lang = postLang(post);
+  const cats = new Set(post.data.categories);
+  return postsForLocale(all, lang)
+    .filter((p) => p.id !== post.id)
+    .map((p) => ({
+      post: p,
+      score: p.data.categories.filter((c) => cats.has(c)).length,
+    }))
+    .filter((x) => x.score > 0)
+    .sort(
+      (a, b) =>
+        b.score - a.score ||
+        b.post.data.publishDate.valueOf() - a.post.data.publishDate.valueOf(),
+    )
+    .slice(0, n)
+    .map((x) => x.post);
+}
+
+/** Previous (older) / next (newer) post in the same language's date order. */
+export function prevNext(sortedSameLang: BlogPost[], post: BlogPost) {
+  const i = sortedSameLang.findIndex((p) => p.id === post.id);
+  return {
+    newer: i > 0 ? sortedSameLang[i - 1] : null,
+    older:
+      i >= 0 && i < sortedSameLang.length - 1 ? sortedSameLang[i + 1] : null,
+  };
+}

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -1,0 +1,27 @@
+---
+import type { GetStaticPaths } from "astro";
+import { getCollection } from "astro:content";
+import BlogIndex from "../../components/blog/BlogIndex.astro";
+import { postsForLocale } from "../../lib/blog";
+import { blogCategories } from "../../data/blogCategories";
+
+export const getStaticPaths = (async ({ paginate }) => {
+  const all = await getCollection("blog");
+  return paginate(postsForLocale(all, "en"), { pageSize: 6 });
+}) satisfies GetStaticPaths;
+
+const { page } = Astro.props;
+const all = await getCollection("blog");
+const enPosts = postsForLocale(all, "en");
+const categoriesInUse = blogCategories
+  .map((c) => c.key)
+  .filter((k) => enPosts.some((p) => p.data.categories.includes(k)));
+---
+
+<BlogIndex
+  locale="en"
+  posts={page.data}
+  categoriesInUse={categoriesInUse}
+  page={{ current: page.currentPage, last: page.lastPage, prevUrl: page.url.prev, nextUrl: page.url.next }}
+  canonical={page.url.current}
+/>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,0 +1,51 @@
+---
+import type { GetStaticPaths } from "astro";
+import { getCollection, render } from "astro:content";
+import PostLayout from "../../components/blog/PostLayout.astro";
+import {
+  postsForLocale,
+  postLang,
+  postSlug,
+  postUrl,
+  blogIndexUrl,
+  postHreflangs,
+  relatedPosts,
+  prevNext,
+  extractSlug,
+} from "../../lib/blog";
+
+export const getStaticPaths = (async () => {
+  const all = await getCollection("blog");
+  return all
+    .filter((p) => postLang(p) === "en" && p.data.publish !== false)
+    .map((post) => ({ params: { slug: postSlug(post) }, props: { post } }));
+}) satisfies GetStaticPaths;
+
+const { post } = Astro.props;
+const all = await getCollection("blog");
+const SITE = "https://www.cushlabs.ai";
+const { Content } = await render(post);
+
+const url = `${SITE}${postUrl("en", postSlug(post))}`;
+const { alternates, xDefault } = postHreflangs(post, SITE);
+
+const twinSlug = extractSlug(post.data.translations?.es);
+const altLocaleHref = { es: twinSlug ? postUrl("es", twinSlug) : blogIndexUrl("es") };
+
+const sameLang = postsForLocale(all, "en");
+const { newer, older } = prevNext(sameLang, post);
+const related = relatedPosts(all, post, 3);
+---
+
+<PostLayout
+  post={post}
+  url={url}
+  hreflangAlternates={alternates}
+  hreflangXDefault={xDefault}
+  altLocaleHref={altLocaleHref}
+  related={related}
+  newer={newer}
+  older={older}
+>
+  <Content />
+</PostLayout>

--- a/src/pages/blog/rss.xml.js
+++ b/src/pages/blog/rss.xml.js
@@ -1,0 +1,22 @@
+import rss from "@astrojs/rss";
+import { getCollection } from "astro:content";
+import { postsForLocale, postSlug, postUrl } from "../../lib/blog";
+
+export async function GET(context) {
+  const all = await getCollection("blog");
+  const posts = postsForLocale(all, "en");
+  return rss({
+    title: "The CushLabs Blog",
+    description:
+      "AI, automation, and local growth for small businesses — in plain language.",
+    site: context.site,
+    items: posts.map((p) => ({
+      title: p.data.title,
+      description: p.data.excerpt,
+      pubDate: p.data.publishDate,
+      link: postUrl("en", postSlug(p)),
+      categories: p.data.categories,
+    })),
+    customData: "<language>en-US</language>",
+  });
+}

--- a/src/pages/es/blog/[...page].astro
+++ b/src/pages/es/blog/[...page].astro
@@ -1,0 +1,27 @@
+---
+import type { GetStaticPaths } from "astro";
+import { getCollection } from "astro:content";
+import BlogIndex from "../../../components/blog/BlogIndex.astro";
+import { postsForLocale } from "../../../lib/blog";
+import { blogCategories } from "../../../data/blogCategories";
+
+export const getStaticPaths = (async ({ paginate }) => {
+  const all = await getCollection("blog");
+  return paginate(postsForLocale(all, "es"), { pageSize: 6 });
+}) satisfies GetStaticPaths;
+
+const { page } = Astro.props;
+const all = await getCollection("blog");
+const esPosts = postsForLocale(all, "es");
+const categoriesInUse = blogCategories
+  .map((c) => c.key)
+  .filter((k) => esPosts.some((p) => p.data.categories.includes(k)));
+---
+
+<BlogIndex
+  locale="es"
+  posts={page.data}
+  categoriesInUse={categoriesInUse}
+  page={{ current: page.currentPage, last: page.lastPage, prevUrl: page.url.prev, nextUrl: page.url.next }}
+  canonical={page.url.current}
+/>

--- a/src/pages/es/blog/[slug].astro
+++ b/src/pages/es/blog/[slug].astro
@@ -1,0 +1,51 @@
+---
+import type { GetStaticPaths } from "astro";
+import { getCollection, render } from "astro:content";
+import PostLayout from "../../../components/blog/PostLayout.astro";
+import {
+  postsForLocale,
+  postLang,
+  postSlug,
+  postUrl,
+  blogIndexUrl,
+  postHreflangs,
+  relatedPosts,
+  prevNext,
+  extractSlug,
+} from "../../../lib/blog";
+
+export const getStaticPaths = (async () => {
+  const all = await getCollection("blog");
+  return all
+    .filter((p) => postLang(p) === "es" && p.data.publish !== false)
+    .map((post) => ({ params: { slug: postSlug(post) }, props: { post } }));
+}) satisfies GetStaticPaths;
+
+const { post } = Astro.props;
+const all = await getCollection("blog");
+const SITE = "https://www.cushlabs.ai";
+const { Content } = await render(post);
+
+const url = `${SITE}${postUrl("es", postSlug(post))}`;
+const { alternates, xDefault } = postHreflangs(post, SITE);
+
+const twinSlug = extractSlug(post.data.translations?.en);
+const altLocaleHref = { en: twinSlug ? postUrl("en", twinSlug) : blogIndexUrl("en") };
+
+const sameLang = postsForLocale(all, "es");
+const { newer, older } = prevNext(sameLang, post);
+const related = relatedPosts(all, post, 3);
+---
+
+<PostLayout
+  post={post}
+  url={url}
+  hreflangAlternates={alternates}
+  hreflangXDefault={xDefault}
+  altLocaleHref={altLocaleHref}
+  related={related}
+  newer={newer}
+  older={older}
+>
+  <Content />
+</PostLayout>

--- a/src/pages/es/blog/rss.xml.js
+++ b/src/pages/es/blog/rss.xml.js
@@ -1,0 +1,22 @@
+import rss from "@astrojs/rss";
+import { getCollection } from "astro:content";
+import { postsForLocale, postSlug, postUrl } from "../../../lib/blog";
+
+export async function GET(context) {
+  const all = await getCollection("blog");
+  const posts = postsForLocale(all, "es");
+  return rss({
+    title: "Blog de CushLabs",
+    description:
+      "IA, automatización y crecimiento local para negocios pequeños — en palabras simples.",
+    site: context.site,
+    items: posts.map((p) => ({
+      title: p.data.title,
+      description: p.data.excerpt,
+      pubDate: p.data.publishDate,
+      link: postUrl("es", postSlug(p)),
+      categories: p.data.categories,
+    })),
+    customData: "<language>es-MX</language>",
+  });
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,24 +1,25 @@
 /* Google Fonts loaded via <link> in BaseLayout.astro for non-blocking render */
 
 @import "tailwindcss";
+@plugin "@tailwindcss/typography";
 
 /* Dark mode via class strategy */
 @custom-variant dark (&:where(.dark, .dark *));
 
 /* ── Theme tokens (static colors, fonts, sizes) ── */
 @theme {
-  --color-cush-orange: #FF6A3D;
+  --color-cush-orange: #ff6a3d;
   --color-cush-black: #000000;
-  --color-cush-gray-900: #0A0A0A;
+  --color-cush-gray-900: #0a0a0a;
   --color-cush-gray-800: #141414;
-  --color-cush-gray-700: #1A1A1A;
-  --color-cush-gray-600: #2A2A2A;
+  --color-cush-gray-700: #1a1a1a;
+  --color-cush-gray-600: #2a2a2a;
   --color-cush-gray-400: #666666;
   --color-cush-gray-300: #888888;
-  --color-cush-gray-200: #AAAAAA;
+  --color-cush-gray-200: #aaaaaa;
 
-  --font-display: 'Space Grotesk', sans-serif;
-  --font-body: 'Source Serif 4', Georgia, serif;
+  --font-display: "Space Grotesk", sans-serif;
+  --font-body: "Source Serif 4", Georgia, serif;
 
   --text-fluid-xs: var(--fluid-text-xs);
   --text-fluid-sm: var(--fluid-text-sm);
@@ -110,8 +111,12 @@ body {
 
 /* Shimmer placeholder for lazy-loaded images */
 @keyframes shimmer {
-  0% { background-position: -200% 0; }
-  100% { background-position: 200% 0; }
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
 }
 
 .shimmer {


### PR DESCRIPTION
Re-introduces a blog on cushlabs.ai — this time with a **content strategy** (the reason it was removed pre-launch). Ports the proven NY English blog engine with the **hybrid content model** from `docs/strategy/BLOG-HYBRID-ARCHITECTURE-PROPOSAL.md`.

## The model
Two native-language tracks (ES/MX primary, EN/US secondary) + periodic fully-bilingual **cornerstones**. A post's mode = whether it has a reciprocal `translations` twin. No forced 1:1 parity.

## What's built
- **Content collection** (`src/content.config.ts`) — one flat `blog`, language from `en/`|`es/` id prefix.
- **Routes** — `/blog/` (EN, unprefixed) + `/es/blog/`, index+pagination (`[...page]`) and detail (`[slug]`) per language, RSS per track.
- **Conditional hreflang** (the correctness crux) — single-language posts emit **self only** (no pointer to a non-existent twin); cornerstones emit the reciprocal `en-US`↔`es-MX` pair. Verified in built HTML + sitemap.
- **Language switcher** falls back to the other-language index on single-language posts (no 404).
- **JSON-LD** — Article + Breadcrumb + conditional FAQPage, referencing the global Org/Person `@id`s.
- **Sitemap** derives cornerstone pairs from EN frontmatter (single source of truth — avoids NY English's hand-maintained-map debt).
- **Build gate** — `validate-blog-translations.mjs` fails on broken/non-reciprocal cornerstone links.
- **Tailwind 4** typography via `@plugin`.

## Content (3 sample posts, all modes)
- ES-only: `mas-citas-desde-facebook` · EN-only: `facebook-leads-after-6pm` · Cornerstone (bilingual + FAQ): `turn-messenger-into-sales-channel` / `messenger-canal-de-ventas`. es-MX throughout.

## Decisions locked (from the collab)
Sales-enablement goal · ES/MX-first · aggressive cadence (held to a per-piece quality bar) · named-author (Person schema).

## Verified
- `npm run build` green; meta-description-gate passes all 117 HTML pages; translation validator passes.
- hreflang correctness confirmed in built HTML for all 3 modes (self-only vs paired).
- Visual QA: index + post render clean, on-brand, bilingual nav.

## Follow-ups (NOT in this PR)
- Add a **Blog** link to header nav + it's already in footer? (add nav entry)
- Submit blog URLs to GSC/IndexNow; add `bing-submit.mjs`
- Per-post featured images (posts currently use a branded gradient placeholder)
- Category archive pages (client-side filter only for now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)