### PR TITLE
fix(sentry): filter browser-injected script noise from error reporting

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -3,4 +3,16 @@ import * as Sentry from "@sentry/astro";
 Sentry.init({
   dsn: import.meta.env.PUBLIC_SENTRY_DSN,
   tracesSampleRate: 0,
+  // Errors thrown by scripts the browser injects into our pages — not reachable
+  // from our bundle and nothing user-facing breaks. Unactionable alert noise
+  // that masks real errors.
+  ignoreErrors: [
+    // DuckDuckGo mobile injects user scripts that call its native message
+    // broker; a page origin not allowlisted for the invoked feature rejects
+    // with BrokerError.policyRestriction, whose message is "invalid origin".
+    // See duckduckgo/apple-browsers UserScriptMessaging.swift.
+    "invalid origin",
+    // Benign layout notification the spec requires browsers to fire.
+    "ResizeObserver loop",
+  ],
 });


### PR DESCRIPTION
Adds `ignoreErrors` to the client Sentry config to drop errors thrown by scripts the **browser** injects into our pages.

Rolls out the standard set in `expat-driver-license-prep` (PR #49) across CushLabs repos with Sentry.

## Why

Triaged a production `invalid origin` error and traced it to DuckDuckGo mobile, not our code: its injected user scripts call the native message broker, which rejects with `BrokerError.policyRestriction` ("invalid origin") when the page origin is not allowlisted for the invoked feature (duckduckgo/apple-browsers `UserScriptMessaging.swift`). The rejection lands in our page JS context, so Sentry stamps it with our URL/transaction and it looks like our bug.

Not cosmetic: with `replaysOnErrorSampleRate: 1.0`, **every junk event burned a session replay** — the scarcest Sentry quota. Verified in the Sentry v10 source that `ignoreErrors` (a client event processor) runs *before* replay learns of the event (a scope processor), and `_notifyEventProcessors` halts on null — so filtered events never trigger a replay flush.

Also filters `ResizeObserver loop`, a benign notification the spec requires browsers to fire.

Filter list kept deliberately tight — over-filtering masks real errors, which is the problem being solved.

## Verification

- Config parses clean (esbuild).
- Only `sentry.client.config.ts` touched; pre-existing working-tree changes left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)