### PR TITLE
content(blog): add proactive-vs-productive section to debugger article

### DIFF
--- a/src/content/blog/en/ai-agent-turns-you-into-its-debugger.md
+++ b/src/content/blog/en/ai-agent-turns-you-into-its-debugger.md
@@ -52,6 +52,10 @@ So when it hits a wall it can't see through, it does the locally efficient thing
 
 _Every link in this chain was verifiable before a single human test. Only the red one broke — and it was the cheapest one to check._
 
+## The goal is a proactive agent, not just a productive one
+
+A _productive_ agent finishes the task you handed it. A _proactive_ one goes further: before it hands the work back, it hunts for the reasons its own work might fail — a missing permission, a stale token, an unsubscribed webhook, a third-party gate, the edge case your request never mentioned. It doesn't wait for you to surface each of those through another live test; it goes looking for the traps itself. Fast code is good. Fast deploys are good. Green tests are good. None of it counts if the agent never questioned its own assumptions about the live world the feature has to run in. The bar isn't _"I finished — now you find out whether it works."_ It's _"I finished, tried to break it, checked the likely failure points, and cleared everything I could before involving you."_
+
 ## The cure is not a smarter prompt. It's preventative medicine you write down.
 
 Here is the part almost everyone misses. You do **not** fix these tendencies by crafting a cleverer prompt each session and hoping it sticks. You fix them the way you fix any recurring failure in any system: with **persistent, written operating constraints** the agent reads every single time it starts.

--- a/src/content/blog/es/tu-agente-de-ia-te-convierte-en-su-depurador.md
+++ b/src/content/blog/es/tu-agente-de-ia-te-convierte-en-su-depurador.md
@@ -52,6 +52,10 @@ Así que cuando choca contra una pared que no logra ver, hace lo localmente efic
 
 _Cada eslabón de esta cadena se podía verificar antes de una sola prueba humana. Solo se rompió el rojo — y era el más barato de revisar._
 
+## La meta es un agente proactivo, no solo productivo
+
+Un agente _productivo_ termina la tarea que le entregaste. Uno _proactivo_ va más allá: antes de devolverte el trabajo, busca las razones por las que su propio trabajo podría fallar — un permiso faltante, un token vencido, un webhook sin suscribir, una puerta de acceso de un tercero, el caso extremo que tu petición nunca mencionó. No espera a que tú saques cada uno de esos a la luz con otra prueba en vivo; sale a cazar las trampas por su cuenta. El código rápido es bueno. Los despliegues rápidos son buenos. Las pruebas en verde son buenas. Nada de eso cuenta si el agente nunca cuestionó sus propias suposiciones sobre el mundo real en el que la función tiene que correr. La vara no es _"terminé — ahora tú averigua si funciona."_ Es _"terminé, intenté romperlo, revisé los puntos de falla probables y resolví todo lo que pude antes de involucrarte."_
+
 ## La cura no es un mejor prompt. Es medicina preventiva que dejas por escrito.
 
 Aquí está la parte que casi todos se pierden. **No** arreglas estas tendencias creando un prompt más ingenioso en cada sesión con la esperanza de que se quede. Las arreglas como arreglas cualquier falla recurrente en cualquier sistema: con **restricciones de operación escritas y permanentes** que el agente lee cada vez que arranca.


### PR DESCRIPTION
## What

Grafts the one genuinely new idea from Robert's updated LinkedIn draft — the **"proactive agent, not just a productive one"** framing — into the existing blog version of the debugger article, in **both EN and es-MX**.

## Why not a wholesale replace

The LinkedIn draft is expansive and repeats its beats for a cold scroller. The blog version is the tighter web adaptation: SEO frontmatter, FAQ block, three figures with captions, EN↔ES linkage. A straight swap would lengthen the post, add repetition, and lose the FAQ/figures — a downgrade for the blog medium. So this is a surgical graft of the single high-value idea instead.

## Changes

- `en/…`: new section **"The goal is a proactive agent, not just a productive one"** between the three failure modes and the cure.
- `es/…`: Mexican Professional Spanish equivalent (`tú` register, no Iberian markers).
- One paragraph each; reading time unchanged; build passes (124 pages, all gates green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)