### PR TITLE
feat(pricing): Google-reviews freshness FAQ (EN + ES)

### DIFF
--- a/src/components/pricing/PricingComparison.astro
+++ b/src/components/pricing/PricingComparison.astro
@@ -164,6 +164,10 @@ const copy: Record<
         a: "The moment a lead is ready — or a conversation needs a person — you get an instant WhatsApp alert, plus email and a note inside Messenger. Included on every plan at no extra cost.",
       },
       {
+        q: "How fast do you catch new Google reviews?",
+        a: "Within hours, not days. We read your reviews straight from Google, so a new one shows up almost as soon as it's posted — and we always see the current text, even after an edit. We draft a reply, you approve it, and it posts back to Google automatically: the whole loop in one place.",
+      },
+      {
         q: "Can I switch plans later?",
         a: "Anytime, up or down, with no penalty. Start on Basic, move to Premium when you want the website chatbot and SEO reports, add Ultra's voice agent when you're ready. Changes take effect the next billing cycle.",
       },
@@ -283,6 +287,10 @@ const copy: Record<
       {
         q: "¿Cómo me entero de un nuevo lead?",
         a: "En cuanto un lead está listo — o una conversación necesita a una persona — recibes una alerta al instante por WhatsApp, además de correo y un aviso dentro de Messenger. Incluido en todos los planes sin costo extra.",
+      },
+      {
+        q: "¿Qué tan rápido detectan las nuevas reseñas de Google?",
+        a: "En cuestión de horas, no días. Leemos tus reseñas directamente de Google, así que una reseña nueva aparece casi en cuanto se publica — y siempre vemos el texto actual, incluso después de una edición. Redactamos una respuesta, tú la apruebas y se publica de vuelta en Google automáticamente: todo el ciclo en un solo lugar.",
       },
       {
         q: "¿Puedo cambiar de plan después?",


### PR DESCRIPTION
Adds the freshness angle of the now-live Google review closed loop to the pricing comparison FAQ (both languages), right after the lead-alert FAQ.

**Q (EN):** "How fast do you catch new Google reviews?" → within hours (read live from Google, current text after edits), draft→approve→auto-post loop in one place.
**Q (ES):** "¿Qué tan rápido detectan las nuevas reseñas de Google?"

Truthful to the verified capability. astro check 0 errors · es-MX clean · 1 file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)