### PR TITLE
feat(marketing): reflect Google auto-post + live WhatsApp alert in copy

### DIFF
--- a/src/components/pricing/PricingComparison.astro
+++ b/src/components/pricing/PricingComparison.astro
@@ -86,7 +86,7 @@ const copy: Record<
       {
         label: "Reviews & local SEO",
         rows: [
-          { label: "Google review management — with your approval", cells: [true, true, true] },
+          { label: "Google review management — approve a reply and it posts to Google automatically", cells: [true, true, true] },
           { label: "Weekly local SEO & competitor report", cells: [false, true, true] },
         ],
       },
@@ -97,9 +97,9 @@ const copy: Record<
           {
             label: "Owner lead alerts",
             cells: [
-              "Email + Messenger (WhatsApp rolling out)",
-              "Email + Messenger (WhatsApp rolling out)",
-              "Email + Messenger (WhatsApp rolling out)",
+              "Instant WhatsApp + email & Messenger",
+              "Instant WhatsApp + email & Messenger",
+              "Instant WhatsApp + email & Messenger",
             ],
           },
           { label: "Human handoff when it matters", cells: [true, true, true] },
@@ -160,8 +160,8 @@ const copy: Record<
         a: "Nothing breaks — the agent keeps answering. Extra answered minutes bill at $8.50 MXN ($0.59 USD) per minute, and we flag it for you as you approach the included 300 so there are no surprises.",
       },
       {
-        q: "When do the WhatsApp lead alerts go live?",
-        a: "You get instant lead alerts today by email and inside Messenger. Direct WhatsApp alerts are rolling out as Meta approves our messaging access — every plan gets them automatically when they land, at no price change.",
+        q: "How do I hear about a new lead?",
+        a: "The moment a lead is ready — or a conversation needs a person — you get an instant WhatsApp alert, plus email and a note inside Messenger. Included on every plan at no extra cost.",
       },
       {
         q: "Can I switch plans later?",
@@ -204,7 +204,7 @@ const copy: Record<
       {
         label: "Reseñas y SEO local",
         rows: [
-          { label: "Gestión de reseñas de Google — con tu aprobación", cells: [true, true, true] },
+          { label: "Gestión de reseñas de Google — apruebas la respuesta y se publica en Google automáticamente", cells: [true, true, true] },
           { label: "Reporte semanal de SEO local y competencia", cells: [false, true, true] },
         ],
       },
@@ -215,9 +215,9 @@ const copy: Record<
           {
             label: "Avisos de leads al dueño",
             cells: [
-              "Correo + Messenger (WhatsApp muy pronto)",
-              "Correo + Messenger (WhatsApp muy pronto)",
-              "Correo + Messenger (WhatsApp muy pronto)",
+              "WhatsApp al instante + correo y Messenger",
+              "WhatsApp al instante + correo y Messenger",
+              "WhatsApp al instante + correo y Messenger",
             ],
           },
           { label: "Transferencia a una persona cuando hace falta", cells: [true, true, true] },
@@ -281,8 +281,8 @@ const copy: Record<
         a: "Nada se detiene — el agente sigue contestando. Los minutos contestados extra se cobran a $8.50 MXN ($0.59 USD) por minuto, y te avisamos conforme te acercas a los 300 incluidos para que no haya sorpresas.",
       },
       {
-        q: "¿Cuándo se activan los avisos de leads por WhatsApp?",
-        a: "Hoy ya recibes avisos de leads al instante por correo y dentro de Messenger. Los avisos directos por WhatsApp se están activando conforme Meta aprueba nuestro acceso de mensajería — todos los planes los reciben automáticamente cuando lleguen, sin cambio de precio.",
+        q: "¿Cómo me entero de un nuevo lead?",
+        a: "En cuanto un lead está listo — o una conversación necesita a una persona — recibes una alerta al instante por WhatsApp, además de correo y un aviso dentro de Messenger. Incluido en todos los planes sin costo extra.",
       },
       {
         q: "¿Puedo cambiar de plan después?",

--- a/src/components/pricing/PricingSection.astro
+++ b/src/components/pricing/PricingSection.astro
@@ -46,8 +46,8 @@ const copy = {
         featured: false,
         features: [
           "AI assistant on Facebook Messenger (24/7)",
-          "Google review management — with your approval",
-          "Lead capture + owner notifications (instant WhatsApp alerts on the way)",
+          "Google review management — approve a reply and it posts to Google automatically",
+          "Lead capture + owner notifications (instant WhatsApp alerts)",
           "Fully managed: setup, training, ongoing support",
         ],
         cta: "Get started",
@@ -112,8 +112,8 @@ const copy = {
         featured: false,
         features: [
           "Asistente con IA en Facebook Messenger (24/7)",
-          "Gestión de reseñas de Google — con tu aprobación",
-          "Captura de leads + avisos al dueño (alertas por WhatsApp muy pronto)",
+          "Gestión de reseñas de Google — apruebas la respuesta y se publica en Google automáticamente",
+          "Captura de leads + avisos al dueño (alertas por WhatsApp al instante)",
           "Todo gestionado: configuración, entrenamiento y soporte",
         ],
         cta: "Empieza",

--- a/src/components/services2/FAQ.astro
+++ b/src/components/services2/FAQ.astro
@@ -21,7 +21,7 @@ const content = {
       },
       {
         q: "What's included in the plans?",
-        a: "It depends on the plan. Basic includes an AI assistant on Facebook Messenger, Google review management (with your approval), and owner lead alerts. Premium adds a website chatbot and a weekly local SEO and competitor report. Ultra adds the AI Voice Agent, priority support, and industry tuning. Every plan is fully managed — setup, training, weekly reports, and monthly tuning — with no setup fee and no contract. See the Pricing page for the full breakdown."
+        a: "It depends on the plan. Basic includes an AI assistant on Facebook Messenger, Google review management (approve a reply and it auto-posts to Google), and instant WhatsApp lead alerts. Premium adds a website chatbot and a weekly local SEO and competitor report. Ultra adds the AI Voice Agent, priority support, and industry tuning. Every plan is fully managed — setup, training, weekly reports, and monthly tuning — with no setup fee and no contract. See the Pricing page for the full breakdown."
       },
       {
         q: "What if the AI voice agent goes over 300 minutes?",
@@ -58,7 +58,7 @@ const content = {
       },
       {
         q: "¿Qué incluyen los planes?",
-        a: "Depende del plan. Básico incluye un asistente con IA en Facebook Messenger, gestión de reseñas de Google (con tu aprobación) y avisos de clientes listos para comprar. Premium agrega un chatbot para tu sitio web y un reporte semanal de SEO local y competencia. Ultra agrega el Agente de Voz con IA, soporte prioritario y personalización por industria. Todos los planes son totalmente gestionados — configuración, entrenamiento, reportes semanales y ajuste mensual — sin cuota de instalación y sin contrato. Consulta la página de Precios para el desglose completo."
+        a: "Depende del plan. Básico incluye un asistente con IA en Facebook Messenger, gestión de reseñas de Google (apruebas la respuesta y se publica en Google automáticamente) y alertas al instante por WhatsApp cuando un cliente está listo para comprar. Premium agrega un chatbot para tu sitio web y un reporte semanal de SEO local y competencia. Ultra agrega el Agente de Voz con IA, soporte prioritario y personalización por industria. Todos los planes son totalmente gestionados — configuración, entrenamiento, reportes semanales y ajuste mensual — sin cuota de instalación y sin contrato. Consulta la página de Precios para el desglose completo."
       },
       {
         q: "¿Qué pasa si el agente de voz supera los 300 minutos?",

--- a/src/pages/es/messenger-assistant.astro
+++ b/src/pages/es/messenger-assistant.astro
@@ -102,7 +102,7 @@ const themes = [
       "Te pasa la conversación con todo el contexto cuando el cliente pide una persona",
       "Contesta \"¿eres un bot?\" con honestidad — sin traspasos falsos ni incómodos",
       "Captura el lead — nombre, contacto, intención — con el consentimiento del cliente",
-      "Los leads calientes llegan a tu bandeja para cerrar — alertas por WhatsApp muy pronto",
+      "Los leads calientes llegan a tu bandeja para cerrar — con alertas por WhatsApp al instante",
       "Retoma la conversación automáticamente cuando terminas",
     ],
   },

--- a/src/pages/messenger-assistant.astro
+++ b/src/pages/messenger-assistant.astro
@@ -102,7 +102,7 @@ const themes = [
       "Hands off to you with full context when a customer asks for a person",
       "Answers \"are you a bot?\" honestly — no awkward false handoffs",
       "Captures the lead — name, contact, intent — with the customer's consent",
-      "Hot leads land in your inbox to close — instant WhatsApp alerts on the way",
+      "Hot leads land in your inbox to close — with instant WhatsApp alerts",
       "Picks the conversation back up automatically once you're done",
     ],
   },


### PR DESCRIPTION
Two capabilities verified functionally today → now reflected in marketing copy (clears the marketing↔bot truth contract).

## Google review management — closed loop
"with your approval" → **"approve a reply and it posts to Google automatically"** (pricing bullet, comparison matrix row, services FAQ). EN + ES.

## WhatsApp lead/handoff alert — LIVE (hedges removed)
es_MX template Active, verified live send (200). Removed every "on the way / muy pronto / rolling out" hedge on the **owner alert**:
- Pricing Basic bullet, comparison-matrix "Owner lead alerts" cells, and the alert FAQ (reworded "when do alerts go live" → "how do I hear about a new lead").
- messenger-assistant hero bullet (EN + ES).

## Deliberately NOT changed
WhatsApp/Instagram as a **customer channel** (`/salons/` + `/salones/` FAQ) is a separate, still-pending capability — left as "on the way / en camino."

## Verified
astro check 0 errors · es-MX clean · EN/ES parity · 5 files, 20/20 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)