### PR TITLE
feat(about): plain-English positioning statement (diagnosis-first)

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -17,6 +17,10 @@ const content = {
       ctaPrimary: "Book a Free Call",
       ctaSecondary: "See Real Solutions",
     },
+    statement: {
+      label: "In plain English",
+      body: `CushLabs is an AI consulting and full-stack development practice based in Guadalajara, serving small and mid-sized businesses on both sides of the US–Mexico border. Founded by Robert after a full career in enterprise IT, CushLabs takes a <span class="text-cush-orange font-semibold">diagnosis-first</span> approach — understanding what's actually broken before prescribing a fix, instead of pushing pre-packaged solutions.`,
+    },
     trust: {
       title: "Built on Experience, Not Hype",
       stats: [
@@ -96,6 +100,10 @@ const content = {
       subheadline: "Los pequeños negocios merecen las mismas ventajas de IA que las grandes empresas — sin el precio empresarial. He construido ese puente a lo largo de toda una carrera en TI.",
       ctaPrimary: "Agendar Llamada Gratis",
       ctaSecondary: "Ver Soluciones Reales",
+    },
+    statement: {
+      label: "En pocas palabras",
+      body: `CushLabs es una consultoría de IA y desarrollo full-stack con base en Guadalajara, que atiende a pequeñas y medianas empresas en ambos lados de la frontera entre México y Estados Unidos. Fundada por Robert tras una carrera completa en TI empresarial, CushLabs trabaja con un enfoque de <span class="text-cush-orange font-semibold">diagnóstico primero</span>: entender qué está realmente fallando antes de recetar una solución, en lugar de vender paquetes prearmados.`,
     },
     trust: {
       title: "Construido sobre Experiencia, No Promesas",
@@ -223,6 +231,18 @@ const t = content[locale];
             </svg>
           </a>
         </div>
+      </div>
+    </Container>
+  </section>
+
+  <!-- Plain-English Statement -->
+  <section class="py-16 lg:py-20">
+    <Container>
+      <div class="max-w-3xl mx-auto text-center">
+        <span class="inline-block px-3 py-1 text-xs font-display font-semibold text-cush-orange bg-cush-orange/10 rounded-full mb-6">
+          {t.statement.label}
+        </span>
+        <p class="text-xl md:text-2xl leading-relaxed text-gray-700 dark:text-gray-300" set:html={t.statement.body} />
       </div>
     </Container>
   </section>


### PR DESCRIPTION
Adds a straightforward positioning statement to the top of the About page — an "in plain English" lead that sits above the benefit-driven hero copy.

**Why:** The existing About page leads with sales-register benefit promises. This introduces the **diagnosis-first** framing ("understand what's actually broken before prescribing a fix") — a genuine differentiator that appeared nowhere on the site.

**Changes:**
- New "In plain English" / "En pocas palabras" statement section, EN + es-MX (parity rule)
- Founder framed as "Robert" (matches existing "About Robert" section); full name still lives in the LinkedIn link + photo alt
- Deliberately does **not** claim "Fortune 500" — kept to "after a full career in enterprise IT," consistent with the rest of the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)