### PR TITLE
fix(pricing): align public site with what we can actually deliver

### DIFF
--- a/docs/strategy/ADVERTISED-COMMITMENTS.md
+++ b/docs/strategy/ADVERTISED-COMMITMENTS.md
@@ -95,9 +95,9 @@ Three tiers. One flat monthly price each. **Per business, includes up to 2 locat
 ### 2.2 Universal terms (apply to every tier)
 
 - **Locations:** every plan includes **up to 2 locations**; additional locations **+$690 MXN/mo** ( **+$49 USD/mo** ) each.
-- **No setup fee. No contracts. 2-week free trial. Unlimited conversations (fair use).**
-- **Payment (MXN):** SPEI or OXXO; **CFDI invoice included.**
-- **Payment (USD):** card; invoice included.
+- **No setup fee. No contracts. 1-week free trial. Unlimited conversations (fair use).**
+- **Payment (MXN):** bank transfer (SPEI); **CFDI invoice included.** (OXXO = roadmap via Mercado Pago; not live.)
+- **Payment (USD):** bank transfer; invoice included.
 
 ### 2.3 Currency rule (do not break this)
 
@@ -200,7 +200,7 @@ two demo bots `m.me/cushlabs` and `m.me/nyenglishteacher`).
 ### 5.1 The four guarantees (`Guarantee.astro`)
 
 1. **Free discovery call** — 30 min; honest fit assessment; "no hard sell, ever."
-2. **Free 2-week trial** — no setup fee, no deposit; client pays nothing until it works as agreed.
+2. **Free 1-week trial** — no setup fee, no deposit; client pays nothing until it works as agreed.
 3. **Month-to-month, cancel anytime** — no lock-in; 30 days' notice; no penalty.
 4. **Client owns their data & system** — full documentation, access credentials, code where applicable; fully portable.
 
@@ -375,7 +375,7 @@ directly. Do the following to establish durable connectivity:
 8. **Answer "what do we charge 1,990 pesos for?" from §2.1 Basic**, not from memory: AI Messenger
    Assistant (24/7, the full §4 feature set) + Google review management (owner-approved) + owner lead
    alerts + fully-managed (setup/training/support), per business incl. up to 2 locations, no setup fee,
-   no contract, 2-week free trial, unlimited conversations (fair use), CFDI invoice.
+   no contract, 1-week free trial, unlimited conversations (fair use), CFDI invoice.
 
 **Sync protocol going forward:** any change to price, a guarantee, or an advertised feature is made in
 the marketing repo **and** reflected here in the _same_ PR; then this file's `Last reconciled` date is

