### PR TITLE
feat(blog): after-hours hero for standalone ES post (Más citas desde Facebook)

### DIFF
--- a/src/content/blog/es/mas-citas-desde-facebook.md
+++ b/src/content/blog/es/mas-citas-desde-facebook.md
@@ -6,6 +6,8 @@ categories:
   - "facebook-messenger"
   - "lead-generation"
 readingTime: "5 min de lectura"
+featuredImage: "../../../assets/blog/facebook-leads-after-6pm.webp"
+imageAlt: "Un teléfono en la recepción de un negocio local ya cerrado por la noche muestra un mensaje de Facebook Messenger —'¡Hola! ¿Tienen disponibilidad este fin de semana?'— que llega a las 9:01 p. m."
 seo:
   description: "Convierte los mensajes de Facebook de tu negocio en citas agendadas sin contratar personal ni vivir pegado al celular. Guía práctica para dueños."
 ---


### PR DESCRIPTION
Fixes the missing image on the **first ES blog card** (`/es/blog/`), which showed the "CushLabs" placeholder.

## Why it was missing
`mas-citas-desde-facebook` is a **single-language ES post** (not a twin of the EN `facebook-leads-after-6pm`), so the earlier hero passes never touched it.

## Fix
Adds `featuredImage` reusing the after-hours WebP (`facebook-leads-after-6pm.webp`). Its content — a "¿Tienen disponibilidad este fin de semana?" Messenger message arriving at 9 PM while the business is closed — maps directly onto this article's response-speed theme, and keeps the two ES cards visually distinct (card 1 = after-hours, card 2 = open salon). Mexican Professional Spanish alt text.

Single-file change, single-language ES post → no EN parity obligation.

## Verification
Build green (119 pages, meta-description gate pass). Both ES index cards now render distinct heroes; ES post page renders the hero with es-MX alt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)