### PR TITLE
fix(lumiere): point the preview hub's Chat button at the live demo page

### DIFF
--- a/demos/lumiere/preview.html
+++ b/demos/lumiere/preview.html
@@ -887,7 +887,7 @@
             </a>
             <a
               class="cta-messenger-alt"
-              href="https://m.me/M_ME_PAGE_ID_PLACEHOLDER"
+              href="https://m.me/1141370822403121"
               target="_blank"
               rel="noopener"
               style="


### PR DESCRIPTION
The Lumière Medspa - Demo Facebook page is live (1141370822403121) — bot
access verified (8 scopes incl. the comment pair), tenant seeded, webhooks
subscribed, page dressed, posts published, EN/ES pipeline verified including
the medical-compliance consult guardrail. The m.me CTA now opens a real chat.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
