### PR TITLE
feat(demos): Lumière public offerings-only services page

### DIFF
--- a/api/demo.ts
+++ b/api/demo.ts
@@ -67,7 +67,9 @@ const DEMOS: Record<string, DemoConfig> = {
     clientName: "Lumière Medspa (Demo) — US medspa showcase",
     accessToken: "lumiere-DZK5Tk4i4yhTvINZMbf2",
     createdAt: "2026-07-25",
-    pages: ["preview.html", "proposal.html"],
+    // services.html = public offerings-only composite (only what we deliver today,
+    // incl. live in-chat booking). No roadmap/"coming soon" items are referenced.
+    pages: ["preview.html", "proposal.html", "services.html"],
   },
 };
 

--- a/demos/lumiere/services.html
+++ b/demos/lumiere/services.html
@@ -1,0 +1,1593 @@
+<title>Lumière Medspa — The complete AI front office · CushLabs</title>
+<style>
+  /* No external font import — gated demo pages stay self-contained (CSP-safe,
+     matching demos/lumiere/preview.html & proposal.html). Brand fonts are used
+     when locally available; the stacks fall back cleanly to system-ui / Georgia. */
+  :root {
+    --bg: #f6f3f0;
+    --surface: #ffffff;
+    --surface-2: #f1ece7;
+    --ink: #16130f;
+    --ink-soft: #5f5a54;
+    --orange: #ff6a3d;
+    --orange-ink: #d24d20;
+    --orange-deep: #e0522a;
+    --line: #e8e1d9;
+    --live: #3fbf6a;
+    --live-ink: #1c7a44;
+    --shadow: 24px 24px 60px rgba(22, 19, 15, 0.08);
+    --glow: rgba(255, 106, 61, 0.18);
+    --font-display: "Space Grotesk", system-ui, sans-serif;
+    --font-body: "Source Serif 4", Georgia, "Times New Roman", serif;
+    color-scheme: light;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #000000;
+      --surface: #111111;
+      --surface-2: #191919;
+      --ink: #ffffff;
+      --ink-soft: #a6a6a6;
+      --orange: #ff6a3d;
+      --orange-ink: #ff8256;
+      --orange-deep: #ff7d52;
+      --line: #232323;
+      --live: #3fbf6a;
+      --live-ink: #6ee7a0;
+      --shadow: 24px 24px 60px rgba(0, 0, 0, 0.45);
+      --glow: rgba(255, 106, 61, 0.22);
+      color-scheme: dark;
+    }
+  }
+  :root[data-theme="light"] {
+    --bg: #f6f3f0;
+    --surface: #ffffff;
+    --surface-2: #f1ece7;
+    --ink: #16130f;
+    --ink-soft: #5f5a54;
+    --orange: #ff6a3d;
+    --orange-ink: #d24d20;
+    --orange-deep: #e0522a;
+    --line: #e8e1d9;
+    --live: #3fbf6a;
+    --live-ink: #1c7a44;
+    --shadow: 24px 24px 60px rgba(22, 19, 15, 0.08);
+    --glow: rgba(255, 106, 61, 0.18);
+    color-scheme: light;
+  }
+  :root[data-theme="dark"] {
+    --bg: #000000;
+    --surface: #111111;
+    --surface-2: #191919;
+    --ink: #ffffff;
+    --ink-soft: #a6a6a6;
+    --orange: #ff6a3d;
+    --orange-ink: #ff8256;
+    --orange-deep: #ff7d52;
+    --line: #232323;
+    --live: #3fbf6a;
+    --live-ink: #6ee7a0;
+    --shadow: 24px 24px 60px rgba(0, 0, 0, 0.45);
+    --glow: rgba(255, 106, 61, 0.22);
+    color-scheme: dark;
+  }
+
+  * {
+    box-sizing: border-box;
+  }
+  html,
+  body {
+    margin: 0;
+    padding: 0;
+  }
+  body {
+    background: var(--bg);
+    color: var(--ink);
+    font-family: var(--font-body);
+    font-size: 17px;
+    line-height: 1.65;
+    overflow-x: hidden;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+  h1,
+  h2,
+  h3 {
+    font-family: var(--font-display);
+    font-weight: 600;
+    text-wrap: balance;
+    margin: 0;
+    letter-spacing: -0.01em;
+  }
+  p {
+    margin: 0;
+  }
+  a {
+    color: var(--orange-ink);
+  }
+  ::selection {
+    background: var(--orange);
+    color: #000;
+  }
+  :focus-visible {
+    outline: 2px solid var(--orange);
+    outline-offset: 3px;
+    border-radius: 6px;
+  }
+
+  .wrap {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 0 24px;
+  }
+  .narrow {
+    max-width: 760px;
+  }
+
+  /* ---------- language toggle ---------- */
+  .langtoggle {
+    position: fixed;
+    top: 14px;
+    right: 14px;
+    z-index: 50;
+    display: flex;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 100px;
+    padding: 3px;
+    box-shadow: var(--shadow);
+  }
+  .langtoggle button {
+    border: 0;
+    background: transparent;
+    color: var(--ink-soft);
+    font-family: var(--font-display);
+    font-size: 12.5px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    padding: 6px 15px;
+    border-radius: 100px;
+    cursor: pointer;
+  }
+  .langtoggle button.on {
+    background: var(--orange);
+    color: #000;
+  }
+  #doc[data-lang="es"] .lang-en {
+    display: none !important;
+  }
+  #doc[data-lang="en"] .lang-es {
+    display: none !important;
+  }
+
+  /* ---------- topbar / brand ---------- */
+  .topbar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 26px 0 0;
+    color: var(--ink-soft);
+    font-size: 13px;
+    letter-spacing: 0.04em;
+  }
+  .wordmark {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 9px;
+  }
+  .wordmark .name {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 21px;
+    letter-spacing: -0.01em;
+    color: var(--ink);
+  }
+  .wordmark .name b {
+    color: var(--orange);
+    font-weight: 700;
+  }
+  .wordmark .kicker {
+    font-family: var(--font-display);
+    font-size: 10.5px;
+    font-weight: 600;
+    letter-spacing: 0.24em;
+    text-transform: uppercase;
+    color: var(--ink-soft);
+  }
+  .topbar .by {
+    margin-left: auto;
+    font-family: var(--font-display);
+    font-size: 11.5px;
+    letter-spacing: 0.06em;
+  }
+  .topbar .by b {
+    color: var(--ink);
+    font-weight: 600;
+  }
+  @media (max-width: 560px) {
+    .topbar .by {
+      display: none;
+    }
+  }
+
+  .eyebrow {
+    font-family: var(--font-display);
+    font-size: 12px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    font-weight: 600;
+    color: var(--orange-ink);
+    margin-bottom: 16px;
+    display: flex;
+    align-items: center;
+    gap: 9px;
+  }
+  .eyebrow svg {
+    width: 15px;
+    height: 15px;
+  }
+
+  /* ---------- hero ---------- */
+  .hero {
+    position: relative;
+    padding: 30px 0 56px;
+  }
+  .hero-glow {
+    position: absolute;
+    top: -40px;
+    left: 20%;
+    width: 460px;
+    height: 460px;
+    background: var(--glow);
+    border-radius: 50%;
+    filter: blur(120px);
+    z-index: -1;
+    pointer-events: none;
+  }
+  .hero-inner {
+    padding-top: 34px;
+  }
+  .hero h1 {
+    font-size: clamp(33px, 5.6vw, 56px);
+    line-height: 1.05;
+    max-width: 18ch;
+  }
+  .hero h1 em {
+    color: var(--orange);
+    font-style: normal;
+  }
+  .hero .lede {
+    margin-top: 22px;
+    max-width: 60ch;
+    font-size: clamp(17px, 2.2vw, 19px);
+    color: var(--ink-soft);
+    line-height: 1.6;
+  }
+  .hero .meta {
+    margin-top: 30px;
+    font-size: 13.5px;
+    color: var(--ink-soft);
+    letter-spacing: 0.02em;
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+  .hero .meta .pill {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 100px;
+    padding: 6px 15px;
+    color: var(--ink);
+    font-weight: 500;
+    font-family: var(--font-display);
+    font-size: 12.5px;
+  }
+
+  /* ---------- sections ---------- */
+  section {
+    padding: 58px 0;
+  }
+  .band {
+    background: var(--surface);
+    border-top: 1px solid var(--line);
+    border-bottom: 1px solid var(--line);
+  }
+  .section-head {
+    max-width: 46ch;
+    margin-bottom: 34px;
+  }
+  .section-head.center {
+    margin-inline: auto;
+    text-align: center;
+    max-width: 46ch;
+  }
+  .section-head.center .eyebrow {
+    justify-content: center;
+  }
+  .section-head h2 {
+    font-size: clamp(26px, 4.2vw, 38px);
+    line-height: 1.12;
+  }
+  .section-head p {
+    margin-top: 15px;
+    color: var(--ink-soft);
+    max-width: 60ch;
+  }
+  .section-head.center p {
+    margin-inline: auto;
+  }
+
+  /* ---------- status badge ---------- */
+  .badge-status {
+    font-family: var(--font-display);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+    padding: 4px 10px;
+    border-radius: 100px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    white-space: nowrap;
+    flex: none;
+  }
+  .badge-status .bdot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+  }
+  .badge-status.live {
+    color: var(--live-ink);
+    background: color-mix(in srgb, var(--live) 15%, var(--surface));
+    border: 1px solid color-mix(in srgb, var(--live) 40%, var(--line));
+  }
+  .band .badge-status.live {
+    background: color-mix(in srgb, var(--live) 15%, var(--bg));
+  }
+  .badge-status.live .bdot {
+    background: var(--live);
+  }
+
+  /* ---------- capability grid ---------- */
+  .cap-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+    margin-top: 8px;
+  }
+  .cap {
+    position: relative;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 18px;
+    padding: 24px 24px;
+    display: flex;
+    flex-direction: column;
+  }
+  .band .cap {
+    background: var(--bg);
+  }
+  .cap-top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 15px;
+  }
+  .cap-ic {
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--orange) 12%, transparent);
+    display: grid;
+    place-items: center;
+    color: var(--orange-deep);
+    flex: none;
+  }
+  .cap-ic svg {
+    width: 22px;
+    height: 22px;
+  }
+  .cap h3 {
+    font-family: var(--font-display);
+    font-size: 17px;
+    font-weight: 600;
+    color: var(--ink);
+    margin-bottom: 8px;
+  }
+  .cap p {
+    font-size: 14.5px;
+    color: var(--ink-soft);
+    line-height: 1.5;
+    flex: 1;
+  }
+  .cap-link {
+    margin-top: 14px;
+    font-family: var(--font-display);
+    font-size: 13.5px;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    text-decoration: none;
+    color: var(--orange-ink);
+    align-self: flex-start;
+  }
+  .cap-link svg {
+    width: 15px;
+    height: 15px;
+    transition: transform 0.2s ease;
+  }
+  .cap-link:hover svg {
+    transform: translateX(3px);
+  }
+  @media (max-width: 720px) {
+    .cap-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  /* ---------- powered by Meta band ---------- */
+  .meta-platforms {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 14px;
+    margin-top: 30px;
+    max-width: 640px;
+    margin-inline: auto;
+  }
+  .mp {
+    display: flex;
+    align-items: flex-start;
+    gap: 13px;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 16px;
+    padding: 20px 20px;
+    text-align: left;
+  }
+  .band .mp {
+    background: var(--bg);
+  }
+  .mp .mp-ic {
+    width: 40px;
+    height: 40px;
+    border-radius: 10px;
+    background: color-mix(in srgb, var(--orange) 12%, transparent);
+    display: grid;
+    place-items: center;
+    color: var(--orange-deep);
+    flex: none;
+  }
+  .mp .mp-ic svg {
+    width: 20px;
+    height: 20px;
+  }
+  .mp .mp-name {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 15px;
+    color: var(--ink);
+    line-height: 1.25;
+  }
+  .mp .mp-sub {
+    font-size: 12.5px;
+    color: var(--ink-soft);
+    margin-top: 5px;
+    line-height: 1.45;
+  }
+  @media (max-width: 720px) {
+    .meta-platforms {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  /* ---------- pricing tiers ---------- */
+  .tiers {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+    align-items: start;
+    margin-top: 8px;
+  }
+  .tier {
+    position: relative;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 20px;
+    padding: 28px 26px;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+  .band .tier {
+    background: var(--bg);
+  }
+  .tier.featured {
+    border: 2px solid var(--orange);
+    box-shadow:
+      0 18px 44px var(--glow),
+      var(--shadow);
+  }
+  .tier .badge {
+    position: absolute;
+    top: -13px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--orange);
+    color: #fff;
+    font-family: var(--font-display);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 5px 14px;
+    border-radius: 100px;
+    white-space: nowrap;
+  }
+  .tier .tname {
+    font-family: var(--font-display);
+    font-size: 19px;
+    font-weight: 700;
+    color: var(--ink);
+  }
+  .tier .ttag {
+    font-size: 13.5px;
+    color: var(--ink-soft);
+    margin-top: 3px;
+    min-height: 2.6em;
+  }
+  .tier .price {
+    margin-top: 16px;
+    display: flex;
+    align-items: baseline;
+    gap: 7px;
+  }
+  .tier .price .amt {
+    font-family: var(--font-display);
+    font-size: 40px;
+    font-weight: 700;
+    color: var(--ink);
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+  }
+  .tier .price .per {
+    font-size: 14px;
+    color: var(--ink-soft);
+  }
+  .tier ul {
+    list-style: none;
+    margin: 22px 0 0;
+    padding: 0;
+    display: grid;
+    gap: 12px;
+    flex: 1;
+  }
+  .tier ul li {
+    display: grid;
+    grid-template-columns: 20px 1fr;
+    gap: 11px;
+    font-size: 14.5px;
+    color: var(--ink);
+    line-height: 1.45;
+    align-items: start;
+  }
+  .tier ul li svg {
+    width: 18px;
+    height: 18px;
+    color: var(--orange);
+    margin-top: 2px;
+    flex: none;
+  }
+  .tier ul li.lead {
+    color: var(--ink-soft);
+    font-style: italic;
+  }
+  .tier .tcta {
+    margin-top: 24px;
+    display: block;
+    text-align: center;
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 15px;
+    text-decoration: none;
+    padding: 13px 20px;
+    border-radius: 12px;
+    border: 1px solid var(--line);
+    color: var(--ink);
+    transition:
+      border-color 0.2s ease,
+      color 0.2s ease,
+      background 0.2s ease;
+  }
+  .tier .tcta:hover {
+    border-color: var(--orange);
+    color: var(--orange-ink);
+  }
+  .tier.featured .tcta {
+    background: var(--orange);
+    color: #fff;
+    border-color: var(--orange);
+  }
+  .tier.featured .tcta:hover {
+    background: var(--orange-deep);
+    color: #fff;
+  }
+  @media (max-width: 820px) {
+    .tiers {
+      grid-template-columns: 1fr;
+    }
+    .tier .ttag {
+      min-height: 0;
+    }
+  }
+  .tiers-note {
+    text-align: center;
+    font-size: 14px;
+    color: var(--ink-soft);
+    margin-top: 24px;
+    max-width: 62ch;
+    margin-inline: auto;
+  }
+  .trust-strip {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 9px;
+    justify-content: center;
+    margin-top: 26px;
+  }
+  .trust-strip span {
+    font-family: var(--font-display);
+    font-size: 12.5px;
+    color: var(--ink);
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 100px;
+    padding: 8px 16px;
+    font-weight: 500;
+  }
+  .band .trust-strip span {
+    background: var(--bg);
+  }
+
+  /* ---------- honesty note ---------- */
+  .compliance {
+    max-width: 64ch;
+    margin: 30px auto 0;
+    text-align: center;
+    font-size: 13.5px;
+    color: var(--ink-soft);
+    line-height: 1.6;
+  }
+
+  /* ---------- primary CTA button ---------- */
+  .btn-messenger {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    background: var(--orange);
+    color: #fff;
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 17px;
+    letter-spacing: 0.01em;
+    text-decoration: none;
+    padding: 16px 26px;
+    border-radius: 14px;
+    box-shadow:
+      0 10px 30px var(--glow),
+      0 2px 6px rgba(0, 0, 0, 0.08);
+    transition:
+      transform 0.2s ease,
+      box-shadow 0.25s ease,
+      background 0.2s ease;
+  }
+  .btn-messenger:hover {
+    background: var(--orange-deep);
+    transform: translateY(-2px);
+    box-shadow:
+      0 16px 40px var(--glow),
+      0 4px 10px rgba(0, 0, 0, 0.1);
+  }
+  .btn-messenger svg {
+    width: 24px;
+    height: 24px;
+    flex: none;
+  }
+  .btn-messenger .arrow {
+    width: 18px;
+    height: 18px;
+    transition: transform 0.2s ease;
+  }
+  .btn-messenger:hover .arrow {
+    transform: translateX(3px);
+  }
+
+  /* ---------- final cta ---------- */
+  .final {
+    text-align: center;
+    padding: 70px 0;
+  }
+  .final h2 {
+    font-size: clamp(28px, 5vw, 42px);
+    line-height: 1.1;
+    max-width: 20ch;
+    margin: 0 auto;
+  }
+  .final h2 em {
+    color: var(--orange);
+    font-style: normal;
+  }
+  .final p {
+    margin: 20px auto 28px;
+    max-width: 48ch;
+    color: var(--ink-soft);
+  }
+
+  /* ---------- footer ---------- */
+  footer {
+    border-top: 1px solid var(--line);
+    padding: 32px 0;
+    text-align: center;
+    font-size: 13px;
+    color: var(--ink-soft);
+  }
+  footer .foot-brand {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 15px;
+    color: var(--ink);
+  }
+  footer .foot-brand span {
+    color: var(--orange);
+  }
+  footer .foot-meta {
+    margin-top: 6px;
+  }
+
+  /* ---------- reveal ---------- */
+  .reveal {
+    opacity: 0;
+    transform: translateY(18px);
+    transition:
+      opacity 0.7s ease,
+      transform 0.7s ease;
+  }
+  .reveal.in {
+    opacity: 1;
+    transform: none;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .reveal {
+      opacity: 1;
+      transform: none;
+      transition: none;
+    }
+    .btn-messenger,
+    .btn-messenger:hover {
+      transform: none;
+    }
+  }
+</style>
+
+<div class="langtoggle" role="group" aria-label="Language / Idioma">
+  <button id="btnEn" class="on" aria-pressed="true">EN</button>
+  <button id="btnEs" aria-pressed="false">ES</button>
+</div>
+
+<div id="doc" data-lang="en">
+  <!-- ===================== HERO ===================== -->
+  <div class="hero">
+    <div class="hero-glow"></div>
+    <div class="wrap">
+      <div class="topbar">
+        <span class="wordmark">
+          <span class="name">Lumi<b>è</b>re</span>
+          <span class="kicker">Medspa</span>
+        </span>
+        <span class="by lang-en">Prepared by <b>CushLabs.ai</b></span>
+        <span class="by lang-es">Preparado por <b>CushLabs.ai</b></span>
+      </div>
+
+      <div class="hero-inner">
+        <div class="eyebrow">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M12 8V4H8" />
+            <rect width="16" height="12" x="4" y="8" rx="2" />
+            <path d="M2 14h2" />
+            <path d="M20 14h2" />
+            <path d="M15 13v2" />
+            <path d="M9 13v2" />
+          </svg>
+          <span class="lang-en">The full front office · Powered by Meta</span>
+          <span class="lang-es"
+            >Toda la recepción · Con la tecnología de Meta</span
+          >
+        </div>
+
+        <h1 class="lang-en">
+          The complete <em>AI front office</em> for your medspa.
+        </h1>
+        <h1 class="lang-es">
+          La <em>recepción con IA</em> completa para tu medspa.
+        </h1>
+
+        <p class="lede lang-en">
+          One AI brain across Messenger, Google, WhatsApp alerts, and voice —
+          trained on your real menu, prices, and hours. This is the whole front
+          office for a medspa like Lumière, live and working today.
+        </p>
+        <p class="lede lang-es">
+          Un solo cerebro de IA en Messenger, Google, avisos por WhatsApp y voz
+          — entrenado con tu menú, precios y horarios reales. Esta es toda la
+          recepción para un medspa como Lumière, en vivo y funcionando hoy.
+        </p>
+
+        <div class="meta">
+          <span class="pill lang-en">Prepared for Lumière Medspa</span>
+          <span class="pill lang-es">Preparado para Lumière Medspa</span>
+          <span>Austin, TX</span>
+          <span style="opacity: 0.5">·</span>
+          <span class="lang-en">July 2026</span>
+          <span class="lang-es">Julio 2026</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ===================== CAPABILITY GRID ===================== -->
+  <section class="band">
+    <div class="wrap">
+      <div class="section-head reveal">
+        <div class="eyebrow">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <rect width="7" height="7" x="3" y="3" rx="1" />
+            <rect width="7" height="7" x="14" y="3" rx="1" />
+            <rect width="7" height="7" x="14" y="14" rx="1" />
+            <rect width="7" height="7" x="3" y="14" rx="1" />
+          </svg>
+          <span class="lang-en">Every capability, live today</span>
+          <span class="lang-es">Cada función, en vivo hoy</span>
+        </div>
+        <h2 class="lang-en">The front office, piece by piece.</h2>
+        <h2 class="lang-es">La recepción, pieza por pieza.</h2>
+        <p class="lang-en">
+          Every card below is <b>live today</b> — running in production and
+          included in the plans right now.
+        </p>
+        <p class="lang-es">
+          Cada tarjeta de abajo está <b>en vivo hoy</b> — funcionando en
+          producción e incluida en los planes ahora mismo.
+        </p>
+      </div>
+
+      <div class="cap-grid reveal">
+        <!-- 1 · Messenger AI assistant · LIVE -->
+        <div class="cap">
+          <div class="cap-top">
+            <span class="cap-ic">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z" />
+              </svg>
+            </span>
+            <span class="badge-status live">
+              <span class="bdot"></span><span class="lang-en">Live today</span
+              ><span class="lang-es">En vivo hoy</span>
+            </span>
+          </div>
+          <h3 class="lang-en">Messenger AI assistant</h3>
+          <h3 class="lang-es">Asistente de IA en Messenger</h3>
+          <p class="lang-en">
+            Instant DM and comment-to-DM replies on your Facebook page,
+            bilingual, 24/7. This is the assistant you can message right now.
+          </p>
+          <p class="lang-es">
+            Respuestas al instante a mensajes y comentarios en tu página de
+            Facebook, bilingüe, 24/7. Es el asistente al que puedes escribirle
+            ahora mismo.
+          </p>
+          <a class="cap-link" href="preview.html">
+            <span class="lang-en">See it live</span
+            ><span class="lang-es">Verla en vivo</span>
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M5 12h14" />
+              <path d="m12 5 7 7-7 7" />
+            </svg>
+          </a>
+        </div>
+
+        <!-- 2 · Google reviews & reputation · LIVE -->
+        <div class="cap">
+          <div class="cap-top">
+            <span class="cap-ic">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path
+                  d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z"
+                />
+              </svg>
+            </span>
+            <span class="badge-status live">
+              <span class="bdot"></span><span class="lang-en">Live today</span
+              ><span class="lang-es">En vivo hoy</span>
+            </span>
+          </div>
+          <h3 class="lang-en">Google reviews &amp; reputation</h3>
+          <h3 class="lang-es">Reseñas y reputación en Google</h3>
+          <p class="lang-en">
+            Drafts and manages on-brand review responses — you approve, it posts
+            — and tracks how you rank against nearby competitors each week.
+          </p>
+          <p class="lang-es">
+            Redacta y gestiona respuestas con tu estilo — tú apruebas y se
+            publica — y vigila cómo te posicionas frente a la competencia
+            cercana cada semana.
+          </p>
+        </div>
+
+        <!-- 3 · Owner WhatsApp lead-alert · LIVE (since 2026-07-09) -->
+        <div class="cap">
+          <div class="cap-top">
+            <span class="cap-ic">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+                <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+              </svg>
+            </span>
+            <span class="badge-status live">
+              <span class="bdot"></span><span class="lang-en">Live today</span
+              ><span class="lang-es">En vivo hoy</span>
+            </span>
+          </div>
+          <h3 class="lang-en">Owner WhatsApp lead-alert</h3>
+          <h3 class="lang-es">Aviso al dueño por WhatsApp</h3>
+          <p class="lang-en">
+            The moment a lead is hot, the owner gets a WhatsApp ping with the
+            name, contact, and intent — so you only step in to close. Live and
+            delivering today.
+          </p>
+          <p class="lang-es">
+            En cuanto un cliente está listo, la dueña recibe un aviso por
+            WhatsApp con el nombre, el contacto y lo que busca — para que solo
+            entres a cerrar. En vivo y funcionando hoy.
+          </p>
+        </div>
+
+        <!-- 4 · AI Voice agent · LIVE -->
+        <div class="cap">
+          <div class="cap-top">
+            <span class="cap-ic">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path
+                  d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"
+                />
+              </svg>
+            </span>
+            <span class="badge-status live">
+              <span class="bdot"></span><span class="lang-en">Live today</span
+              ><span class="lang-es">En vivo hoy</span>
+            </span>
+          </div>
+          <h3 class="lang-en">AI Voice agent</h3>
+          <h3 class="lang-es">Agente de voz con IA</h3>
+          <p class="lang-en">
+            Answers missed calls and books consults by phone, in your voice —
+            300 answered minutes per location on the Ultra plan.
+          </p>
+          <p class="lang-es">
+            Contesta llamadas perdidas y agenda consultas por teléfono, con tu
+            voz — 300 minutos contestados por sucursal en el plan Ultra.
+          </p>
+        </div>
+
+        <!-- 5 · In-chat booking · LIVE -->
+        <div class="cap">
+          <div class="cap-top">
+            <span class="cap-ic">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M8 2v4" />
+                <path d="M16 2v4" />
+                <rect width="18" height="18" x="3" y="4" rx="2" />
+                <path d="M3 10h18" />
+                <path d="m9 16 2 2 4-4" />
+              </svg>
+            </span>
+            <span class="badge-status live">
+              <span class="bdot"></span><span class="lang-en">Live today</span
+              ><span class="lang-es">En vivo hoy</span>
+            </span>
+          </div>
+          <h3 class="lang-en">In-chat booking</h3>
+          <h3 class="lang-es">Agenda dentro del chat</h3>
+          <p class="lang-en">
+            Camila, our AI assistant, books consultations right in the chat —
+            she offers real open times and sends a confirmation with a
+            video-call link.
+          </p>
+          <p class="lang-es">
+            Camila, nuestra asistente de IA, agenda consultas dentro del mismo
+            chat — ofrece horarios reales disponibles y envía una confirmación
+            con un enlace de videollamada.
+          </p>
+          <a class="cap-link" href="preview.html">
+            <span class="lang-en">See it live</span
+            ><span class="lang-es">Míralo en vivo</span>
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M5 12h14" />
+              <path d="m12 5 7 7-7 7" />
+            </svg>
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===================== POWERED BY META ===================== -->
+  <section>
+    <div class="wrap">
+      <div class="section-head center reveal">
+        <div class="eyebrow">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10" />
+          </svg>
+          <span class="lang-en">Powered by Meta</span>
+          <span class="lang-es">Con la tecnología de Meta</span>
+        </div>
+        <h2 class="lang-en">One platform behind it all: Meta.</h2>
+        <h2 class="lang-es">Una sola plataforma detrás de todo: Meta.</h2>
+        <p class="lang-en">
+          Messenger and WhatsApp both run on Meta's official Business Platform —
+          approved, connected, and live, handling your customers and alerting
+          your owner in real time.
+        </p>
+        <p class="lang-es">
+          Messenger y WhatsApp funcionan sobre la Plataforma de Negocios oficial
+          de Meta — aprobados, conectados y en vivo, atendiendo a tus clientes y
+          avisando al dueño en tiempo real.
+        </p>
+      </div>
+
+      <div class="meta-platforms reveal">
+        <div class="mp">
+          <span class="mp-ic">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z" />
+            </svg>
+          </span>
+          <div>
+            <div class="mp-name">Messenger</div>
+            <div class="mp-sub lang-en">
+              Approved &amp; live — DMs plus post comments, bilingual, 24/7.
+            </div>
+            <div class="mp-sub lang-es">
+              Aprobado y en vivo — mensajes y comentarios, bilingüe, 24/7.
+            </div>
+          </div>
+        </div>
+        <div class="mp">
+          <span class="mp-ic">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+              <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+            </svg>
+          </span>
+          <div>
+            <div class="mp-name lang-en">WhatsApp — owner alerts</div>
+            <div class="mp-name lang-es">WhatsApp — avisos al dueño</div>
+            <div class="mp-sub lang-en">
+              Live — hot-lead pings sent to the owner's WhatsApp.
+            </div>
+            <div class="mp-sub lang-es">
+              En vivo — avisos de clientes listos al WhatsApp de la dueña.
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===================== PRICING TIERS ===================== -->
+  <section>
+    <div class="wrap">
+      <div class="section-head center reveal">
+        <div class="eyebrow">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <line x1="12" x2="12" y1="2" y2="22" />
+            <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
+          </svg>
+          <span class="lang-en">One price, fully managed</span>
+          <span class="lang-es">Un precio, todo gestionado</span>
+        </div>
+        <h2 class="lang-en">Everything above rolls into one monthly plan.</h2>
+        <h2 class="lang-es">Todo lo anterior entra en un solo plan mensual.</h2>
+        <p class="lang-en">
+          No à-la-carte menu, no setup fee, no contract. Pick a tier and we
+          build, train, connect, and manage the whole thing.
+        </p>
+        <p class="lang-es">
+          Sin menú por pieza, sin cuota de instalación, sin contrato. Eliges un
+          plan y nosotros construimos, entrenamos, conectamos y administramos
+          todo.
+        </p>
+      </div>
+
+      <div class="tiers reveal">
+        <!-- Basic -->
+        <div class="tier">
+          <div class="tname">Basic</div>
+          <div class="ttag lang-en">For getting started</div>
+          <div class="ttag lang-es">Para empezar</div>
+          <div class="price">
+            <span class="amt">$129</span>
+            <span class="per lang-en">USD/mo</span>
+            <span class="per lang-es">USD/mes</span>
+          </div>
+          <ul>
+            <li>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M20 6 9 17l-5-5" /></svg
+              ><span class="lang-en"
+                >Messenger AI assistant (24/7, bilingual)</span
+              ><span class="lang-es"
+                >Asistente de IA en Messenger (24/7, bilingüe)</span
+              >
+            </li>
+            <li>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M20 6 9 17l-5-5" /></svg
+              ><span class="lang-en"
+                >Google review management — you approve, it posts</span
+              ><span class="lang-es"
+                >Gestión de reseñas de Google — apruebas y se publica</span
+              >
+            </li>
+            <li>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M20 6 9 17l-5-5" /></svg
+              ><span class="lang-en"
+                >Lead capture + owner alerts on WhatsApp</span
+              ><span class="lang-es"
+                >Captura de clientes + avisos al dueño por WhatsApp</span
+              >
+            </li>
+            <li>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M20 6 9 17l-5-5" /></svg
+              ><span class="lang-en"
+                >Fully managed: setup, training, support</span
+              ><span class="lang-es"
+                >Todo gestionado: configuración, entrenamiento y soporte</span
+              >
+            </li>
+          </ul>
+          <a class="tcta" href="preview.html"
+            ><span class="lang-en">Try the live demo</span
+            ><span class="lang-es">Prueba el demo en vivo</span></a
+          >
+        </div>
+
+        <!-- Premium -->
+        <div class="tier">
+          <div class="tname">Premium</div>
+          <div class="ttag lang-en">For growing practices</div>
+          <div class="ttag lang-es">Para consultorios en crecimiento</div>
+          <div class="price">
+            <span class="amt">$229</span>
+            <span class="per lang-en">USD/mo</span>
+            <span class="per lang-es">USD/mes</span>
+          </div>
+          <ul>
+            <li class="lead">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M20 6 9 17l-5-5" /></svg
+              ><span class="lang-en">Everything in Basic, plus:</span
+              ><span class="lang-es">Todo lo de Basic, más:</span>
+            </li>
+            <li>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M20 6 9 17l-5-5" /></svg
+              ><span class="lang-en"
+                >Website chatbot — the same AI brain on your site</span
+              ><span class="lang-es"
+                >Chatbot para tu sitio — el mismo cerebro de IA en tu
+                sitio</span
+              >
+            </li>
+            <li>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M20 6 9 17l-5-5" /></svg
+              ><span class="lang-en"
+                >Weekly local SEO &amp; competitor report</span
+              ><span class="lang-es"
+                >Reporte semanal de SEO local y competencia</span
+              >
+            </li>
+          </ul>
+          <a class="tcta" href="preview.html"
+            ><span class="lang-en">Try the live demo</span
+            ><span class="lang-es">Prueba el demo en vivo</span></a
+          >
+        </div>
+
+        <!-- Ultra (featured, medspa tier) -->
+        <div class="tier featured">
+          <span class="badge lang-en">Recommended for medspas</span>
+          <span class="badge lang-es">Recomendado para medspas</span>
+          <div class="tname">Ultra</div>
+          <div class="ttag lang-en">For clinics &amp; high-volume medspas</div>
+          <div class="ttag lang-es">
+            Para clínicas y medspas de alto volumen
+          </div>
+          <div class="price">
+            <span class="amt">$349</span>
+            <span class="per lang-en">USD/mo</span>
+            <span class="per lang-es">USD/mes</span>
+          </div>
+          <ul>
+            <li class="lead">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M20 6 9 17l-5-5" /></svg
+              ><span class="lang-en">Everything in Premium, plus:</span
+              ><span class="lang-es">Todo lo de Premium, más:</span>
+            </li>
+            <li>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M20 6 9 17l-5-5" /></svg
+              ><span class="lang-en"
+                >AI Voice Agent — 300 answered min/location/mo</span
+              ><span class="lang-es"
+                >Agente de Voz con IA — 300 min contestados/sucursal/mes</span
+              >
+            </li>
+            <li>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M20 6 9 17l-5-5" /></svg
+              ><span class="lang-en">Priority support</span
+              ><span class="lang-es">Soporte prioritario</span>
+            </li>
+            <li>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M20 6 9 17l-5-5" /></svg
+              ><span class="lang-en">Healthcare industry tuning</span
+              ><span class="lang-es">Personalización para el sector salud</span>
+            </li>
+          </ul>
+          <a class="tcta" href="preview.html"
+            ><span class="lang-en">Try the live demo</span
+            ><span class="lang-es">Prueba el demo en vivo</span></a
+          >
+        </div>
+      </div>
+
+      <p class="tiers-note reveal">
+        <span class="lang-en"
+          >Every plan includes up to 2 locations · additional locations +$49
+          USD/mo each · 2-week free trial · no setup fee · no contract. USD
+          pricing for US-based businesses.</span
+        >
+        <span class="lang-es"
+          >Todos los planes incluyen hasta 2 sucursales · sucursales adicionales
+          +$49 USD/mes cada una · prueba gratis de 2 semanas · sin cuota de
+          instalación · sin contrato. Precios en USD para negocios en EE.
+          UU.</span
+        >
+      </p>
+
+      <div class="trust-strip reveal">
+        <span class="lang-en">2-week free trial</span
+        ><span class="lang-es">Prueba gratis de 2 semanas</span>
+        <span class="lang-en">No setup fee</span
+        ><span class="lang-es">Sin cuota de instalación</span>
+        <span class="lang-en">Month-to-month, no contract</span
+        ><span class="lang-es">Mes a mes, sin contrato</span>
+        <span class="lang-en">Unlimited conversations</span
+        ><span class="lang-es">Conversaciones ilimitadas</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===================== FINAL CTA ===================== -->
+  <section class="final band">
+    <div class="wrap narrow">
+      <h2 class="lang-en reveal">
+        See it for yourself — <em>message Camila</em>.
+      </h2>
+      <h2 class="lang-es reveal">
+        Compruébalo tú mismo — <em>escríbele a Camila</em>.
+      </h2>
+      <p class="lang-en reveal">
+        The Messenger assistant is running right now. Chat with Camila and see
+        exactly how she'd answer your medspa's customers — in seconds, on your
+        Facebook page.
+      </p>
+      <p class="lang-es reveal">
+        El asistente de Messenger ya está funcionando. Chatea con Camila y mira
+        exactamente cómo contestaría a los clientes de tu medspa — en segundos,
+        en tu página de Facebook.
+      </p>
+      <div class="reveal">
+        <a class="btn-messenger" href="preview.html">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z" />
+          </svg>
+          <span class="lang-en">Chat with Camila</span>
+          <span class="lang-es">Chatea con Camila</span>
+          <svg
+            class="arrow"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M5 12h14" />
+            <path d="m12 5 7 7-7 7" />
+          </svg>
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <footer>
+    <div class="wrap">
+      <div class="foot-brand">Cush<span>Labs</span>.ai</div>
+      <div class="foot-meta lang-en">
+        Demonstration · CushLabs.ai · Lumière Medspa is a fictitious business
+        created for this demo.
+      </div>
+      <div class="foot-meta lang-es">
+        Demostración · CushLabs.ai · Lumière Medspa es un negocio ficticio
+        creado para esta demostración.
+      </div>
+    </div>
+  </footer>
+</div>
+
+<script>
+  (function () {
+    var doc = document.getElementById("doc");
+    var btnEs = document.getElementById("btnEs");
+    var btnEn = document.getElementById("btnEn");
+
+    function setLang(lang) {
+      doc.setAttribute("data-lang", lang);
+      btnEs.classList.toggle("on", lang === "es");
+      btnEn.classList.toggle("on", lang === "en");
+      btnEs.setAttribute("aria-pressed", String(lang === "es"));
+      btnEn.setAttribute("aria-pressed", String(lang === "en"));
+    }
+    btnEs.addEventListener("click", function () {
+      setLang("es");
+    });
+    btnEn.addEventListener("click", function () {
+      setLang("en");
+    });
+    setLang("en");
+
+    var reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    var reveals = document.querySelectorAll(".reveal");
+    if (reduce || !("IntersectionObserver" in window)) {
+      reveals.forEach(function (el) {
+        el.classList.add("in");
+      });
+    } else {
+      var io = new IntersectionObserver(
+        function (entries) {
+          entries.forEach(function (e) {
+            if (e.isIntersecting) {
+              e.target.classList.add("in");
+              io.unobserve(e.target);
+            }
+          });
+        },
+        { threshold: 0.12 },
+      );
+      reveals.forEach(function (el) {
+        io.observe(el);
+      });
+    }
+  })();
+</script>


### PR DESCRIPTION
The public, sendable composite services page for the Lumière medspa demo — shows ONLY what CushLabs delivers today, framed present-tense. No roadmap/'coming soon' items referenced.

- demos/lumiere/services.html — capability grid (Messenger AI, Google reviews, owner WhatsApp alert, AI Voice, and now **in-chat booking, LIVE** with a 'See it live' link to Camila), 'Powered by Meta' band (live channels only), tiers ($129/$229/$349), CTA to Camila.
- api/demo.ts — registers services.html on the lumiere gate entry.

Isolated on a clean branch off main (does NOT include the parallel session's rate-limiter/portfolio/logo commits). Verified: 0 roadmap/coming/instagram references; all 5 capability badges 'Live today'; bilingual EN/es-MX balanced 66/66; self-contained (no external fonts/CDN); tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)