### PR TITLE
fix(blog): remove stale /blog→/portfolio redirects blocking relaunch

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -56,36 +56,6 @@
       "source": "/es/servicios/",
       "destination": "/es/services/",
       "permanent": true
-    },
-    {
-      "source": "/blog",
-      "destination": "/portfolio/",
-      "permanent": true
-    },
-    {
-      "source": "/blog/",
-      "destination": "/portfolio/",
-      "permanent": true
-    },
-    {
-      "source": "/blog/:path*",
-      "destination": "/portfolio/",
-      "permanent": true
-    },
-    {
-      "source": "/es/blog",
-      "destination": "/es/portfolio/",
-      "permanent": true
-    },
-    {
-      "source": "/es/blog/",
-      "destination": "/es/portfolio/",
-      "permanent": true
-    },
-    {
-      "source": "/es/blog/:path*",
-      "destination": "/es/portfolio/",
-      "permanent": true
     }
   ],
   "headers": [


### PR DESCRIPTION
## Problem

The bilingual blog relaunched in #168, but its **index pages and both RSS feeds were 308-redirecting to `/portfolio/`** in production:

- `https://cushlabs.ai/blog/` → `/portfolio/`
- `https://cushlabs.ai/es/blog/` → `/es/portfolio/`
- `https://cushlabs.ai/blog/rss.xml` → `/portfolio/`
- `https://cushlabs.ai/es/blog/rss.xml` → `/es/portfolio/`

Post detail pages served fine (200), so the relaunch looked live but the entry points were unreachable.

## Root cause

When the old blog was removed pre-launch, six `permanent` (308) redirects were added to `vercel.json` pointing `/blog*` and `/es/blog*` at `/portfolio/`. Those were never removed, so they intercepted the relaunched routes.

## Fix

Removed all six stale blog redirects from `vercel.json`. No other redirects touched.

## Verification

Local build green (119 pages, all blog routes + RSS emitted). Will confirm 200s on production after this merges and deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)