--- a/src/components/home2/FAQ.astro
+++ b/src/components/home2/FAQ.astro
@@ -13,7 +13,7 @@ const content = {
     faqs: [
       {
         q: "How much does this cost? Is it SMB-affordable?",
-        a: "Plans start at $1,990 MXN/mo (Basic) and go up to $5,490 (Ultra) — see the full breakdown on the Pricing page. Everything's a simple monthly subscription: no setup fees, no contracts, and a free 2-week trial. The discovery call is free — I'll recommend the right plan before you commit to anything."
+        a: "Plans start at $1,990 MXN/mo (Basic) and go up to $5,490 (Ultra) — see the full breakdown on the Pricing page. Everything's a simple monthly subscription: no setup fees, no contracts, and a free 1-week trial. The discovery call is free — I'll recommend the right plan before you commit to anything."
       },
       {
         q: "How long does implementation take?",
@@ -44,7 +44,7 @@ const content = {
     faqs: [
       {
         q: "¿Cuánto cuesta esto? ¿Es asequible para PYMES?",
-        a: "Los planes comienzan en $1,990 MXN/mes (Básico) y llegan hasta $5,490 (Ultra) — puedes ver el desglose completo en la página de Precios. Todo es una suscripción mensual simple: sin cuotas de instalación, sin contratos y con prueba gratis de 2 semanas. La llamada de descubrimiento es gratuita — te recomiendo el plan correcto antes de que te comprometas a nada."
+        a: "Los planes comienzan en $1,990 MXN/mes (Básico) y llegan hasta $5,490 (Ultra) — puedes ver el desglose completo en la página de Precios. Todo es una suscripción mensual simple: sin cuotas de instalación, sin contratos y con prueba gratis de 1 semana. La llamada de descubrimiento es gratuita — te recomiendo el plan correcto antes de que te comprometas a nada."
       },
       {
         q: "¿Cuánto tiempo toma la implementación?",

--- a/src/components/home2/Guarantee.astro
+++ b/src/components/home2/Guarantee.astro
@@ -20,8 +20,8 @@ const content = {
       },
       {
         number: '2',
-        title: 'Start With a Free 2-Week Trial.',
-        body: 'No setup fee, no deposit. I build your assistant and you watch it work for two full weeks before you pay anything. If it isn\'t answering customers and capturing leads the way we agreed, you walk away owing nothing.',
+        title: 'Start With a Free 1-Week Trial.',
+        body: 'No setup fee, no deposit. I build your assistant and you watch it work for one full week before you pay anything. If it isn\'t answering customers and capturing leads the way we agreed, you walk away owing nothing.',
       },
       {
         number: '3',
@@ -51,8 +51,8 @@ const content = {
       },
       {
         number: '2',
-        title: 'Empieza con una Prueba Gratis de 2 Semanas.',
-        body: 'Sin cuota de instalación, sin depósito. Construyo tu asistente y lo ves funcionando durante dos semanas completas antes de pagar nada. Si no está contestando clientes y capturando leads como acordamos, te retiras sin deber nada.',
+        title: 'Empieza con una Prueba Gratis de 1 Semana.',
+        body: 'Sin cuota de instalación, sin depósito. Construyo tu asistente y lo ves funcionando durante una semana completa antes de pagar nada. Si no está contestando clientes y capturando leads como acordamos, te retiras sin deber nada.',
       },
       {
         number: '3',

--- a/src/components/home2/Hero.astro
+++ b/src/components/home2/Hero.astro
@@ -16,7 +16,7 @@ const content = {
     trustStrip: [
       '35+ projects shipped',
       'Native bilingual EN/ES',
-      'Free 2-week trial',
+      'Free 1-week trial',
       'Live demo below ↓',
     ],
     ctaPrimary: 'Book a Free 30-min Call',
@@ -32,7 +32,7 @@ const content = {
     trustStrip: [
       '35+ proyectos entregados',
       'Bilingüe EN/ES nativo',
-      'Prueba gratis de 2 semanas',
+      'Prueba gratis de 1 semana',
       'Demo en vivo aquí abajo ↓',
     ],
     ctaPrimary: 'Agendar Llamada Gratis — 30 min',

--- a/src/components/pricing/PricingSection.astro
+++ b/src/components/pricing/PricingSection.astro
@@ -77,8 +77,8 @@ const copy = {
       usd: "Every plan includes up to 2 locations · additional locations +$49 USD/mo each",
     },
     notes: {
-      mxn: "No setup fee · No contracts · 2-week free trial · Unlimited conversations (fair use) · Pay via SPEI or OXXO · CFDI invoice included",
-      usd: "No setup fee · No contracts · 2-week free trial · Unlimited conversations (fair use) · Pay by card · Invoice included",
+      mxn: "No setup fee · No contracts · 1-week free trial · Unlimited conversations (fair use) · Pay by bank transfer · CFDI invoice included",
+      usd: "No setup fee · No contracts · 1-week free trial · Unlimited conversations (fair use) · Pay by bank transfer · Invoice included",
     },
     footerQ: "Need something custom?",
     footerLink: "Let's talk",
@@ -142,8 +142,8 @@ const copy = {
       usd: "Todos los planes incluyen hasta 2 sucursales · sucursales adicionales +$49 USD/mes cada una",
     },
     notes: {
-      mxn: "Sin cuota de instalación · Sin contratos · Prueba gratis de 2 semanas · Conversaciones ilimitadas (uso justo) · Pago con SPEI u OXXO · Factura (CFDI) incluida",
-      usd: "Sin cuota de instalación · Sin contratos · Prueba gratis de 2 semanas · Conversaciones ilimitadas (uso justo) · Pago con tarjeta · Factura incluida",
+      mxn: "Sin cuota de instalación · Sin contratos · Prueba gratis de 1 semana · Conversaciones ilimitadas (uso justo) · Pago por transferencia bancaria · Factura (CFDI) incluida",
+      usd: "Sin cuota de instalación · Sin contratos · Prueba gratis de 1 semana · Conversaciones ilimitadas (uso justo) · Pago por transferencia bancaria · Factura incluida",
     },
     footerQ: "¿Necesitas algo a la medida?",
     footerLink: "Hablemos",

--- a/src/components/services2/FAQ.astro
+++ b/src/components/services2/FAQ.astro
@@ -12,7 +12,7 @@ const content = {
     heading: "Services FAQ",
     faqs: [
       {
-        q: "How does the free 2-week trial work?",
+        q: "How does the free 1-week trial work?",
         a: "I build and launch your AI system during the trial — you see it working with real customers before you pay anything. If you're not happy with the results, you walk away. No invoice, no awkward conversation. If you decide to continue, your monthly billing starts after the trial ends."
       },
       {
@@ -49,7 +49,7 @@ const content = {
     heading: "Preguntas Frecuentes",
     faqs: [
       {
-        q: "¿Cómo funciona la prueba gratis de 2 semanas?",
+        q: "¿Cómo funciona la prueba gratis de 1 semana?",
         a: "Construyo y lanzo tu sistema de IA durante la prueba — lo ves trabajando con clientes reales antes de pagar nada. Si no estás contento con los resultados, te vas sin compromiso. Sin factura, sin conversación incómoda. Si decides continuar, la facturación mensual empieza al terminar la prueba."
       },
       {

--- a/src/components/services2/FinalCTA.astro
+++ b/src/components/services2/FinalCTA.astro
@@ -10,21 +10,21 @@ const { locale } = Astro.props;
 const content = {
   en: {
     heading: "Stop Losing Customers. Start Your Free Trial.",
-    body: "Book a free 30-minute discovery call. I'll assess your situation, recommend the right service, and if we're a fit — your 2-week free trial starts immediately.\n\nNo jargon. No pressure. No commitment until you've seen it working.",
+    body: "Book a free 30-minute discovery call. I'll assess your situation, recommend the right service, and if we're a fit — your 1-week free trial starts immediately.\n\nNo jargon. No pressure. No commitment until you've seen it working.",
     primaryCta: "Start Free Trial",
     primaryLink: "/consultation/",
     secondaryCta: "Have questions? See the FAQ →",
     secondaryLink: "#faq",
-    footer: "I respond within 24 hours · Free 2-week trial · Cancel anytime"
+    footer: "I respond within 24 hours · Free 1-week trial · Cancel anytime"
   },
   es: {
     heading: "Deja de Perder Clientes. Empieza Tu Prueba Gratis.",
-    body: "Agenda una llamada gratuita de 30 minutos. Evalúo tu situación, recomiendo el servicio correcto, y si hacemos match — tu prueba gratis de 2 semanas empieza de inmediato.\n\nSin tecnicismos. Sin presión. Sin compromiso hasta que lo veas funcionando.",
+    body: "Agenda una llamada gratuita de 30 minutos. Evalúo tu situación, recomiendo el servicio correcto, y si hacemos match — tu prueba gratis de 1 semana empieza de inmediato.\n\nSin tecnicismos. Sin presión. Sin compromiso hasta que lo veas funcionando.",
     primaryCta: "Empezar Prueba Gratis",
     primaryLink: "/es/reservar/",
     secondaryCta: "¿Tienes preguntas? Ve las FAQ →",
     secondaryLink: "#faq",
-    footer: "Respondo en < 24 horas · Prueba gratis de 2 semanas · Cancela cuando quieras"
+    footer: "Respondo en < 24 horas · Prueba gratis de 1 semana · Cancela cuando quieras"
   }
 };
 

--- a/src/components/services2/Hero.astro
+++ b/src/components/services2/Hero.astro
@@ -12,14 +12,14 @@ const content = {
     headline: "You're Losing Customers Right Now. I Fix That With AI.",
     subheadline1: "Unanswered messages. Invisible Google rankings. Manual busywork eating your team's time. I build AI systems that solve these problems — and you only pay monthly for what's working.",
     subheadline2: "",
-    cta: "Start Your Free 2-Week Trial",
+    cta: "Start Your Free 1-Week Trial",
     ctaLink: "/consultation/"
   },
   es: {
     headline: "Estás Perdiendo Clientes Ahora Mismo. Lo Resuelvo con IA.",
     subheadline1: "Mensajes sin contestar. Invisible en Google Maps. Trabajo manual que consume a tu equipo. Construyo sistemas de IA que resuelven estos problemas — y solo pagas mensualmente por lo que funciona.",
     subheadline2: "",
-    cta: "Empieza Tu Prueba Gratis de 2 Semanas",
+    cta: "Empieza Tu Prueba Gratis de 1 Semana",
     ctaLink: "/es/reservar/"
   }
 };

--- a/src/components/services2/HowIWork.astro
+++ b/src/components/services2/HowIWork.astro
@@ -17,7 +17,7 @@ const content = {
         desc: "I assess your situation, identify the highest-impact opportunity, and recommend the right starting point. No commitment. If AI isn't the right answer for your business, I'll tell you — and I won't charge you for the honesty."
       },
       {
-        title: "Step 2: Free 2-Week Trial",
+        title: "Step 2: Free 1-Week Trial",
         desc: "I build and launch your AI system at no cost. You see it working with real customers on your real channels before you pay a cent. If it doesn't deliver, you walk away. No hard feelings, no invoice."
       },
       {
@@ -41,7 +41,7 @@ const content = {
         desc: "Evalúo tu situación, identifico la oportunidad de mayor impacto y recomiendo el punto de partida correcto. Sin compromiso. Si la IA no es lo indicado para tu negocio, te lo diré — y no te cobro por la honestidad."
       },
       {
-        title: "Paso 2: Prueba Gratis de 2 Semanas",
+        title: "Paso 2: Prueba Gratis de 1 Semana",
         desc: "Construyo y lanzo tu sistema de IA sin costo. Lo ves trabajando con clientes reales en tus canales reales antes de pagar un peso. Si no entrega, te vas sin compromiso. Sin resentimientos, sin factura."
       },
       {

--- a/src/components/services2/ServiceBlock.astro
+++ b/src/components/services2/ServiceBlock.astro
@@ -33,7 +33,7 @@ const data = {
       ],
       timeline: "Fast setup — often live within days of your intake form. Discovery call → training → testing → launch.",
       investment: "Included in every plan — from **$1,990 MXN/mo**. Unlimited conversations (fair use), fully managed. Includes setup, training, weekly reports, and monthly tuning. No setup fee. No contract.",
-      investmentDisclaimer: "Free 2-week trial. Cancel anytime.",
+      investmentDisclaimer: "Free 1-week trial. Cancel anytime.",
       bestFor: [
         "Customer support teams handling 500+ inquiries/month",
         "Businesses losing leads after hours or on weekends",
@@ -62,7 +62,7 @@ const data = {
       ],
       timeline: "Configuración rápida — en vivo pocos días después de tu formulario. Llamada → entrenamiento → pruebas → lanzamiento.",
       investment: "Incluido en todos los planes — desde **$1,990 MXN/mes**. Conversaciones ilimitadas (uso justo), totalmente gestionado. Incluye configuración, entrenamiento, reportes semanales y ajuste mensual. Sin cuota de instalación. Sin contrato.",
-      investmentDisclaimer: "Prueba gratis de 2 semanas. Cancela cuando quieras.",
+      investmentDisclaimer: "Prueba gratis de 1 semana. Cancela cuando quieras.",
       bestFor: [
         "Equipos de atención al cliente que manejan más de 500 consultas al mes",
         "Negocios que pierden leads fuera de horario o en fines de semana",
@@ -95,7 +95,7 @@ const data = {
       ],
       timeline: "Fast setup — often live within days of your intake form. Discovery call → training → testing → launch.",
       investment: "Included in every plan — from **$1,990 MXN/mo**. Single page, unlimited conversations (fair use), fully managed. Includes setup, training, weekly reports, and monthly tuning. No setup fee. No contract.",
-      investmentDisclaimer: "Free 2-week trial. Cancel anytime.",
+      investmentDisclaimer: "Free 1-week trial. Cancel anytime.",
       bestFor: [
         "Local businesses losing leads to slow response times",
         "Owners drowning in repeat questions on Facebook Messenger",
@@ -124,7 +124,7 @@ const data = {
       ],
       timeline: "Configuración rápida — en vivo pocos días después de tu formulario. Llamada de descubrimiento → entrenamiento → pruebas → lanzamiento.",
       investment: "Incluido en todos los planes — desde **$1,990 MXN/mes**. Una sola página, conversaciones ilimitadas (uso justo), totalmente gestionado. Incluye configuración, entrenamiento, reportes semanales y ajuste mensual. Sin cuota de instalación. Sin contrato.",
-      investmentDisclaimer: "Prueba gratis de 2 semanas. Cancela cuando quieras.",
+      investmentDisclaimer: "Prueba gratis de 1 semana. Cancela cuando quieras.",
       bestFor: [
         "Negocios locales perdiendo clientes por respuestas lentas",
         "Dueños ahogados en preguntas repetitivas en Facebook Messenger",
@@ -155,7 +155,7 @@ const data = {
       ],
       timeline: "First report in 1 week. Discovery call → setup → first Monday delivery.",
       investment: "Included from the **Premium plan — $3,490 MXN/mo**. Fully managed — I handle setup, monitoring, and weekly delivery. No setup fee. No contract.",
-      investmentDisclaimer: "Free 2-week trial. Cancel anytime.",
+      investmentDisclaimer: "Free 1-week trial. Cancel anytime.",
       bestFor: [
         "Businesses with 2+ locations competing on Google Maps",
         "Owners who want to know their competitive position without becoming SEO experts",
@@ -184,7 +184,7 @@ const data = {
       ],
       timeline: "Primer reporte en 1 semana. Llamada de descubrimiento → configuración → primera entrega el lunes.",
       investment: "Incluido desde el **plan Premium — $3,490 MXN/mes**. Totalmente gestionado — me encargo de la configuración, el monitoreo y la entrega semanal. Sin cuota de instalación. Sin contrato.",
-      investmentDisclaimer: "Prueba gratis de 2 semanas. Cancela cuando quieras.",
+      investmentDisclaimer: "Prueba gratis de 1 semana. Cancela cuando quieras.",
       bestFor: [
         "Negocios con 2+ ubicaciones compitiendo en Google Maps",
         "Dueños que quieren conocer su posición competitiva sin volverse expertos en SEO",
@@ -220,7 +220,7 @@ const data = {
       ],
       timeline: "Fast setup — live soon after your intake form. Discovery call → voice setup → testing → launch.",
       investment: "Included in the **Ultra plan — $5,490 MXN/mo**. 300 answered minutes, setup, training, and monthly reports. Overage at $8.50 MXN/min. No setup fee. No contract.",
-      investmentDisclaimer: "Free 2-week trial. Cancel anytime.",
+      investmentDisclaimer: "Free 1-week trial. Cancel anytime.",
       bestFor: [
         "Service businesses missing calls during busy hours (salons, clinics, contractors)",
         "Small teams with no dedicated receptionist",
@@ -250,7 +250,7 @@ const data = {
       ],
       timeline: "Configuración rápida — en vivo poco después de tu formulario. Llamada → configuración de voz → pruebas → lanzamiento.",
       investment: "Incluido en el **plan Ultra — $5,490 MXN/mes**. 300 minutos contestados, configuración, entrenamiento y reportes mensuales. Excedente a $8.50 MXN/min. Sin cuota de instalación. Sin contrato.",
-      investmentDisclaimer: "Prueba gratis de 2 semanas. Cancela cuando quieras.",
+      investmentDisclaimer: "Prueba gratis de 1 semana. Cancela cuando quieras.",
       bestFor: [
         "Negocios de servicio que pierden llamadas en horas pico (salones, clínicas, contratistas)",
         "Equipos pequeños sin recepcionista dedicada",

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -47,7 +47,7 @@ const content = {
         },
         {
           title: "Simple Monthly Pricing, No Surprises",
-          description: "One flat monthly price you know upfront — no hourly billing that spirals, no scope creep, no mystery invoices. Start with a free 2-week trial before you commit.",
+          description: "One flat monthly price you know upfront — no hourly billing that spirals, no scope creep, no mystery invoices. Start with a free 1-week trial before you commit.",
         },
         {
           title: "Fast Delivery",

--- a/src/pages/es/about.astro
+++ b/src/pages/es/about.astro
@@ -41,7 +41,7 @@ const content = {
     title: "Cómo Trabajo Diferente",
     items: [
       { title: "Práctico Sobre Perfecto", description: "Construyo soluciones que funcionan en el mundo real, no demos impresionantes que fallan en producción. Obtienes herramientas que tu equipo realmente usará." },
-      { title: "Precios Mensuales Simples, Sin Sorpresas", description: "Un precio mensual fijo que conoces desde el inicio — sin facturación por hora que se dispara, sin cambios de alcance, sin facturas misteriosas. Empieza con una prueba gratis de 2 semanas antes de comprometerte." },
+      { title: "Precios Mensuales Simples, Sin Sorpresas", description: "Un precio mensual fijo que conoces desde el inicio — sin facturación por hora que se dispara, sin cambios de alcance, sin facturas misteriosas. Empieza con una prueba gratis de 1 semana antes de comprometerte." },
       { title: "Entrega Rápida", description: "La mayoría de las configuraciones se lanzan en días, no semanas. Verás software funcionando rápidamente — no meses de planeación y reuniones." },
       { title: "Tú Eres Dueño de Todo", description: "Documentación completa, código limpio, sin dependencia de proveedor. Si nos separamos, te quedas con todo lo que construí." },
     ],

--- a/src/pages/es/messenger-assistant.astro
+++ b/src/pages/es/messenger-assistant.astro
@@ -354,7 +354,7 @@ const themes = [
                 Incluido en <span class="text-white font-bold">todos los planes — desde $1,990 MXN/mes</span>. Una sola página, conversaciones ilimitadas (uso justo), totalmente gestionado. Incluye configuración, entrenamiento, reportes semanales y ajuste mensual. Sin cuota de instalación. Sin contrato.
               </div>
             </div>
-            <p class="text-xs text-cush-orange font-medium mt-4 italic">Prueba gratis de 2 semanas. Cancela cuando quieras.</p>
+            <p class="text-xs text-cush-orange font-medium mt-4 italic">Prueba gratis de 1 semana. Cancela cuando quieras.</p>
             <div class="mt-8">
               <a href="/es/reservar/" class="block w-full text-center px-6 py-3 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-colors duration-300">
                 Agendar Llamada
@@ -482,7 +482,7 @@ const themes = [
             href="/es/reservar/"
             class="inline-flex items-center gap-2 px-8 py-4 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-all duration-300 shadow-lg shadow-cush-orange/25 hover:shadow-xl text-lg"
           >
-            Empieza Tu Prueba Gratis de 2 Semanas
+            Empieza Tu Prueba Gratis de 1 Semana
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
             </svg>

--- a/src/pages/es/messenger-assistant/connect.astro
+++ b/src/pages/es/messenger-assistant/connect.astro
@@ -7,7 +7,7 @@ const OAUTH_START_URL = "https://messenger.cushlabs.ai/oauth/start?lang=es";
 const steps = [
   { n: 1, title: "Conecta tu página de Facebook", desc: "Autoriza a CushLabs para recibir y responder mensajes en la página de Facebook que elijas." },
   { n: 2, title: "Configuramos tu negocio", desc: "Subimos tus servicios, precios y preguntas frecuentes y afinamos al asistente con tu voz. Tiempo típico: 5 días hábiles." },
-  { n: 3, title: "Prueba gratis de 2 semanas", desc: "Tu asistente entra en producción en tu página. Lo ves trabajar. Si no se gana su lugar, nos despedimos como amigos." },
+  { n: 3, title: "Prueba gratis de 1 semana", desc: "Tu asistente entra en producción en tu página. Lo ves trabajar. Si no se gana su lugar, nos despedimos como amigos." },
   { n: 4, title: "Ajuste mensual", desc: "Reportes semanales de desempeño. Ajuste mensual conforme tu negocio evoluciona." },
 ];
 

--- a/src/pages/es/messenger-assistant/connected.astro
+++ b/src/pages/es/messenger-assistant/connected.astro
@@ -54,7 +54,7 @@ import Container from "../../../components/layout/Container.astro";
             </li>
             <li class="flex gap-3">
               <span class="text-cush-orange font-display font-bold">3.</span>
-              <span>Tu asistente entra en producción en tu página en 5 días hábiles. Comienza la prueba gratis de 2 semanas.</span>
+              <span>Tu asistente entra en producción en tu página en 5 días hábiles. Comienza la prueba gratis de 1 semana.</span>
             </li>
           </ol>
         </div>

--- a/src/pages/es/services.astro
+++ b/src/pages/es/services.astro
@@ -12,7 +12,7 @@ import FinalCTA from "../../components/services2/FinalCTA.astro";
 const locale = "es" as const;
 
 const title = "Servicios de IA — Messenger, Voz y Automatización | CushLabs";
-const description = "Asistente de IA para Facebook Messenger, inteligencia competitiva en Google Maps, chatbots web y agentes de voz. Bilingüe. Prueba gratis 2 semanas.";
+const description = "Asistente de IA para Facebook Messenger, inteligencia competitiva en Google Maps, chatbots web y agentes de voz. Bilingüe. Prueba gratis 1 semana.";
 ---
 
 <BaseLayout title={title} description={description}>

--- a/src/pages/es/voice-agent.astro
+++ b/src/pages/es/voice-agent.astro
@@ -57,7 +57,7 @@ const bestFor = [
           Un agente de voz con IA disponible 24/7 que contesta el teléfono de tu negocio con voz natural — agenda citas, captura leads y nunca manda a un cliente al buzón.
         </p>
         <p class="text-fluid-base text-gray-500 dark:text-gray-400 mb-10 max-w-2xl mx-auto leading-relaxed">
-          Bilingüe EN/ES. Totalmente gestionado. Configuración rápida. Prueba gratis de 2 semanas.
+          Bilingüe EN/ES. Totalmente gestionado. Configuración rápida. Prueba gratis de 1 semana.
         </p>
 
         <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
@@ -201,7 +201,7 @@ const bestFor = [
                 Incluido en el <span class="text-white font-bold text-2xl">plan Ultra — $5,490 MXN/mes</span>. 300 minutos contestados, configuración, entrenamiento y reportes mensuales. Excedente a $8.50 MXN/min. Sin cuota de instalación. Sin contrato.
               </div>
             </div>
-            <p class="text-xs text-cush-orange font-medium mt-4 italic">Prueba gratis de 2 semanas. Cancela cuando quieras.</p>
+            <p class="text-xs text-cush-orange font-medium mt-4 italic">Prueba gratis de 1 semana. Cancela cuando quieras.</p>
             <div class="mt-8 space-y-3">
               <a href="/es/reservar/" class="block w-full text-center px-6 py-3 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-colors duration-300">
                 Agendar Llamada
@@ -308,7 +308,7 @@ const bestFor = [
             href="/es/reservar/"
             class="inline-flex items-center gap-2 px-8 py-4 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-all duration-300 shadow-lg shadow-cush-orange/25 hover:shadow-xl text-lg"
           >
-            Empieza Tu Prueba Gratis de 2 Semanas
+            Empieza Tu Prueba Gratis de 1 Semana
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
             </svg>

--- a/src/pages/messenger-assistant.astro
+++ b/src/pages/messenger-assistant.astro
@@ -354,7 +354,7 @@ const themes = [
                 Included in <span class="text-white font-bold">every plan — from $1,990 MXN/mo</span>. Single page, unlimited conversations (fair use), fully managed. Includes setup, training, weekly reports, and monthly tuning. No setup fee. No contract.
               </div>
             </div>
-            <p class="text-xs text-cush-orange font-medium mt-4 italic">Free 2-week trial. Cancel anytime.</p>
+            <p class="text-xs text-cush-orange font-medium mt-4 italic">Free 1-week trial. Cancel anytime.</p>
             <div class="mt-8">
               <a href="/consultation/" class="block w-full text-center px-6 py-3 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-colors duration-300">
                 Book a Discovery Call
@@ -482,7 +482,7 @@ const themes = [
             href="/consultation/"
             class="inline-flex items-center gap-2 px-8 py-4 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-all duration-300 shadow-lg shadow-cush-orange/25 hover:shadow-xl text-lg"
           >
-            Start Your Free 2-Week Trial
+            Start Your Free 1-Week Trial
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
             </svg>

--- a/src/pages/messenger-assistant/connect.astro
+++ b/src/pages/messenger-assistant/connect.astro
@@ -10,7 +10,7 @@ const OAUTH_START_URL = "https://messenger.cushlabs.ai/oauth/start";
 const steps = [
   { n: 1, title: "Connect your Facebook Page", desc: "Authorize CushLabs to receive and respond to messages on the Facebook Page you choose." },
   { n: 2, title: "We onboard your business", desc: "We ingest your services, pricing, and FAQs and tune the assistant to your voice. Typical turnaround: 5 business days." },
-  { n: 3, title: "Free 2-week trial", desc: "Your assistant goes live on your Page. You watch it work. If it doesn't earn its keep, we part as friends." },
+  { n: 3, title: "Free 1-week trial", desc: "Your assistant goes live on your Page. You watch it work. If it doesn't earn its keep, we part as friends." },
   { n: 4, title: "We tune monthly", desc: "Weekly performance reports. Monthly tuning as your business evolves." },
 ];
 

--- a/src/pages/messenger-assistant/connected.astro
+++ b/src/pages/messenger-assistant/connected.astro
@@ -57,7 +57,7 @@ import Container from "../../components/layout/Container.astro";
             </li>
             <li class="flex gap-3">
               <span class="text-cush-orange font-display font-bold">3.</span>
-              <span>Your assistant goes live on your Page within 5 business days. Free 2-week trial begins.</span>
+              <span>Your assistant goes live on your Page within 5 business days. Free 1-week trial begins.</span>
             </li>
           </ol>
         </div>

--- a/src/pages/salones.astro
+++ b/src/pages/salones.astro
@@ -69,7 +69,7 @@ const steps = [
   },
   {
     n: "3",
-    title: "Prueba gratis de 2 semanas",
+    title: "Prueba gratis de 1 semana",
     desc: "Lo ves ganar clientas. Si no se gana su lugar, nos despedimos como amigos.",
   },
 ];
@@ -93,11 +93,11 @@ const faqs = [
   },
   {
     q: "¿Y si no me funciona?",
-    a: "Tienes 2 semanas de prueba gratis y no hay contratos. Si no te trae más clientas, lo cancelas cuando quieras.",
+    a: "Tienes 1 semana de prueba gratis y no hay contratos. Si no te trae más clientas, lo cancelas cuando quieras.",
   },
   {
     q: "¿Cómo les pago y me dan factura?",
-    a: "Pagas por SPEI u OXXO, lo que te sea más fácil. Te entregamos factura (CFDI) sin costo extra.",
+    a: "Pagas por transferencia bancaria, lo que te sea más fácil. Te entregamos factura (CFDI) sin costo extra.",
   },
   {
     q: "¿Qué necesitan de mí para empezar?",
@@ -173,7 +173,7 @@ const faqs = [
         </a>
       </div>
       <p class="mt-6 text-sm text-gray-500 dark:text-gray-400">
-        Sin instalación · Sin contratos · Prueba gratis de 2 semanas
+        Sin instalación · Sin contratos · Prueba gratis de 1 semana
       </p>
     </div>
   </section>
@@ -319,7 +319,7 @@ const faqs = [
           Sin cuota de instalación. Sin contratos. Cancela cuando quieras.
         </p>
         <p class="text-sm text-white/60 mb-8">
-          Pago con SPEI u OXXO · Factura (CFDI) incluida
+          Pago con transferencia bancaria · Factura (CFDI) incluida
         </p>
         <a
           href={whatsappLink}
@@ -327,7 +327,7 @@ const faqs = [
           rel="noopener"
           class="block w-full px-6 py-4 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-colors duration-300 text-lg"
         >
-          Empieza tu prueba gratis de 2 semanas
+          Empieza tu prueba gratis de 1 semana
         </a>
       </div>
 

--- a/src/pages/salons.astro
+++ b/src/pages/salons.astro
@@ -65,7 +65,7 @@ const steps = [
   },
   {
     n: "3",
-    title: "2-week free trial",
+    title: "1-week free trial",
     desc: "You watch it win clients. If it doesn't earn its place, we part as friends.",
   },
 ];
@@ -89,11 +89,11 @@ const faqs = [
   },
   {
     q: "What if it doesn't work for me?",
-    a: "You get a 2-week free trial and there are no contracts. If it doesn't bring you more clients, cancel anytime.",
+    a: "You get a 1-week free trial and there are no contracts. If it doesn't bring you more clients, cancel anytime.",
   },
   {
     q: "How do I pay?",
-    a: "Pay by card, monthly. An invoice is available at no extra cost.",
+    a: "Pay by bank transfer, monthly. An invoice is available at no extra cost.",
   },
   {
     q: "What do you need from me to start?",
@@ -168,7 +168,7 @@ const faqs = [
         </a>
       </div>
       <p class="mt-6 text-sm text-gray-500 dark:text-gray-400">
-        No setup fees · No contracts · 2-week free trial
+        No setup fees · No contracts · 1-week free trial
       </p>
     </div>
   </section>
@@ -314,13 +314,13 @@ const faqs = [
           No setup fee. No contracts. Cancel anytime.
         </p>
         <p class="text-sm text-white/60 mb-8">
-          Pay by card · Invoice available
+          Pay by bank transfer · Invoice available
         </p>
         <a
           href={ctaHref}
           class="block w-full px-6 py-4 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-colors duration-300 text-lg"
         >
-          Start your 2-week free trial
+          Start your 1-week free trial
         </a>
       </div>
 

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -14,11 +14,11 @@ const locale = (Astro.currentLocale === "es" ? "es" : "en") as "en" | "es";
 const meta = {
   en: {
     title: "AI Services — Messenger, Voice, Automation | CushLabs.ai",
-    description: "Facebook Messenger AI assistant, Google Maps competitive intelligence, website chatbots, and AI voice agents. Bilingual EN/ES. Free 2-week trial.",
+    description: "Facebook Messenger AI assistant, Google Maps competitive intelligence, website chatbots, and AI voice agents. Bilingual EN/ES. Free 1-week trial.",
   },
   es: {
     title: "Servicios de IA — Messenger, Voz y Automatización | CushLabs",
-    description: "Asistente de IA para Facebook Messenger, inteligencia competitiva en Google Maps, chatbots web y agentes de voz. Bilingüe. Prueba gratis 2 semanas.",
+    description: "Asistente de IA para Facebook Messenger, inteligencia competitiva en Google Maps, chatbots web y agentes de voz. Bilingüe. Prueba gratis 1 semana.",
   },
 };
 ---

--- a/src/pages/voice-agent.astro
+++ b/src/pages/voice-agent.astro
@@ -57,7 +57,7 @@ const bestFor = [
           A 24/7 AI voice agent that answers your business phone with a natural, conversational voice — books appointments, captures leads, and never sends a caller to voicemail.
         </p>
         <p class="text-fluid-base text-gray-500 dark:text-gray-400 mb-10 max-w-2xl mx-auto leading-relaxed">
-          Bilingual EN/ES. Fully managed. Fast setup. Free 2-week trial.
+          Bilingual EN/ES. Fully managed. Fast setup. Free 1-week trial.
         </p>
 
         <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
@@ -201,7 +201,7 @@ const bestFor = [
                 Included in the <span class="text-white font-bold text-2xl">Ultra plan — $5,490 MXN/month</span>. 300 answered minutes, setup, training, and monthly reports. Overage at $8.50 MXN/min. No setup fee. No contract.
               </div>
             </div>
-            <p class="text-xs text-cush-orange font-medium mt-4 italic">Free 2-week trial. Cancel anytime.</p>
+            <p class="text-xs text-cush-orange font-medium mt-4 italic">Free 1-week trial. Cancel anytime.</p>
             <div class="mt-8 space-y-3">
               <a href="/consultation/" class="block w-full text-center px-6 py-3 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-colors duration-300">
                 Book a Discovery Call
@@ -308,7 +308,7 @@ const bestFor = [
             href="/consultation/"
             class="inline-flex items-center gap-2 px-8 py-4 bg-cush-orange text-white font-display font-semibold rounded-lg hover:bg-cush-orange/90 transition-all duration-300 shadow-lg shadow-cush-orange/25 hover:shadow-xl text-lg"
           >
-            Start Your Free 2-Week Trial
+            Start Your Free 1-Week Trial
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
             </svg>


### PR DESCRIPTION
## What & why

The public marketing site advertised things we don't actually offer yet. Before Susy (Azúcar) sees the site alongside tomorrow's pitch, the copy needs to match reality.

**Two corrections, 24 files:**

1. **Free trial: 2 weeks → 1 week**, site-wide (EN "2-week" + es-MX "2 semanas" variants). Revenue-protection call — one week is enough to prove value.
2. **Payment methods: drop OXXO + card.** We can't process either yet (roadmap via Mercado Pago). Replaced with the real method — **bank transfer (SPEI)**. **CFDI invoicing stays** — that's live via the existing NY English facturación path.

## Scope guardrails

Deliberately **not** touched:
- `terms.astro` + `es/terms.astro` — legal pages, handled separately
- `salons.astro:7` — US-page comment correctly stating it has *no* SPEI/OXXO/CFDI
- `es/voice-agent.astro:273` — "1–2 semanas" is a hiring-time comparison, not a trial claim
- **Tier feature lists unchanged** — the Basic→Premium review-management redefinition is a bespoke Azúcar framing, not published to public tiers yet

Pure phrase swaps: 66 insertions / 66 deletions, no structural changes. es-MX copy verified natural ("Pago por transferencia bancaria").

## Deploy note

Live pricing — **Robert reviews & merges.** ~2 Vercel deploys (1 preview on this PR, 1 on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
