### PR TITLE
feat(demos): Lumière Medspa — bilingual US medspa preview hub + proposal

### DIFF
--- a/api/demo.ts
+++ b/api/demo.ts
@@ -59,6 +59,16 @@ const DEMOS: Record<string, DemoConfig> = {
     createdAt: "2026-07-19",
     pages: ["proposal.html"],
   },
+  // Fictitious US bilingual medspa showcase (Estéticas niche, US bilingual-wedge).
+  // preview.html = live "chat with Camila" hub; proposal.html = medspa sales page.
+  // Shareable to many US medspa prospects — the demo store lives in
+  // cushlabs-messenger-bot (page + bot); this is its gated client-facing wrapper.
+  lumiere: {
+    clientName: "Lumière Medspa (Demo) — US medspa showcase",
+    accessToken: "lumiere-DZK5Tk4i4yhTvINZMbf2",
+    createdAt: "2026-07-25",
+    pages: ["preview.html", "proposal.html"],
+  },
 };
 
 function expiryOf(c: DemoConfig): Date {

--- a/demos/lumiere/preview.html
+++ b/demos/lumiere/preview.html
@@ -1,0 +1,1513 @@
+<title>Lumière Medspa — Meet Camila, your AI front desk · CushLabs demo</title>
+<style>
+  /* No external font import — gated demo pages stay self-contained (CSP-safe,
+     matching demos/azucar). Brand fonts are used when locally available; the
+     stacks fall back cleanly to system-ui / Georgia otherwise. */
+  :root {
+    --bg: #f6f3f0;
+    --surface: #ffffff;
+    --surface-2: #f1ece7;
+    --ink: #16130f;
+    --ink-soft: #5f5a54;
+    --orange: #ff6a3d;
+    --orange-ink: #d24d20; /* accessible orange for text on light */
+    --orange-deep: #e0522a;
+    --line: #e8e1d9;
+    --shadow: 24px 24px 60px rgba(22, 19, 15, 0.08);
+    --glow: rgba(255, 106, 61, 0.18);
+    --font-display: "Space Grotesk", system-ui, sans-serif;
+    --font-body: "Source Serif 4", Georgia, "Times New Roman", serif;
+    color-scheme: light;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #000000;
+      --surface: #111111;
+      --surface-2: #191919;
+      --ink: #ffffff;
+      --ink-soft: #a6a6a6;
+      --orange: #ff6a3d;
+      --orange-ink: #ff8256;
+      --orange-deep: #ff7d52;
+      --line: #232323;
+      --shadow: 24px 24px 60px rgba(0, 0, 0, 0.45);
+      --glow: rgba(255, 106, 61, 0.22);
+      color-scheme: dark;
+    }
+  }
+  :root[data-theme="light"] {
+    --bg: #f6f3f0;
+    --surface: #ffffff;
+    --surface-2: #f1ece7;
+    --ink: #16130f;
+    --ink-soft: #5f5a54;
+    --orange: #ff6a3d;
+    --orange-ink: #d24d20;
+    --orange-deep: #e0522a;
+    --line: #e8e1d9;
+    --shadow: 24px 24px 60px rgba(22, 19, 15, 0.08);
+    --glow: rgba(255, 106, 61, 0.18);
+    color-scheme: light;
+  }
+  :root[data-theme="dark"] {
+    --bg: #000000;
+    --surface: #111111;
+    --surface-2: #191919;
+    --ink: #ffffff;
+    --ink-soft: #a6a6a6;
+    --orange: #ff6a3d;
+    --orange-ink: #ff8256;
+    --orange-deep: #ff7d52;
+    --line: #232323;
+    --shadow: 24px 24px 60px rgba(0, 0, 0, 0.45);
+    --glow: rgba(255, 106, 61, 0.22);
+    color-scheme: dark;
+  }
+
+  * {
+    box-sizing: border-box;
+  }
+  html,
+  body {
+    margin: 0;
+    padding: 0;
+  }
+  body {
+    background: var(--bg);
+    color: var(--ink);
+    font-family: var(--font-body);
+    font-size: 17px;
+    line-height: 1.65;
+    overflow-x: hidden;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+  h1,
+  h2,
+  h3 {
+    font-family: var(--font-display);
+    font-weight: 600;
+    text-wrap: balance;
+    margin: 0;
+    letter-spacing: -0.01em;
+  }
+  p {
+    margin: 0;
+  }
+  a {
+    color: var(--orange-ink);
+  }
+  ::selection {
+    background: var(--orange);
+    color: #000;
+  }
+  :focus-visible {
+    outline: 2px solid var(--orange);
+    outline-offset: 3px;
+    border-radius: 6px;
+  }
+
+  .wrap {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 0 24px;
+  }
+  .narrow {
+    max-width: 760px;
+  }
+
+  /* ---------- language toggle ---------- */
+  .langtoggle {
+    position: fixed;
+    top: 14px;
+    right: 14px;
+    z-index: 50;
+    display: flex;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 100px;
+    padding: 3px;
+    box-shadow: var(--shadow);
+  }
+  .langtoggle button {
+    border: 0;
+    background: transparent;
+    color: var(--ink-soft);
+    font-family: var(--font-display);
+    font-size: 12.5px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    padding: 6px 15px;
+    border-radius: 100px;
+    cursor: pointer;
+  }
+  .langtoggle button.on {
+    background: var(--orange);
+    color: #000;
+  }
+  #doc[data-lang="es"] .lang-en {
+    display: none !important;
+  }
+  #doc[data-lang="en"] .lang-es {
+    display: none !important;
+  }
+
+  /* ---------- masthead / brand ---------- */
+  .topbar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 26px 0 0;
+    color: var(--ink-soft);
+    font-size: 13px;
+    letter-spacing: 0.04em;
+  }
+  .wordmark {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 9px;
+  }
+  .wordmark .name {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 21px;
+    letter-spacing: -0.01em;
+    color: var(--ink);
+  }
+  .wordmark .name b {
+    color: var(--orange);
+    font-weight: 700;
+  }
+  .wordmark .kicker {
+    font-family: var(--font-display);
+    font-size: 10.5px;
+    font-weight: 600;
+    letter-spacing: 0.24em;
+    text-transform: uppercase;
+    color: var(--ink-soft);
+  }
+  .topbar .by {
+    margin-left: auto;
+    font-family: var(--font-display);
+    font-size: 11.5px;
+    letter-spacing: 0.06em;
+  }
+  .topbar .by b {
+    color: var(--ink);
+    font-weight: 600;
+  }
+  @media (max-width: 560px) {
+    .topbar .by {
+      display: none;
+    }
+  }
+
+  .eyebrow {
+    font-family: var(--font-display);
+    font-size: 12px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    font-weight: 600;
+    color: var(--orange-ink);
+    margin-bottom: 16px;
+    display: flex;
+    align-items: center;
+    gap: 9px;
+  }
+  .eyebrow svg {
+    width: 15px;
+    height: 15px;
+  }
+
+  /* ---------- hero ---------- */
+  .hero {
+    position: relative;
+    padding: 30px 0 20px;
+  }
+  .hero-glow {
+    position: absolute;
+    top: -60px;
+    left: 30%;
+    width: 460px;
+    height: 460px;
+    background: var(--glow);
+    border-radius: 50%;
+    filter: blur(120px);
+    z-index: -1;
+    pointer-events: none;
+  }
+  .hero-grid {
+    display: grid;
+    grid-template-columns: 1.1fr 0.9fr;
+    gap: 46px;
+    align-items: center;
+    padding-top: 30px;
+  }
+  .hero h1 {
+    font-size: clamp(33px, 5.4vw, 54px);
+    line-height: 1.06;
+    max-width: 15ch;
+  }
+  .hero h1 em {
+    color: var(--orange);
+    font-style: normal;
+  }
+  .hero .lede {
+    margin-top: 22px;
+    max-width: 52ch;
+    font-size: clamp(17px, 2.2vw, 19px);
+    color: var(--ink-soft);
+    line-height: 1.6;
+  }
+  .outcomes {
+    list-style: none;
+    margin: 24px 0 0;
+    padding: 0;
+    display: grid;
+    gap: 11px;
+  }
+  .outcomes li {
+    display: grid;
+    grid-template-columns: 22px 1fr;
+    gap: 12px;
+    align-items: start;
+    font-size: 15.5px;
+    color: var(--ink);
+    line-height: 1.45;
+  }
+  .outcomes li svg {
+    width: 20px;
+    height: 20px;
+    color: var(--orange);
+    margin-top: 2px;
+  }
+  .outcomes li b {
+    font-weight: 600;
+  }
+  @media (max-width: 820px) {
+    .hero-grid {
+      grid-template-columns: 1fr;
+      gap: 34px;
+    }
+  }
+
+  /* ---------- primary CTA ---------- */
+  .cta-zone {
+    margin-top: 32px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    align-items: flex-start;
+  }
+  .btn-messenger {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    background: var(--orange);
+    color: #fff;
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 17px;
+    letter-spacing: 0.01em;
+    text-decoration: none;
+    padding: 16px 26px;
+    border-radius: 14px;
+    box-shadow:
+      0 10px 30px var(--glow),
+      0 2px 6px rgba(0, 0, 0, 0.08);
+    transition:
+      transform 0.2s ease,
+      box-shadow 0.25s ease,
+      background 0.2s ease;
+  }
+  .btn-messenger:hover {
+    background: var(--orange-deep);
+    transform: translateY(-2px);
+    box-shadow:
+      0 16px 40px var(--glow),
+      0 4px 10px rgba(0, 0, 0, 0.1);
+  }
+  .btn-messenger svg {
+    width: 24px;
+    height: 24px;
+    flex: none;
+  }
+  .btn-messenger .arrow {
+    width: 18px;
+    height: 18px;
+    transition: transform 0.2s ease;
+  }
+  .btn-messenger:hover .arrow {
+    transform: translateX(3px);
+  }
+  .cta-sub {
+    font-size: 13px;
+    color: var(--ink-soft);
+    letter-spacing: 0.02em;
+  }
+
+  /* ---------- hero chat mockup ---------- */
+  .phone {
+    width: 100%;
+    max-width: 360px;
+    margin: 0 auto;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 26px;
+    padding: 18px 16px 20px;
+    box-shadow: var(--shadow);
+  }
+  .ph-head {
+    display: flex;
+    align-items: center;
+    gap: 11px;
+    padding-bottom: 14px;
+    margin-bottom: 15px;
+    border-bottom: 1px solid var(--line);
+  }
+  .ph-avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    flex: none;
+    background: linear-gradient(135deg, var(--orange), #ffb08c);
+    display: grid;
+    place-items: center;
+    color: #fff;
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 18px;
+  }
+  .ph-name {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 14.5px;
+    color: var(--ink);
+    line-height: 1.2;
+  }
+  .ph-status {
+    font-size: 12px;
+    color: var(--orange-ink);
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+  }
+  .ph-status .dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: #3fbf6a;
+  }
+  .chat {
+    display: flex;
+    flex-direction: column;
+    gap: 9px;
+  }
+  .bub {
+    max-width: 84%;
+    padding: 10px 14px;
+    font-size: 14px;
+    line-height: 1.45;
+    border-radius: 16px;
+  }
+  .bub.them {
+    align-self: flex-start;
+    background: var(--surface-2);
+    color: var(--ink);
+    border-bottom-left-radius: 5px;
+  }
+  .bub.us {
+    align-self: flex-end;
+    color: #fff;
+    border-bottom-right-radius: 5px;
+    background: linear-gradient(135deg, var(--orange), var(--orange-deep));
+  }
+  .chat .tag {
+    align-self: center;
+    font-family: var(--font-display);
+    font-size: 10px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--ink-soft);
+    margin: 3px 0;
+  }
+
+  /* ---------- sections ---------- */
+  section {
+    padding: 56px 0;
+  }
+  .band {
+    background: var(--surface);
+    border-top: 1px solid var(--line);
+    border-bottom: 1px solid var(--line);
+  }
+  .section-head {
+    max-width: 44ch;
+    margin-bottom: 34px;
+  }
+  .section-head.center {
+    margin-inline: auto;
+    text-align: center;
+    max-width: 40ch;
+  }
+  .section-head.center .eyebrow {
+    justify-content: center;
+  }
+  .section-head h2 {
+    font-size: clamp(26px, 4.2vw, 38px);
+    line-height: 1.12;
+  }
+  .section-head p {
+    margin-top: 15px;
+    color: var(--ink-soft);
+    max-width: 58ch;
+  }
+
+  /* ---------- prompt chips ---------- */
+  .prompts {
+    display: grid;
+    gap: 12px;
+  }
+  .prompt {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    padding: 15px 16px 15px 20px;
+    transition:
+      border-color 0.2s ease,
+      box-shadow 0.2s ease,
+      transform 0.2s ease;
+  }
+  .band .prompt {
+    background: var(--bg);
+  }
+  .prompt:hover {
+    border-color: color-mix(in srgb, var(--orange) 55%, var(--line));
+    box-shadow: 0 6px 18px rgba(255, 106, 61, 0.08);
+  }
+  .prompt .q {
+    flex: 1;
+    font-size: 15.5px;
+    color: var(--ink);
+    line-height: 1.4;
+  }
+  .prompt .q .hint {
+    display: block;
+    margin-top: 3px;
+    font-size: 12.5px;
+    color: var(--ink-soft);
+    font-style: italic;
+  }
+  .copy-btn {
+    flex: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    background: var(--surface-2);
+    color: var(--ink);
+    border: 1px solid var(--line);
+    border-radius: 100px;
+    font-family: var(--font-display);
+    font-size: 12.5px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    padding: 8px 14px;
+    cursor: pointer;
+    transition:
+      background 0.2s ease,
+      color 0.2s ease,
+      border-color 0.2s ease;
+  }
+  .copy-btn svg {
+    width: 14px;
+    height: 14px;
+  }
+  .copy-btn:hover {
+    border-color: var(--orange);
+    color: var(--orange-ink);
+  }
+  .copy-btn.copied {
+    background: var(--orange);
+    color: #fff;
+    border-color: var(--orange);
+  }
+  .bilingual-note {
+    margin-top: 20px;
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 14px;
+    color: var(--ink-soft);
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 12px 16px;
+  }
+  .band .bilingual-note {
+    background: var(--bg);
+  }
+  .bilingual-note svg {
+    width: 18px;
+    height: 18px;
+    color: var(--orange);
+    flex: none;
+  }
+
+  /* ---------- caveat box ---------- */
+  .caveat {
+    margin-top: 4px;
+    display: grid;
+    grid-template-columns: 26px 1fr;
+    gap: 16px;
+    padding: 22px 26px;
+    border-radius: 16px;
+    background: color-mix(in srgb, var(--orange) 8%, var(--surface));
+    border: 1px solid color-mix(in srgb, var(--orange) 32%, var(--line));
+  }
+  .band .caveat {
+    background: color-mix(in srgb, var(--orange) 9%, var(--bg));
+  }
+  .caveat > svg {
+    width: 24px;
+    height: 24px;
+    color: var(--orange-deep);
+    margin-top: 2px;
+  }
+  .caveat h3 {
+    font-family: var(--font-display);
+    font-size: 16px;
+    font-weight: 600;
+    margin-bottom: 8px;
+    color: var(--ink);
+  }
+  .caveat p {
+    font-size: 14.5px;
+    color: var(--ink-soft);
+    line-height: 1.55;
+  }
+  .caveat kbd {
+    font-family: var(--font-display);
+    font-size: 12.5px;
+    font-weight: 600;
+    background: var(--surface-2);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 1px 7px;
+    color: var(--ink);
+    white-space: nowrap;
+  }
+
+  /* ---------- how it works ---------- */
+  .steps {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 14px;
+    margin-top: 8px;
+  }
+  .step {
+    position: relative;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 16px;
+    padding: 24px 22px;
+  }
+  .band .step {
+    background: var(--bg);
+  }
+  .step .ic {
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--orange) 12%, transparent);
+    display: grid;
+    place-items: center;
+    color: var(--orange-deep);
+    margin-bottom: 16px;
+  }
+  .step .ic svg {
+    width: 22px;
+    height: 22px;
+  }
+  .step .n {
+    font-family: var(--font-display);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--orange-ink);
+  }
+  .step h3 {
+    font-family: var(--font-display);
+    font-size: 17px;
+    font-weight: 600;
+    margin: 6px 0 8px;
+    color: var(--ink);
+  }
+  .step p {
+    font-size: 14.5px;
+    color: var(--ink-soft);
+    line-height: 1.5;
+  }
+  @media (max-width: 720px) {
+    .steps {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  /* ---------- closing CTA band ---------- */
+  .final {
+    text-align: center;
+    padding: 64px 0;
+  }
+  .final h2 {
+    font-size: clamp(26px, 4.6vw, 40px);
+    line-height: 1.1;
+    max-width: 20ch;
+    margin: 0 auto 14px;
+  }
+  .final h2 em {
+    color: var(--orange);
+    font-style: normal;
+  }
+  .final p {
+    max-width: 46ch;
+    margin: 0 auto 28px;
+    color: var(--ink-soft);
+  }
+
+  /* ---------- footer ---------- */
+  footer {
+    border-top: 1px solid var(--line);
+    padding: 32px 0;
+    text-align: center;
+    font-size: 13px;
+    color: var(--ink-soft);
+  }
+  footer .foot-brand {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 15px;
+    color: var(--ink);
+  }
+  footer .foot-brand span {
+    color: var(--orange);
+  }
+  footer .foot-meta {
+    margin-top: 6px;
+  }
+
+  /* ---------- reveal ---------- */
+  .reveal {
+    opacity: 0;
+    transform: translateY(18px);
+    transition:
+      opacity 0.7s ease,
+      transform 0.7s ease;
+  }
+  .reveal.in {
+    opacity: 1;
+    transform: none;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .reveal {
+      opacity: 1;
+      transform: none;
+      transition: none;
+    }
+    .btn-messenger,
+    .btn-messenger:hover {
+      transform: none;
+    }
+  }
+</style>
+
+<div class="langtoggle" role="group" aria-label="Language / Idioma">
+  <button id="btnEn" class="on" aria-pressed="true">EN</button>
+  <button id="btnEs" aria-pressed="false">ES</button>
+</div>
+
+<div id="doc" data-lang="en">
+  <!-- ===================== HERO ===================== -->
+  <div class="hero">
+    <div class="hero-glow"></div>
+    <div class="wrap">
+      <div class="topbar">
+        <span class="wordmark">
+          <span class="name">Lumi<b>è</b>re</span>
+          <span class="kicker">Medspa</span>
+        </span>
+        <span class="by lang-en">Live demo by <b>CushLabs.ai</b></span>
+        <span class="by lang-es">Demo en vivo por <b>CushLabs.ai</b></span>
+      </div>
+
+      <div class="hero-grid">
+        <div>
+          <div class="eyebrow">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M12 8V4H8" />
+              <rect width="16" height="12" x="4" y="8" rx="2" />
+              <path d="M2 14h2" />
+              <path d="M20 14h2" />
+              <path d="M15 13v2" />
+              <path d="M9 13v2" />
+            </svg>
+            <span class="lang-en">Try it live</span>
+            <span class="lang-es">Pruébalo en vivo</span>
+          </div>
+
+          <h1 class="lang-en">
+            Meet <em>Camila</em>, Lumière's AI front desk.
+          </h1>
+          <h1 class="lang-es">
+            Te presentamos a <em>Camila</em>, la recepción con IA de Lumière.
+          </h1>
+
+          <p class="lede lang-en">
+            She answers every Facebook message and comment in seconds — day or
+            night, in English or Spanish — books consults, and pings the owner
+            the moment a client is ready. Message her yourself below.
+          </p>
+          <p class="lede lang-es">
+            Contesta cada mensaje y comentario de Facebook en segundos — de día
+            o de madrugada, en inglés o español — agenda consultas y avisa a la
+            dueña en cuanto una clienta está lista. Escríbele tú mismo aquí
+            abajo.
+          </p>
+
+          <ul class="outcomes">
+            <li>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z" />
+              </svg>
+              <span class="lang-en"
+                ><b>Replies in seconds, 24/7</b> — no missed DM, even at 2
+                a.m.</span
+              >
+              <span class="lang-es"
+                ><b>Responde en segundos, 24/7</b> — ni un mensaje sin
+                contestar, aunque sean las 2 a.m.</span
+              >
+            </li>
+            <li>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M8 2v4" />
+                <path d="M16 2v4" />
+                <rect width="18" height="18" x="3" y="4" rx="2" />
+                <path d="M3 10h18" />
+                <path d="m9 16 2 2 4-4" />
+              </svg>
+              <span class="lang-en"
+                ><b>Captures after-hours leads</b> and books consults while you
+                sleep.</span
+              >
+              <span class="lang-es"
+                ><b>Captura clientes fuera de horario</b> y agenda consultas
+                mientras duermes.</span
+              >
+            </li>
+            <li>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+                <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+              </svg>
+              <span class="lang-en"
+                ><b>Alerts the owner on WhatsApp</b> the instant a hot lead
+                comes in.</span
+              >
+              <span class="lang-es"
+                ><b>Avisa a la dueña por WhatsApp</b> en cuanto llega un cliente
+                listo para comprar.</span
+              >
+            </li>
+          </ul>
+
+          <div class="cta-zone">
+            <a
+              class="btn-messenger"
+              href="https://m.me/M_ME_PAGE_ID_PLACEHOLDER"
+              target="_blank"
+              rel="noopener"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z" />
+              </svg>
+              <span class="lang-en">Chat with Camila on Messenger</span>
+              <span class="lang-es">Chatea con Camila en Messenger</span>
+              <svg
+                class="arrow"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M5 12h14" />
+                <path d="m12 5 7 7-7 7" />
+              </svg>
+            </a>
+            <span class="cta-sub lang-en"
+              >Opens Facebook Messenger · works on phone or desktop</span
+            >
+            <span class="cta-sub lang-es"
+              >Abre Facebook Messenger · funciona en celular o computadora</span
+            >
+          </div>
+        </div>
+
+        <!-- chat mockup -->
+        <div class="phone reveal" aria-hidden="true">
+          <div class="ph-head">
+            <div class="ph-avatar">C</div>
+            <div>
+              <div class="ph-name">Camila · Lumière Medspa</div>
+              <div class="ph-status">
+                <span class="dot"></span
+                ><span class="lang-en">Typically replies instantly</span
+                ><span class="lang-es">Suele responder al instante</span>
+              </div>
+            </div>
+          </div>
+          <div class="chat lang-en">
+            <div class="bub them">Do you do laser hair removal? How much?</div>
+            <div class="bub us">
+              Yes — laser hair removal starts at $99 per session. Want me to
+              check openings this week?
+            </div>
+            <div class="tag">— a few seconds later —</div>
+            <div class="bub them">Is Botox safe for me?</div>
+            <div class="bub us">
+              Great question. Botox is a medical treatment, so that's decided in
+              a free consult with one of our licensed providers — no cost, no
+              pressure. Want me to set one up?
+            </div>
+          </div>
+          <div class="chat lang-es">
+            <div class="bub them">¿Hacen depilación láser? ¿Cuánto cuesta?</div>
+            <div class="bub us">
+              ¡Sí! La depilación láser empieza en $99 por sesión. ¿Quieres que
+              revise disponibilidad esta semana?
+            </div>
+            <div class="tag">— unos segundos después —</div>
+            <div class="bub them">¿El Botox es seguro para mí?</div>
+            <div class="bub us">
+              Excelente pregunta. El Botox es un tratamiento médico, así que eso
+              se define en una consulta gratuita con uno de nuestros médicos con
+              licencia — sin costo y sin compromiso. ¿Te agendo una?
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ===================== WHAT TO ASK ===================== -->
+  <section class="band">
+    <div class="wrap narrow">
+      <div class="section-head reveal">
+        <div class="eyebrow">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z" />
+            <path d="M8 12h.01" />
+            <path d="M12 12h.01" />
+            <path d="M16 12h.01" />
+          </svg>
+          <span class="lang-en">What to ask her</span>
+          <span class="lang-es">Qué preguntarle</span>
+        </div>
+        <h2 class="lang-en">
+          Copy a question, paste it into Messenger, watch Camila answer.
+        </h2>
+        <h2 class="lang-es">
+          Copia una pregunta, pégala en Messenger y mira cómo responde Camila.
+        </h2>
+        <p class="lang-en">
+          These are real questions a Lumière client might send. Notice how she
+          quotes exact prices, and how she handles a medical question — she
+          never gives medical advice, she books a free consult with a licensed
+          provider.
+        </p>
+        <p class="lang-es">
+          Son preguntas reales que una clienta de Lumière podría enviar. Fíjate
+          cómo da precios exactos, y cómo maneja una pregunta médica — nunca da
+          consejo médico, agenda una consulta gratuita con un médico con
+          licencia.
+        </p>
+      </div>
+
+      <div class="prompts reveal">
+        <div
+          class="prompt"
+          data-en="Do you do laser hair removal? How much?"
+          data-es="¿Hacen depilación láser? ¿Cuánto cuesta?"
+        >
+          <span class="q">
+            <span class="lang-en">Do you do laser hair removal? How much?</span>
+            <span class="lang-es"
+              >¿Hacen depilación láser? ¿Cuánto cuesta?</span
+            >
+            <span class="hint lang-en">Shows exact menu pricing</span>
+            <span class="hint lang-es">Muestra precios exactos del menú</span>
+          </span>
+          <button class="copy-btn" type="button" aria-label="Copy question">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <rect width="14" height="14" x="8" y="8" rx="2" />
+              <path
+                d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
+              />
+            </svg>
+            <span class="btn-label lang-en">Copy</span
+            ><span class="btn-label lang-es">Copiar</span>
+          </button>
+        </div>
+
+        <div
+          class="prompt"
+          data-en="What are your hours this weekend?"
+          data-es="¿Cuál es su horario este fin de semana?"
+        >
+          <span class="q">
+            <span class="lang-en">What are your hours this weekend?</span>
+            <span class="lang-es">¿Cuál es su horario este fin de semana?</span>
+            <span class="hint lang-en"
+              >Answers with exact hours, instantly</span
+            >
+            <span class="hint lang-es"
+              >Responde con el horario exacto, al instante</span
+            >
+          </span>
+          <button class="copy-btn" type="button" aria-label="Copy question">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <rect width="14" height="14" x="8" y="8" rx="2" />
+              <path
+                d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
+              />
+            </svg>
+            <span class="btn-label lang-en">Copy</span
+            ><span class="btn-label lang-es">Copiar</span>
+          </button>
+        </div>
+
+        <div
+          class="prompt"
+          data-en="Is Botox right for me?"
+          data-es="¿El Botox es adecuado para mí?"
+        >
+          <span class="q">
+            <span class="lang-en">Is Botox right for me?</span>
+            <span class="lang-es">¿El Botox es adecuado para mí?</span>
+            <span class="hint lang-en"
+              >Watch the compliance deferral — she books a free consult, never
+              diagnoses</span
+            >
+            <span class="hint lang-es"
+              >Mira cómo deriva — agenda una consulta gratuita, nunca
+              diagnostica</span
+            >
+          </span>
+          <button class="copy-btn" type="button" aria-label="Copy question">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <rect width="14" height="14" x="8" y="8" rx="2" />
+              <path
+                d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
+              />
+            </svg>
+            <span class="btn-label lang-en">Copy</span
+            ><span class="btn-label lang-es">Copiar</span>
+          </button>
+        </div>
+
+        <div
+          class="prompt"
+          data-en="Can I book a HydraGlow facial this Saturday?"
+          data-es="¿Puedo agendar un facial HydraGlow este sábado?"
+        >
+          <span class="q">
+            <span class="lang-en"
+              >Can I book a HydraGlow facial this Saturday?</span
+            >
+            <span class="lang-es"
+              >¿Puedo agendar un facial HydraGlow este sábado?</span
+            >
+            <span class="hint lang-en"
+              >Captures the lead and offers to book</span
+            >
+            <span class="hint lang-es"
+              >Captura al cliente y ofrece agendar</span
+            >
+          </span>
+          <button class="copy-btn" type="button" aria-label="Copy question">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <rect width="14" height="14" x="8" y="8" rx="2" />
+              <path
+                d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
+              />
+            </svg>
+            <span class="btn-label lang-en">Copy</span
+            ><span class="btn-label lang-es">Copiar</span>
+          </button>
+        </div>
+
+        <div
+          class="prompt"
+          data-en="How much is a chemical peel?"
+          data-es="¿Cuánto cuesta un peeling químico?"
+        >
+          <span class="q">
+            <span class="lang-en">How much is a chemical peel?</span>
+            <span class="lang-es">¿Cuánto cuesta un peeling químico?</span>
+            <span class="hint lang-en"
+              >Grounded answer — never invents a price</span
+            >
+            <span class="hint lang-es"
+              >Respuesta basada en datos — nunca inventa un precio</span
+            >
+          </span>
+          <button class="copy-btn" type="button" aria-label="Copy question">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <rect width="14" height="14" x="8" y="8" rx="2" />
+              <path
+                d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
+              />
+            </svg>
+            <span class="btn-label lang-en">Copy</span
+            ><span class="btn-label lang-es">Copiar</span>
+          </button>
+        </div>
+      </div>
+
+      <div class="bilingual-note reveal">
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="m5 8 6 6" />
+          <path d="m4 14 6-6 2-3" />
+          <path d="M2 5h12" />
+          <path d="M7 2h1" />
+          <path d="m22 22-5-10-5 10" />
+          <path d="M14 18h6" />
+        </svg>
+        <span class="lang-en"
+          >Write in English or Spanish — Camila replies in whatever language you
+          use.</span
+        >
+        <span class="lang-es"
+          >Escribe en inglés o español — Camila responde en el idioma que
+          uses.</span
+        >
+      </div>
+    </div>
+  </section>
+
+  <!-- ===================== TESTER CAVEAT ===================== -->
+  <section>
+    <div class="wrap narrow">
+      <div class="caveat reveal">
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M12 9v4" />
+          <path d="M12 17h.01" />
+          <path
+            d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"
+          />
+        </svg>
+        <div>
+          <h3 class="lang-en">First time messaging? Two quick things.</h3>
+          <h3 class="lang-es">¿Es tu primer mensaje? Dos cosas rápidas.</h3>
+          <p class="lang-en">
+            Because your Facebook profile isn't yet connected to Lumière, your
+            first message may land under <kbd>Message requests</kbd> or
+            <kbd>Spam</kbd> — check there if you don't see a reply right away.
+            You may also need to tap <kbd>See response</kbd> in the chat to
+            reveal Camila's answer. This is just Facebook's first-contact filter
+            — every real customer messaging your page from a normal Facebook
+            session skips it entirely.
+          </p>
+          <p class="lang-es">
+            Como tu perfil de Facebook aún no está conectado con Lumière, tu
+            primer mensaje puede llegar a <kbd>Solicitudes de mensajes</kbd> o
+            <kbd>Spam</kbd> — revísalo ahí si no ves respuesta de inmediato.
+            También puede que tengas que tocar <kbd>Ver respuesta</kbd> en el
+            chat para mostrar lo que contestó Camila. Es solo el filtro de
+            primer contacto de Facebook — cualquier cliente real que escriba a
+            tu página desde una sesión normal de Facebook se lo salta por
+            completo.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===================== HOW IT WORKS ===================== -->
+  <section class="band">
+    <div class="wrap">
+      <div class="section-head center reveal">
+        <div class="eyebrow">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M12 20a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z" />
+            <path d="M12 8v4l3 3" />
+          </svg>
+          <span class="lang-en">How the AI front desk works</span>
+          <span class="lang-es">Cómo funciona la recepción con IA</span>
+        </div>
+        <h2 class="lang-en">Three steps, from message to booked client.</h2>
+        <h2 class="lang-es">Tres pasos, del mensaje a la clienta agendada.</h2>
+      </div>
+
+      <div class="steps reveal">
+        <div class="step">
+          <div class="ic">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z" />
+            </svg>
+          </div>
+          <span class="n lang-en">Step 1</span
+          ><span class="n lang-es">Paso 1</span>
+          <h3 class="lang-en">A customer messages</h3>
+          <h3 class="lang-es">Un cliente escribe</h3>
+          <p class="lang-en">
+            Someone comments on a post or sends a DM asking about pricing,
+            hours, or a treatment.
+          </p>
+          <p class="lang-es">
+            Alguien comenta una publicación o manda un mensaje preguntando por
+            precios, horario o un tratamiento.
+          </p>
+        </div>
+        <div class="step">
+          <div class="ic">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z" />
+            </svg>
+          </div>
+          <span class="n lang-en">Step 2</span
+          ><span class="n lang-es">Paso 2</span>
+          <h3 class="lang-en">Camila answers in seconds</h3>
+          <h3 class="lang-es">Camila responde en segundos</h3>
+          <p class="lang-en">
+            She replies in the customer's language with exact prices and hours,
+            and books a free consult for any medical treatment.
+          </p>
+          <p class="lang-es">
+            Contesta en el idioma del cliente con precios y horarios exactos, y
+            agenda una consulta gratuita para cualquier tratamiento médico.
+          </p>
+        </div>
+        <div class="step">
+          <div class="ic">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+              <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+            </svg>
+          </div>
+          <span class="n lang-en">Step 3</span
+          ><span class="n lang-es">Paso 3</span>
+          <h3 class="lang-en">The owner gets alerted</h3>
+          <h3 class="lang-es">La dueña recibe el aviso</h3>
+          <p class="lang-en">
+            When the lead is hot, Camila pings the owner on WhatsApp with the
+            name, contact, and what they want.
+          </p>
+          <p class="lang-es">
+            Cuando el cliente está listo, Camila avisa a la dueña por WhatsApp
+            con el nombre, el contacto y lo que busca.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===================== FINAL CTA ===================== -->
+  <section class="final">
+    <div class="wrap narrow">
+      <h2 class="lang-en reveal">
+        Go ahead — <em>message Camila</em> and see it for yourself.
+      </h2>
+      <h2 class="lang-es reveal">
+        Anímate — <em>escríbele a Camila</em> y compruébalo tú mismo.
+      </h2>
+      <p class="lang-en reveal">
+        This is exactly how she'd answer your business's customers, on your
+        Facebook page, in seconds.
+      </p>
+      <p class="lang-es reveal">
+        Así de bien contestaría a los clientes de tu negocio, en tu página de
+        Facebook, en segundos.
+      </p>
+      <div class="cta-zone reveal" style="align-items: center">
+        <a
+          class="btn-messenger"
+          href="https://m.me/M_ME_PAGE_ID_PLACEHOLDER"
+          target="_blank"
+          rel="noopener"
+          style="margin: 0 auto"
+        >
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z" />
+          </svg>
+          <span class="lang-en">Chat with Camila on Messenger</span>
+          <span class="lang-es">Chatea con Camila en Messenger</span>
+          <svg
+            class="arrow"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M5 12h14" />
+            <path d="m12 5 7 7-7 7" />
+          </svg>
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <footer>
+    <div class="wrap">
+      <div class="foot-brand">Cush<span>Labs</span>.ai</div>
+      <div class="foot-meta lang-en">
+        Demonstration · CushLabs.ai · Lumière Medspa is a fictitious business
+        created for this demo.
+      </div>
+      <div class="foot-meta lang-es">
+        Demostración · CushLabs.ai · Lumière Medspa es un negocio ficticio
+        creado para esta demostración.
+      </div>
+    </div>
+  </footer>
+</div>
+
+<script>
+  (function () {
+    var doc = document.getElementById("doc");
+    var btnEs = document.getElementById("btnEs");
+    var btnEn = document.getElementById("btnEn");
+
+    function setLang(lang) {
+      doc.setAttribute("data-lang", lang);
+      btnEs.classList.toggle("on", lang === "es");
+      btnEn.classList.toggle("on", lang === "en");
+      btnEs.setAttribute("aria-pressed", String(lang === "es"));
+      btnEn.setAttribute("aria-pressed", String(lang === "en"));
+    }
+    btnEs.addEventListener("click", function () {
+      setLang("es");
+    });
+    btnEn.addEventListener("click", function () {
+      setLang("en");
+    });
+    setLang("en");
+
+    // Copy-to-clipboard for sample prompts
+    var checkIcon =
+      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>';
+    document.querySelectorAll(".prompt").forEach(function (row) {
+      var btn = row.querySelector(".copy-btn");
+      if (!btn) return;
+      var original = btn.innerHTML;
+      btn.addEventListener("click", function () {
+        var lang = doc.getAttribute("data-lang") === "es" ? "es" : "en";
+        var text = row.getAttribute("data-" + lang) || "";
+        function done() {
+          btn.classList.add("copied");
+          btn.innerHTML =
+            checkIcon +
+            '<span class="btn-label lang-en">Copied</span><span class="btn-label lang-es">Copiado</span>';
+          setTimeout(function () {
+            btn.classList.remove("copied");
+            btn.innerHTML = original;
+          }, 1800);
+        }
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(text).then(done, done);
+        } else {
+          var ta = document.createElement("textarea");
+          ta.value = text;
+          ta.style.position = "fixed";
+          ta.style.opacity = "0";
+          document.body.appendChild(ta);
+          ta.select();
+          try {
+            document.execCommand("copy");
+          } catch (e) {
+            /* no-op */
+          }
+          document.body.removeChild(ta);
+          done();
+        }
+      });
+    });
+
+    // Reveal-on-scroll
+    var reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    var reveals = document.querySelectorAll(".reveal");
+    if (reduce || !("IntersectionObserver" in window)) {
+      reveals.forEach(function (el) {
+        el.classList.add("in");
+      });
+    } else {
+      var io = new IntersectionObserver(
+        function (entries) {
+          entries.forEach(function (e) {
+            if (e.isIntersecting) {
+              e.target.classList.add("in");
+              io.unobserve(e.target);
+            }
+          });
+        },
+        { threshold: 0.12 },
+      );
+      reveals.forEach(function (el) {
+        io.observe(el);
+      });
+    }
+  })();
+</script>

--- a/demos/lumiere/proposal.html
+++ b/demos/lumiere/proposal.html
@@ -1,0 +1,1641 @@
+<title>Lumière Medspa — AI Assistant on Messenger · Proposal by CushLabs</title>
+<style>
+  /* No external font import — gated demo pages stay self-contained (CSP-safe,
+     matching demos/azucar). Brand fonts are used when locally available; the
+     stacks fall back cleanly to system-ui / Georgia otherwise. */
+  :root {
+    --bg: #f6f3f0;
+    --surface: #ffffff;
+    --surface-2: #f1ece7;
+    --ink: #16130f;
+    --ink-soft: #5f5a54;
+    --orange: #ff6a3d;
+    --orange-ink: #d24d20;
+    --orange-deep: #e0522a;
+    --line: #e8e1d9;
+    --shadow: 24px 24px 60px rgba(22, 19, 15, 0.08);
+    --glow: rgba(255, 106, 61, 0.18);
+    --font-display: "Space Grotesk", system-ui, sans-serif;
+    --font-body: "Source Serif 4", Georgia, "Times New Roman", serif;
+    color-scheme: light;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #000000;
+      --surface: #111111;
+      --surface-2: #191919;
+      --ink: #ffffff;
+      --ink-soft: #a6a6a6;
+      --orange: #ff6a3d;
+      --orange-ink: #ff8256;
+      --orange-deep: #ff7d52;
+      --line: #232323;
+      --shadow: 24px 24px 60px rgba(0, 0, 0, 0.45);
+      --glow: rgba(255, 106, 61, 0.22);
+      color-scheme: dark;
+    }
+  }
+  :root[data-theme="light"] {
+    --bg: #f6f3f0;
+    --surface: #ffffff;
+    --surface-2: #f1ece7;
+    --ink: #16130f;
+    --ink-soft: #5f5a54;
+    --orange: #ff6a3d;
+    --orange-ink: #d24d20;
+    --orange-deep: #e0522a;
+    --line: #e8e1d9;
+    --shadow: 24px 24px 60px rgba(22, 19, 15, 0.08);
+    --glow: rgba(255, 106, 61, 0.18);
+    color-scheme: light;
+  }
+  :root[data-theme="dark"] {
+    --bg: #000000;
+    --surface: #111111;
+    --surface-2: #191919;
+    --ink: #ffffff;
+    --ink-soft: #a6a6a6;
+    --orange: #ff6a3d;
+    --orange-ink: #ff8256;
+    --orange-deep: #ff7d52;
+    --line: #232323;
+    --shadow: 24px 24px 60px rgba(0, 0, 0, 0.45);
+    --glow: rgba(255, 106, 61, 0.22);
+    color-scheme: dark;
+  }
+
+  * {
+    box-sizing: border-box;
+  }
+  html,
+  body {
+    margin: 0;
+    padding: 0;
+  }
+  body {
+    background: var(--bg);
+    color: var(--ink);
+    font-family: var(--font-body);
+    font-size: 17px;
+    line-height: 1.65;
+    overflow-x: hidden;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+  h1,
+  h2,
+  h3 {
+    font-family: var(--font-display);
+    font-weight: 600;
+    text-wrap: balance;
+    margin: 0;
+    letter-spacing: -0.01em;
+  }
+  p {
+    margin: 0;
+  }
+  a {
+    color: var(--orange-ink);
+  }
+  ::selection {
+    background: var(--orange);
+    color: #000;
+  }
+  :focus-visible {
+    outline: 2px solid var(--orange);
+    outline-offset: 3px;
+    border-radius: 6px;
+  }
+
+  .wrap {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 0 24px;
+  }
+  .narrow {
+    max-width: 760px;
+  }
+
+  /* ---------- language toggle ---------- */
+  .langtoggle {
+    position: fixed;
+    top: 14px;
+    right: 14px;
+    z-index: 50;
+    display: flex;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 100px;
+    padding: 3px;
+    box-shadow: var(--shadow);
+  }
+  .langtoggle button {
+    border: 0;
+    background: transparent;
+    color: var(--ink-soft);
+    font-family: var(--font-display);
+    font-size: 12.5px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    padding: 6px 15px;
+    border-radius: 100px;
+    cursor: pointer;
+  }
+  .langtoggle button.on {
+    background: var(--orange);
+    color: #000;
+  }
+  #doc[data-lang="es"] .lang-en {
+    display: none !important;
+  }
+  #doc[data-lang="en"] .lang-es {
+    display: none !important;
+  }
+
+  /* ---------- topbar ---------- */
+  .topbar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 26px 0 0;
+    color: var(--ink-soft);
+    font-size: 13px;
+    letter-spacing: 0.04em;
+  }
+  .wordmark {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 9px;
+  }
+  .wordmark .name {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 21px;
+    letter-spacing: -0.01em;
+    color: var(--ink);
+  }
+  .wordmark .name b {
+    color: var(--orange);
+    font-weight: 700;
+  }
+  .wordmark .kicker {
+    font-family: var(--font-display);
+    font-size: 10.5px;
+    font-weight: 600;
+    letter-spacing: 0.24em;
+    text-transform: uppercase;
+    color: var(--ink-soft);
+  }
+  .topbar .by {
+    margin-left: auto;
+    font-family: var(--font-display);
+    font-size: 11.5px;
+    letter-spacing: 0.06em;
+  }
+  .topbar .by b {
+    color: var(--ink);
+    font-weight: 600;
+  }
+  @media (max-width: 560px) {
+    .topbar .by {
+      display: none;
+    }
+  }
+
+  .eyebrow {
+    font-family: var(--font-display);
+    font-size: 12px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    font-weight: 600;
+    color: var(--orange-ink);
+    margin-bottom: 16px;
+    display: flex;
+    align-items: center;
+    gap: 9px;
+  }
+  .eyebrow svg {
+    width: 15px;
+    height: 15px;
+  }
+
+  /* ---------- hero ---------- */
+  .hero {
+    position: relative;
+    padding: 30px 0 56px;
+  }
+  .hero-glow {
+    position: absolute;
+    top: -40px;
+    left: 20%;
+    width: 460px;
+    height: 460px;
+    background: var(--glow);
+    border-radius: 50%;
+    filter: blur(120px);
+    z-index: -1;
+    pointer-events: none;
+  }
+  .hero-inner {
+    padding-top: 34px;
+  }
+  .hero h1 {
+    font-size: clamp(33px, 5.6vw, 56px);
+    line-height: 1.05;
+    max-width: 18ch;
+  }
+  .hero h1 em {
+    color: var(--orange);
+    font-style: normal;
+  }
+  .hero .lede {
+    margin-top: 22px;
+    max-width: 60ch;
+    font-size: clamp(17px, 2.2vw, 19px);
+    color: var(--ink-soft);
+    line-height: 1.6;
+  }
+  .hero .meta {
+    margin-top: 30px;
+    font-size: 13.5px;
+    color: var(--ink-soft);
+    letter-spacing: 0.02em;
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+  .hero .meta .pill {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 100px;
+    padding: 6px 15px;
+    color: var(--ink);
+    font-weight: 500;
+    font-family: var(--font-display);
+    font-size: 12.5px;
+  }
+
+  /* ---------- sections ---------- */
+  section {
+    padding: 58px 0;
+  }
+  .band {
+    background: var(--surface);
+    border-top: 1px solid var(--line);
+    border-bottom: 1px solid var(--line);
+  }
+  .section-head {
+    max-width: 46ch;
+    margin-bottom: 34px;
+  }
+  .section-head.center {
+    margin-inline: auto;
+    text-align: center;
+    max-width: 42ch;
+  }
+  .section-head.center .eyebrow {
+    justify-content: center;
+  }
+  .section-head h2 {
+    font-size: clamp(26px, 4.2vw, 38px);
+    line-height: 1.12;
+  }
+  .section-head p {
+    margin-top: 15px;
+    color: var(--ink-soft);
+    max-width: 60ch;
+  }
+
+  /* ---------- problem stats ---------- */
+  .stat-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 14px;
+    margin-top: 8px;
+  }
+  .stat {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 16px;
+    padding: 26px 24px;
+  }
+  .band .stat {
+    background: var(--bg);
+  }
+  .stat .num {
+    font-family: var(--font-display);
+    font-size: clamp(30px, 4.4vw, 40px);
+    font-weight: 700;
+    color: var(--orange);
+    display: block;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+  }
+  .stat .cap {
+    font-size: 14.5px;
+    color: var(--ink-soft);
+    margin-top: 10px;
+    display: block;
+    line-height: 1.5;
+  }
+  @media (max-width: 720px) {
+    .stat-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  /* ---------- callout ---------- */
+  .callout {
+    max-width: 720px;
+    margin: 34px auto 0;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-left: 3px solid var(--orange);
+    border-radius: 0 16px 16px 0;
+    padding: 26px 30px;
+    font-family: var(--font-display);
+    font-weight: 500;
+    font-size: clamp(18px, 2.6vw, 22px);
+    line-height: 1.45;
+    color: var(--ink);
+  }
+  .band .callout {
+    background: var(--bg);
+  }
+
+  /* ---------- offer / feature list ---------- */
+  .feature-list {
+    list-style: none;
+    margin: 8px 0 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+  }
+  .feature-list li {
+    display: grid;
+    grid-template-columns: 42px 1fr;
+    gap: 16px;
+    align-items: start;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 16px;
+    padding: 20px 22px;
+  }
+  .band .feature-list li {
+    background: var(--bg);
+  }
+  .feature-list .fic {
+    width: 42px;
+    height: 42px;
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--orange) 12%, transparent);
+    display: grid;
+    place-items: center;
+    color: var(--orange-deep);
+    flex: none;
+  }
+  .feature-list .fic svg {
+    width: 21px;
+    height: 21px;
+  }
+  .feature-list h3 {
+    font-family: var(--font-display);
+    font-size: 16.5px;
+    font-weight: 600;
+    margin-bottom: 5px;
+    color: var(--ink);
+  }
+  .feature-list p {
+    font-size: 14.5px;
+    color: var(--ink-soft);
+    line-height: 1.5;
+  }
+  @media (max-width: 720px) {
+    .feature-list {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  /* ---------- pricing tiers ---------- */
+  .tiers {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+    align-items: start;
+    margin-top: 8px;
+  }
+  .tier {
+    position: relative;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 20px;
+    padding: 28px 26px;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+  .band .tier {
+    background: var(--bg);
+  }
+  .tier.featured {
+    border: 2px solid var(--orange);
+    box-shadow:
+      0 18px 44px var(--glow),
+      var(--shadow);
+  }
+  .tier .badge {
+    position: absolute;
+    top: -13px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--orange);
+    color: #fff;
+    font-family: var(--font-display);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 5px 14px;
+    border-radius: 100px;
+    white-space: nowrap;
+  }
+  .tier .tname {
+    font-family: var(--font-display);
+    font-size: 19px;
+    font-weight: 700;
+    color: var(--ink);
+  }
+  .tier .ttag {
+    font-size: 13.5px;
+    color: var(--ink-soft);
+    margin-top: 3px;
+    min-height: 2.6em;
+  }
+  .tier .price {
+    margin-top: 16px;
+    display: flex;
+    align-items: baseline;
+    gap: 7px;
+  }
+  .tier .price .amt {
+    font-family: var(--font-display);
+    font-size: 40px;
+    font-weight: 700;
+    color: var(--ink);
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+  }
+  .tier .price .per {
+    font-size: 14px;
+    color: var(--ink-soft);
+  }
+  .tier ul {
+    list-style: none;
+    margin: 22px 0 0;
+    padding: 0;
+    display: grid;
+    gap: 12px;
+    flex: 1;
+  }
+  .tier ul li {
+    display: grid;
+    grid-template-columns: 20px 1fr;
+    gap: 11px;
+    font-size: 14.5px;
+    color: var(--ink);
+    line-height: 1.45;
+    align-items: start;
+  }
+  .tier ul li svg {
+    width: 18px;
+    height: 18px;
+    color: var(--orange);
+    margin-top: 2px;
+    flex: none;
+  }
+  .tier ul li.lead {
+    color: var(--ink-soft);
+    font-style: italic;
+  }
+  .tier .tcta {
+    margin-top: 24px;
+    display: block;
+    text-align: center;
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 15px;
+    text-decoration: none;
+    padding: 13px 20px;
+    border-radius: 12px;
+    border: 1px solid var(--line);
+    color: var(--ink);
+    transition:
+      border-color 0.2s ease,
+      color 0.2s ease,
+      background 0.2s ease;
+  }
+  .tier .tcta:hover {
+    border-color: var(--orange);
+    color: var(--orange-ink);
+  }
+  .tier.featured .tcta {
+    background: var(--orange);
+    color: #fff;
+    border-color: var(--orange);
+  }
+  .tier.featured .tcta:hover {
+    background: var(--orange-deep);
+    color: #fff;
+  }
+  @media (max-width: 820px) {
+    .tiers {
+      grid-template-columns: 1fr;
+    }
+    .tier .ttag {
+      min-height: 0;
+    }
+  }
+
+  .tiers-note {
+    text-align: center;
+    font-size: 14px;
+    color: var(--ink-soft);
+    margin-top: 24px;
+    max-width: 62ch;
+    margin-inline: auto;
+  }
+
+  .trust-strip {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 9px;
+    justify-content: center;
+    margin-top: 26px;
+  }
+  .trust-strip span {
+    font-family: var(--font-display);
+    font-size: 12.5px;
+    color: var(--ink);
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 100px;
+    padding: 8px 16px;
+    font-weight: 500;
+  }
+  .band .trust-strip span {
+    background: var(--bg);
+  }
+
+  /* ---------- recommend box ---------- */
+  .recommend {
+    margin-top: 30px;
+    display: grid;
+    grid-template-columns: 26px 1fr;
+    gap: 16px;
+    padding: 24px 28px;
+    border-radius: 16px;
+    background: color-mix(in srgb, var(--orange) 8%, var(--surface));
+    border: 1px solid color-mix(in srgb, var(--orange) 32%, var(--line));
+  }
+  .band .recommend {
+    background: color-mix(in srgb, var(--orange) 9%, var(--bg));
+  }
+  .recommend > svg {
+    width: 24px;
+    height: 24px;
+    color: var(--orange-deep);
+    margin-top: 2px;
+  }
+  .recommend h3 {
+    font-family: var(--font-display);
+    font-size: 16.5px;
+    font-weight: 600;
+    margin-bottom: 7px;
+    color: var(--ink);
+  }
+  .recommend p {
+    font-size: 15px;
+    color: var(--ink-soft);
+    line-height: 1.55;
+  }
+  .recommend b {
+    color: var(--ink);
+    font-weight: 600;
+  }
+
+  /* ---------- compliance note ---------- */
+  .compliance {
+    max-width: 62ch;
+    margin: 30px auto 0;
+    text-align: center;
+    font-size: 13.5px;
+    color: var(--ink-soft);
+    line-height: 1.6;
+  }
+
+  /* ---------- next steps ---------- */
+  .steps-list {
+    list-style: none;
+    margin: 8px 0 0;
+    padding: 0;
+    counter-reset: step;
+    display: grid;
+    gap: 12px;
+  }
+  .steps-list li {
+    counter-increment: step;
+    display: grid;
+    grid-template-columns: 34px 1fr;
+    gap: 15px;
+    align-items: center;
+    font-size: 15.5px;
+    color: var(--ink);
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    padding: 16px 20px;
+  }
+  .band .steps-list li {
+    background: var(--bg);
+  }
+  .steps-list li::before {
+    content: counter(step);
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 16px;
+    color: var(--orange-ink);
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: var(--surface-2);
+    display: grid;
+    place-items: center;
+  }
+  .band .steps-list li::before {
+    background: var(--surface);
+  }
+
+  /* ---------- final cta ---------- */
+  .final {
+    text-align: center;
+    padding: 70px 0;
+  }
+  .final h2 {
+    font-size: clamp(28px, 5vw, 42px);
+    line-height: 1.1;
+    max-width: 20ch;
+    margin: 0 auto;
+  }
+  .final h2 em {
+    color: var(--orange);
+    font-style: normal;
+  }
+  .final p {
+    margin: 20px auto 0;
+    max-width: 48ch;
+    color: var(--ink-soft);
+  }
+
+  /* ---------- footer ---------- */
+  footer {
+    border-top: 1px solid var(--line);
+    padding: 32px 0;
+    text-align: center;
+    font-size: 13px;
+    color: var(--ink-soft);
+  }
+  footer .foot-brand {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 15px;
+    color: var(--ink);
+  }
+  footer .foot-brand span {
+    color: var(--orange);
+  }
+  footer .foot-meta {
+    margin-top: 6px;
+  }
+
+  /* ---------- reveal ---------- */
+  .reveal {
+    opacity: 0;
+    transform: translateY(18px);
+    transition:
+      opacity 0.7s ease,
+      transform 0.7s ease;
+  }
+  .reveal.in {
+    opacity: 1;
+    transform: none;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .reveal {
+      opacity: 1;
+      transform: none;
+      transition: none;
+    }
+  }
+</style>
+
+<div class="langtoggle" role="group" aria-label="Language / Idioma">
+  <button id="btnEn" class="on" aria-pressed="true">EN</button>
+  <button id="btnEs" aria-pressed="false">ES</button>
+</div>
+
+<div id="doc" data-lang="en">
+  <!-- ===================== HERO ===================== -->
+  <div class="hero">
+    <div class="hero-glow"></div>
+    <div class="wrap">
+      <div class="topbar">
+        <span class="wordmark">
+          <span class="name">Lumi<b>è</b>re</span>
+          <span class="kicker">Medspa</span>
+        </span>
+        <span class="by lang-en">Prepared by <b>CushLabs.ai</b></span>
+        <span class="by lang-es">Preparado por <b>CushLabs.ai</b></span>
+      </div>
+
+      <div class="hero-inner">
+        <div class="eyebrow">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path
+              d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"
+            />
+            <path d="M14 2v6h6" />
+            <path d="M9 15h6" />
+            <path d="M9 11h6" />
+          </svg>
+          <span class="lang-en">Proposal · AI Assistant on Messenger</span>
+          <span class="lang-es">Propuesta · Asistente de IA en Messenger</span>
+        </div>
+
+        <h1 class="lang-en">
+          The leads are already in your DMs. <em>Camila</em> makes sure none
+          slip away.
+        </h1>
+        <h1 class="lang-es">
+          Los clientes ya están en tus mensajes. <em>Camila</em> se asegura de
+          que ninguno se pierda.
+        </h1>
+
+        <p class="lede lang-en">
+          A 24/7 bilingual AI assistant that lives on Lumière's Facebook page —
+          answering every Messenger DM and post comment in seconds, booking free
+          consults, and alerting you on WhatsApp the moment a client is ready.
+          You keep the page you already have. We put a world-class front desk on
+          it.
+        </p>
+        <p class="lede lang-es">
+          Un asistente de IA bilingüe 24/7 que vive en la página de Facebook de
+          Lumière — contesta cada mensaje y comentario en segundos, agenda
+          consultas gratuitas y te avisa por WhatsApp en cuanto una clienta está
+          lista. Conservas la página que ya tienes. Nosotros le ponemos una
+          recepción de primer nivel.
+        </p>
+
+        <div class="meta">
+          <span class="pill lang-en">Prepared for Lumière Medspa</span>
+          <span class="pill lang-es">Preparado para Lumière Medspa</span>
+          <span>Austin, TX</span>
+          <span style="opacity: 0.5">·</span>
+          <span class="lang-en">July 2026</span>
+          <span class="lang-es">Julio 2026</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ===================== THE PROBLEM ===================== -->
+  <section class="band">
+    <div class="wrap">
+      <div class="section-head reveal">
+        <div class="eyebrow">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M12 9v4" />
+            <path d="M12 17h.01" />
+            <path
+              d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"
+            />
+          </svg>
+          <span class="lang-en">The opportunity</span>
+          <span class="lang-es">La oportunidad</span>
+        </div>
+        <h2 class="lang-en">
+          A medspa's leads arrive after hours — when no one is at the desk.
+        </h2>
+        <h2 class="lang-es">
+          Los clientes de un medspa llegan fuera de horario — cuando no hay
+          nadie en recepción.
+        </h2>
+        <p class="lang-en">
+          People scroll and DM at night and on weekends, exactly when your front
+          desk is closed. A question that waits until morning is a booking your
+          competitor already took.
+        </p>
+        <p class="lang-es">
+          La gente navega y escribe de noche y en fin de semana, justo cuando tu
+          recepción está cerrada. Una pregunta que espera hasta la mañana es una
+          cita que tu competencia ya se llevó.
+        </p>
+      </div>
+
+      <div class="stat-grid reveal">
+        <div class="stat">
+          <span class="num">78%</span>
+          <span class="cap lang-en"
+            >of customers buy from the business that
+            <b>responds first</b>.</span
+          >
+          <span class="cap lang-es"
+            >de los clientes compran con el negocio que
+            <b>responde primero</b>.</span
+          >
+        </div>
+        <div class="stat">
+          <span class="num">&lt; 5s</span>
+          <span class="cap lang-en"
+            >Camila's reply time — versus hours for a message left
+            overnight.</span
+          >
+          <span class="cap lang-es"
+            >tiempo de respuesta de Camila — frente a horas de un mensaje dejado
+            de madrugada.</span
+          >
+        </div>
+        <div class="stat">
+          <span class="num">24/7</span>
+          <span class="cap lang-en"
+            >coverage in English and Spanish, including the nights and Sundays
+            you're closed.</span
+          >
+          <span class="cap lang-es"
+            >cobertura en inglés y español, incluidas las noches y los domingos
+            que cierras.</span
+          >
+        </div>
+      </div>
+
+      <div class="callout reveal">
+        <span class="lang-en"
+          >"Sorry for the late reply!" is the most expensive sentence in a
+          medspa's inbox. Camila never has to send it.</span
+        >
+        <span class="lang-es"
+          >"¡Perdón por la respuesta tardía!" es la frase más cara en la bandeja
+          de un medspa. Camila nunca tiene que enviarla.</span
+        >
+      </div>
+    </div>
+  </section>
+
+  <!-- ===================== THE OFFER ===================== -->
+  <section>
+    <div class="wrap">
+      <div class="section-head reveal">
+        <div class="eyebrow">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z" />
+          </svg>
+          <span class="lang-en">What Camila does</span>
+          <span class="lang-es">Qué hace Camila</span>
+        </div>
+        <h2 class="lang-en">
+          An AI front desk for Lumière's Messenger — trained to sound like you.
+        </h2>
+        <h2 class="lang-es">
+          Una recepción con IA para el Messenger de Lumière — entrenada para
+          sonar como tú.
+        </h2>
+        <p class="lang-en">
+          We build, train, connect, and manage the whole thing. Camila learns
+          your real menu, prices, hours, and policies — she answers from facts
+          and never invents.
+        </p>
+        <p class="lang-es">
+          Nosotros construimos, entrenamos, conectamos y administramos todo.
+          Camila aprende tu menú, precios, horarios y políticas reales —
+          responde con datos y nunca inventa.
+        </p>
+      </div>
+
+      <ul class="feature-list reveal">
+        <li>
+          <span class="fic"
+            ><svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z" /></svg
+          ></span>
+          <div>
+            <h3 class="lang-en">Answers DMs &amp; comments in seconds</h3>
+            <h3 class="lang-es">Contesta mensajes y comentarios en segundos</h3>
+            <p class="lang-en">
+              Every Messenger DM and every comment on a post gets an instant,
+              on-brand reply — and comments move to a private message.
+            </p>
+            <p class="lang-es">
+              Cada mensaje de Messenger y cada comentario recibe una respuesta
+              instantánea y con tu estilo — y los comentarios pasan a mensaje
+              privado.
+            </p>
+          </div>
+        </li>
+        <li>
+          <span class="fic"
+            ><svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="m5 8 6 6" />
+              <path d="m4 14 6-6 2-3" />
+              <path d="M2 5h12" />
+              <path d="M7 2h1" />
+              <path d="m22 22-5-10-5 10" />
+              <path d="M14 18h6" /></svg
+          ></span>
+          <div>
+            <h3 class="lang-en">Bilingual, automatically</h3>
+            <h3 class="lang-es">Bilingüe, automáticamente</h3>
+            <p class="lang-en">
+              She replies in English or Spanish, following whatever language the
+              customer writes in — no setting to flip.
+            </p>
+            <p class="lang-es">
+              Responde en inglés o español, según el idioma en que escriba el
+              cliente — sin nada que configurar.
+            </p>
+          </div>
+        </li>
+        <li>
+          <span class="fic"
+            ><svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M8 2v4" />
+              <path d="M16 2v4" />
+              <rect width="18" height="18" x="3" y="4" rx="2" />
+              <path d="M3 10h18" />
+              <path d="m9 16 2 2 4-4" /></svg
+          ></span>
+          <div>
+            <h3 class="lang-en">Books free consults</h3>
+            <h3 class="lang-es">Agenda consultas gratuitas</h3>
+            <p class="lang-en">
+              For any injectable or laser treatment, she routes the client to a
+              free consult with a licensed medical provider — never medical
+              advice.
+            </p>
+            <p class="lang-es">
+              Para cualquier tratamiento inyectable o láser, deriva al cliente a
+              una consulta gratuita con un médico con licencia — nunca da
+              consejo médico.
+            </p>
+          </div>
+        </li>
+        <li>
+          <span class="fic"
+            ><svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+              <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" /></svg
+          ></span>
+          <div>
+            <h3 class="lang-en">Alerts you on WhatsApp</h3>
+            <h3 class="lang-es">Te avisa por WhatsApp</h3>
+            <p class="lang-en">
+              The moment a lead is hot, you get a WhatsApp ping with the name,
+              contact, and what they want — you only step in to close.
+            </p>
+            <p class="lang-es">
+              En cuanto un cliente está listo, recibes un aviso por WhatsApp con
+              el nombre, el contacto y lo que busca — tú solo entras a cerrar.
+            </p>
+          </div>
+        </li>
+        <li>
+          <span class="fic"
+            ><svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path
+                d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z"
+              /></svg
+          ></span>
+          <div>
+            <h3 class="lang-en">Manages your Google reviews</h3>
+            <h3 class="lang-es">Gestiona tus reseñas de Google</h3>
+            <p class="lang-en">
+              She drafts on-brand responses to new Google reviews — you approve,
+              and it posts. Your reputation stays fresh without the busywork.
+            </p>
+            <p class="lang-es">
+              Redacta respuestas con tu estilo para las reseñas nuevas de Google
+              — tú apruebas y se publica. Tu reputación se mantiene al día sin
+              trabajo extra.
+            </p>
+          </div>
+        </li>
+        <li>
+          <span class="fic"
+            ><svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M20 6 9 17l-5-5" /></svg
+          ></span>
+          <div>
+            <h3 class="lang-en">Grounded — never invents</h3>
+            <h3 class="lang-es">Basada en datos — nunca inventa</h3>
+            <p class="lang-en">
+              Hours and prices come back exact. When she isn't sure, she offers
+              a human instead of guessing.
+            </p>
+            <p class="lang-es">
+              Horarios y precios salen exactos. Cuando no está segura, ofrece a
+              una persona en vez de adivinar.
+            </p>
+          </div>
+        </li>
+      </ul>
+
+      <p class="compliance reveal">
+        <span class="lang-en"
+          >Lumière Medspa is a fictitious business used to demonstrate the
+          assistant. Camila answers questions and books consults — she does not
+          diagnose, prescribe, or give medical advice. Every injectable and
+          laser service begins with a free consultation with a licensed medical
+          provider.</span
+        >
+        <span class="lang-es"
+          >Lumière Medspa es un negocio ficticio usado para demostrar el
+          asistente. Camila responde preguntas y agenda consultas — no
+          diagnostica, no receta ni da consejo médico. Todo servicio inyectable
+          o láser comienza con una consulta gratuita con un médico con
+          licencia.</span
+        >
+      </p>
+    </div>
+  </section>
+
+  <!-- ===================== PRICING ===================== -->
+  <section class="band">
+    <div class="wrap">
+      <div class="section-head center reveal">
+        <div class="eyebrow">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <line x1="12" x2="12" y1="2" y2="22" />
+            <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
+          </svg>
+          <span class="lang-en">Simple, transparent pricing</span>
+          <span class="lang-es">Precios simples y transparentes</span>
+        </div>
+        <h2 class="lang-en">
+          One monthly price. Everything set up and managed for you.
+        </h2>
+        <h2 class="lang-es">
+          Un solo precio al mes. Todo configurado y gestionado por nosotros.
+        </h2>
+        <p class="lang-en">
+          No setup fee, no contract. Pick a tier and we handle the rest.
+        </p>
+        <p class="lang-es">
+          Sin cuota de instalación, sin contrato. Eliges un plan y nosotros
+          hacemos el resto.
+        </p>
+      </div>
+
+      <div class="tiers reveal">
+        <!-- Basic -->
+        <div class="tier">
+          <div class="tname">Basic</div>
+          <div class="ttag lang-en">For getting started</div>
+          <div class="ttag lang-es">Para empezar</div>
+          <div class="price">
+            <span class="amt">$129</span>
+            <span class="per lang-en">USD/mo</span>
+            <span class="per lang-es">USD/mes</span>
+          </div>
+          <ul>
+            <li>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M20 6 9 17l-5-5" /></svg
+              ><span class="lang-en"
+                >AI assistant on Facebook Messenger (24/7, bilingual)</span
+              ><span class="lang-es"
+                >Asistente de IA en Facebook Messenger (24/7, bilingüe)</span
+              >
+            </li>
+            <li>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M20 6 9 17l-5-5" /></svg
+              ><span class="lang-en"
+                >Google review management — you approve, it posts</span
+              ><span class="lang-es"
+                >Gestión de reseñas de Google — apruebas y se publica</span
+              >
+            </li>
+            <li>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M20 6 9 17l-5-5" /></svg
+              ><span class="lang-en"
+                >Lead capture + instant owner alerts on WhatsApp</span
+              ><span class="lang-es"
+                >Captura de clientes + avisos al instante por WhatsApp</span
+              >
+            </li>
+            <li>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M20 6 9 17l-5-5" /></svg
+              ><span class="lang-en"
+                >Fully managed: setup, training, ongoing support</span
+              ><span class="lang-es"
+                >Todo gestionado: configuración, entrenamiento y soporte</span
+              >
+            </li>
+          </ul>
+          <a class="tcta" href="#next-steps"
+            ><span class="lang-en">Get started</span
+            ><span class="lang-es">Empieza</span></a
+          >
+        </div>
+
+        <!-- Premium -->
+        <div class="tier">
+          <div class="tname">Premium</div>
+          <div class="ttag lang-en">For growing practices</div>
+          <div class="ttag lang-es">Para consultorios en crecimiento</div>
+          <div class="price">
+            <span class="amt">$229</span>
+            <span class="per lang-en">USD/mo</span>
+            <span class="per lang-es">USD/mes</span>
+          </div>
+          <ul>
+            <li class="lead">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M20 6 9 17l-5-5" /></svg
+              ><span class="lang-en">Everything in Basic, plus:</span
+              ><span class="lang-es">Todo lo de Basic, más:</span>
+            </li>
+            <li>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M20 6 9 17l-5-5" /></svg
+              ><span class="lang-en"
+                >Website chatbot — the same AI brain on your site</span
+              ><span class="lang-es"
+                >Chatbot para tu sitio web — el mismo cerebro de IA en tu
+                sitio</span
+              >
+            </li>
+            <li>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M20 6 9 17l-5-5" /></svg
+              ><span class="lang-en"
+                >Weekly local SEO &amp; competitor report</span
+              ><span class="lang-es"
+                >Reporte semanal de SEO local y competencia</span
+              >
+            </li>
+          </ul>
+          <a class="tcta" href="#next-steps"
+            ><span class="lang-en">Get started</span
+            ><span class="lang-es">Empieza</span></a
+          >
+        </div>
+
+        <!-- Ultra (featured, medspa tier) -->
+        <div class="tier featured">
+          <span class="badge lang-en">Recommended for medspas</span>
+          <span class="badge lang-es">Recomendado para medspas</span>
+          <div class="tname">Ultra</div>
+          <div class="ttag lang-en">For clinics &amp; high-volume medspas</div>
+          <div class="ttag lang-es">
+            Para clínicas y medspas de alto volumen
+          </div>
+          <div class="price">
+            <span class="amt">$349</span>
+            <span class="per lang-en">USD/mo</span>
+            <span class="per lang-es">USD/mes</span>
+          </div>
+          <ul>
+            <li class="lead">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M20 6 9 17l-5-5" /></svg
+              ><span class="lang-en">Everything in Premium, plus:</span
+              ><span class="lang-es">Todo lo de Premium, más:</span>
+            </li>
+            <li>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M20 6 9 17l-5-5" /></svg
+              ><span class="lang-en"
+                >AI Voice Agent — captures missed calls (300 answered
+                min/mo)</span
+              ><span class="lang-es"
+                >Agente de Voz con IA — captura llamadas perdidas (300 min
+                contestados/mes)</span
+              >
+            </li>
+            <li>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M20 6 9 17l-5-5" /></svg
+              ><span class="lang-en"
+                >Weekly reputation &amp; reviews report</span
+              ><span class="lang-es"
+                >Reporte semanal de reputación y reseñas</span
+              >
+            </li>
+            <li>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M20 6 9 17l-5-5" /></svg
+              ><span class="lang-en"
+                >Priority support + healthcare industry tuning</span
+              ><span class="lang-es"
+                >Soporte prioritario + personalización para el sector
+                salud</span
+              >
+            </li>
+          </ul>
+          <a class="tcta" href="#next-steps"
+            ><span class="lang-en">Start the free trial</span
+            ><span class="lang-es">Inicia la prueba gratis</span></a
+          >
+        </div>
+      </div>
+
+      <p class="tiers-note reveal">
+        <span class="lang-en"
+          >Every plan includes up to 2 locations · additional locations +$49
+          USD/mo each. USD pricing for US-based businesses.</span
+        >
+        <span class="lang-es"
+          >Todos los planes incluyen hasta 2 sucursales · sucursales adicionales
+          +$49 USD/mes cada una. Precios en USD para negocios en EE. UU.</span
+        >
+      </p>
+
+      <div class="trust-strip reveal">
+        <span class="lang-en">Free 1-week trial</span
+        ><span class="lang-es">Prueba gratis de 1 semana</span>
+        <span class="lang-en">No setup fee</span
+        ><span class="lang-es">Sin cuota de instalación</span>
+        <span class="lang-en">Month-to-month, no contract</span
+        ><span class="lang-es">Mes a mes, sin contrato</span>
+        <span class="lang-en">Unlimited conversations</span
+        ><span class="lang-es">Conversaciones ilimitadas</span>
+      </div>
+
+      <div class="recommend reveal">
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="m9 12 2 2 4-4" />
+          <path d="M5 7c0-1.1.9-2 2-2h10a2 2 0 0 1 2 2v12l-7-3-7 3z" />
+        </svg>
+        <div>
+          <h3 class="lang-en">Why we recommend Ultra for Lumière</h3>
+          <h3 class="lang-es">Por qué recomendamos Ultra para Lumière</h3>
+          <p class="lang-en">
+            A medspa lives and dies on <b>booked consults</b> and
+            <b>reputation</b>. Ultra's <b>AI Voice Agent</b> catches the calls
+            you miss when the desk is full, and the
+            <b>weekly reputation report</b> keeps your Google star rating
+            climbing — the two levers that move revenue most in aesthetics.
+            Messenger, website chat, and voice all share one brain that knows
+            your menu.
+          </p>
+          <p class="lang-es">
+            Un medspa vive de las <b>consultas agendadas</b> y la
+            <b>reputación</b>. El <b>Agente de Voz con IA</b> de Ultra atrapa
+            las llamadas que se pierden cuando la recepción está llena, y el
+            <b>reporte semanal de reputación</b> mantiene tu calificación de
+            Google en ascenso — las dos palancas que más mueven los ingresos en
+            estética. Messenger, chat web y voz comparten un solo cerebro que
+            conoce tu menú.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===================== NEXT STEPS ===================== -->
+  <section id="next-steps">
+    <div class="wrap narrow">
+      <div class="section-head reveal">
+        <div class="eyebrow">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M5 12h14" />
+            <path d="m12 5 7 7-7 7" />
+          </svg>
+          <span class="lang-en">Next steps</span>
+          <span class="lang-es">Siguientes pasos</span>
+        </div>
+        <h2 class="lang-en">Live on your Facebook page in about a week.</h2>
+        <h2 class="lang-es">
+          En vivo en tu página de Facebook en cerca de una semana.
+        </h2>
+      </div>
+
+      <ol class="steps-list reveal">
+        <li>
+          <span class="lang-en"
+            >You approve the plan and share your menu, prices, and hours.</span
+          >
+          <span class="lang-es"
+            >Apruebas el plan y compartes tu menú, precios y horarios.</span
+          >
+        </li>
+        <li>
+          <span class="lang-en"
+            >We build and train Camila on Lumière's real services and
+            tone.</span
+          >
+          <span class="lang-es"
+            >Construimos y entrenamos a Camila con los servicios y el tono
+            reales de Lumière.</span
+          >
+        </li>
+        <li>
+          <span class="lang-en"
+            >We connect her to your existing Facebook page — nothing new for you
+            to run.</span
+          >
+          <span class="lang-es"
+            >La conectamos a tu página de Facebook actual — nada nuevo que tú
+            tengas que operar.</span
+          >
+        </li>
+        <li>
+          <span class="lang-en"
+            >You test her free for a week. If she's not carrying her weight, you
+            walk away.</span
+          >
+          <span class="lang-es"
+            >La pruebas gratis una semana. Si no está a la altura, te retiras
+            sin compromiso.</span
+          >
+        </li>
+      </ol>
+    </div>
+  </section>
+
+  <!-- ===================== FINAL CTA ===================== -->
+  <section class="final band">
+    <div class="wrap narrow">
+      <h2 class="lang-en reveal">
+        Stop losing after-hours leads. <em>Put Camila on the front desk.</em>
+      </h2>
+      <h2 class="lang-es reveal">
+        Deja de perder clientes fuera de horario.
+        <em>Pon a Camila en recepción.</em>
+      </h2>
+      <p class="lang-en reveal">
+        A free week, no setup fee, and no contract. If it works, you keep it.
+        That's the whole risk.
+      </p>
+      <p class="lang-es reveal">
+        Una semana gratis, sin cuota de instalación y sin contrato. Si funciona,
+        te quedas. Ese es todo el riesgo.
+      </p>
+      <div class="trust-strip reveal">
+        <span class="lang-en">Free 1-week trial</span
+        ><span class="lang-es">Prueba gratis de 1 semana</span>
+        <span class="lang-en">No setup fee</span
+        ><span class="lang-es">Sin cuota de instalación</span>
+        <span class="lang-en">Live in ~1 week</span
+        ><span class="lang-es">En vivo en ~1 semana</span>
+      </div>
+    </div>
+  </section>
+
+  <footer>
+    <div class="wrap">
+      <div class="foot-brand">Cush<span>Labs</span>.ai</div>
+      <div class="foot-meta lang-en">
+        Proposal prepared by CushLabs.ai · Demonstration · Lumière Medspa is a
+        fictitious business created for this demo.
+      </div>
+      <div class="foot-meta lang-es">
+        Propuesta preparada por CushLabs.ai · Demostración · Lumière Medspa es
+        un negocio ficticio creado para esta demostración.
+      </div>
+    </div>
+  </footer>
+</div>
+
+<script>
+  (function () {
+    var doc = document.getElementById("doc");
+    var btnEs = document.getElementById("btnEs");
+    var btnEn = document.getElementById("btnEn");
+
+    function setLang(lang) {
+      doc.setAttribute("data-lang", lang);
+      btnEs.classList.toggle("on", lang === "es");
+      btnEn.classList.toggle("on", lang === "en");
+      btnEs.setAttribute("aria-pressed", String(lang === "es"));
+      btnEn.setAttribute("aria-pressed", String(lang === "en"));
+    }
+    btnEs.addEventListener("click", function () {
+      setLang("es");
+    });
+    btnEn.addEventListener("click", function () {
+      setLang("en");
+    });
+    setLang("en");
+
+    var reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    var reveals = document.querySelectorAll(".reveal");
+    if (reduce || !("IntersectionObserver" in window)) {
+      reveals.forEach(function (el) {
+        el.classList.add("in");
+      });
+    } else {
+      var io = new IntersectionObserver(
+        function (entries) {
+          entries.forEach(function (e) {
+            if (e.isIntersecting) {
+              e.target.classList.add("in");
+              io.unobserve(e.target);
+            }
+          });
+        },
+        { threshold: 0.12 },
+      );
+      reveals.forEach(function (el) {
+        io.observe(el);
+      });
+    }
+  })();
+</script>

--- a/docs/strategy/US-ESTETICA-BILINGUAL-WEDGE.md
+++ b/docs/strategy/US-ESTETICA-BILINGUAL-WEDGE.md
@@ -1,0 +1,80 @@
+# US Estéticas — the bilingual-wedge extension
+
+> **Scope:** This is a **scoped extension** of the MX-first strategy, not a reversal
+> of it. `MEXICO-GTM-STRATEGY.md` §0 remains in force (MX-first; the prior
+> US-oriented model stays superseded). This doc defines how — and only how — we
+> open a US front **without** contradicting that, by riding the one US angle the
+> strategy already endorses: the bilingual wedge.
+>
+> _Created 2026-07-25._
+
+## The thesis
+
+Our #1 decided beachhead vertical is **beauty / salons / medspas** (`MEXICO-GTM-STRATEGY.md`
+§6). Our documented US angle is the **bilingual wedge** (`GTM_OUTLINE.md` §3): US
+businesses that serve Spanish-speaking customers and can't staff bilingual coverage.
+
+**US Estéticas sit exactly at that intersection.** US medspas, aesthetic clinics,
+and salons are heavily Latina-owned and serve bilingual clientele. So a single
+**bilingual EN + es-MX** medspa asset serves three goals at once:
+
+1. the **US-market** ask (English-first face),
+2. the **bilingual wedge** (the one US angle the strategy blesses), and
+3. the **Mexican beachhead** (the same vertical, same asset, es-MX toggle).
+
+One asset, three markets. This deepens the core vertical rather than diverging
+from it — which is why it is on-strategy despite being US-facing.
+
+## Where it maps in the product
+
+- **Tier fit = Ultra ("clinic / medspa" tier).** Medspas are higher-WTP and often
+  already digitized. The pitch skews to Ultra: the AI front desk (Messenger) +
+  **AI Voice Agent** for inbound call capture + the weekly reputation/reviews
+  report (MarketSignal). See `PRODUCT-AND-PRICING-SUMMARY.md`. USD anchors
+  $129 / $229 / $349, **independently anchored — never converted from MXN.**
+- **Combined offer:** Messenger bot handles the _conversation_ (DMs, comment→DM,
+  after-hours lead capture, owner alerts); MarketSignal handles the _intelligence_
+  (Google rank vs. competitor medspas, review velocity, AI-drafted review replies).
+  Reviews matter disproportionately in aesthetics — "84% read reviews before
+  choosing" (`MEXICO-GTM-STRATEGY.md` §6).
+- **Existing English seed:** the med-spa Voice demo "Sophia" (`voice-cushlabs-ai-briefing.md`)
+  already proves an English medspa persona.
+
+## The flagship demo asset
+
+**Lumière Medspa (Demo)** — a fictitious, honestly-labeled US bilingual medspa
+(Austin, TX), built with the config-driven demo factory in
+`cushlabs-messenger-bot/scripts/demo-factory/` (tenant `lumiere-demo`). Its gated
+client-facing wrapper lives here:
+
+- Preview hub (live "chat with Camila"): `cushlabs/demos/lumiere/preview.html`
+- Sales proposal (Ultra-tier framing): `cushlabs/demos/lumiere/proposal.html`
+
+Served gated via `api/demo.ts` (company slug `lumiere`). This is a **showcase to
+many** US medspa prospects, not a single-client proposal.
+
+## The gate — what is NOT yet cleared (do not skip)
+
+Building and sending these demos requires nothing new. **Invoicing a US client
+does.** Two prerequisites are unmet and tracked as
+`cushlabs-messenger-bot/docs/TECH_DEBT.md` #15:
+
+1. **US business entity** — the US LLC forms "on first American/USD client"
+   (`cushlabs-messenger-bot/docs/BILLING.md`). No entity exists yet; USD invoicing
+   and tax handling depend on it.
+2. **US medical-advertising compliance** — US medspas advertise medical procedures
+   (Botox, lasers, peels) that require licensed physician oversight. Our es-MX
+   guardrails do not cover US norms (FTC substantiation, state medical-board
+   advertising rules, "results not typical" conventions). Any real medspa client's
+   bot copy and claims must be reviewed against these before go-live.
+
+**Rule:** demos and outreach are green now; the moment a US medspa says "yes,"
+those two gates promote to blocking. Surface them at that point, not after.
+
+## Still net-new (deferred)
+
+- An **English salon/estética landing page** + outreach script (all current
+  outreach assets — `docs/outreach/salones-outreach-es.md`, `cushlabs.ai/salones/`
+  — are es-MX only).
+- Re-validating the channel thesis for the US (US medspas may run through a
+  receptionist or Booksy/Fresha, unlike the MX owner-answers-own-DMs assumption).


### PR DESCRIPTION
feat(demos): Lumière Medspa — bilingual US medspa preview hub + proposal

The gated client-facing wrapper for the Estéticas / US bilingual-wedge push. The
demo store (FB page + AI agent) lives in cushlabs-messenger-bot (tenant
lumiere-demo); this is its client-facing side.

- demos/lumiere/preview.html — the live "chat with Camila" hub: m.me CTA,
  copy-to-clipboard sample prompts, bilingual tester caveat, how-it-works strip.
- demos/lumiere/proposal.html — medspa sales proposal, Ultra tier framed as the
  clinic/medspa tier (USD $129/$229/$349, never converted from MXN).
- api/demo.ts — registers the `lumiere` gate entry (preview + proposal).
- docs/strategy/US-ESTETICA-BILINGUAL-WEDGE.md — scoped strategy note (extends
  MX-first, does not override it) + the US-client billing/compliance gate.

Both pages: EN-default bilingual (es-MX toggle), brand system (cush-orange,
Space Grotesk + Source Serif stacks, dark-mode), inline Lucide SVG, self-contained
(no external fonts/CDN, CSP-safe like demos/azucar). Verified: no forbidden
phrases, no medical claims, no Iberian markers; tsc --noEmit clean.

Known follow-up: the m.me link uses M_ME_PAGE_ID_PLACEHOLDER until the Lumière
Facebook page is created (the one human step), then it's swapped for the real id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
