### PR TITLE
Booking limiter enforced nothing — replace the Map with a shared D1 counter

### DIFF
--- a/tests/rate-limit.test.ts
+++ b/tests/rate-limit.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi } from "vitest";
+// @ts-expect-error — plain JS Worker module, no types alongside it.
+import { checkRateLimit, clientKey } from "../workers/lib/rate-limit-d1.js";
+
+describe("clientKey — the unit a limit applies to", () => {
+  it("uses an IPv4 address whole", () => {
+    expect(clientKey("203.0.113.7")).toBe("203.0.113.7");
+  });
+
+  it("collapses IPv6 to its /64, so a rotating address cannot escape the bucket", () => {
+    // Two temporary addresses from one subscriber's /64. Hosts rotate these on
+    // their own schedule under RFC 4941; keying on the full address gives each
+    // one a fresh bucket, which is how 1,500 requests from a single machine got
+    // through unrefused on a sibling Worker.
+    const a = "2806:103e:19:6dcb:f480:934c:9264:166a";
+    const b = "2806:103e:19:6dcb:aaaa:bbbb:cccc:dddd";
+    expect(clientKey(a)).toBe("2806:103e:19:6dcb::/64");
+    expect(clientKey(a)).toBe(clientKey(b));
+  });
+
+  it("keeps different /64s apart", () => {
+    expect(clientKey("2806:103e:19:6dcb::1")).not.toBe(
+      clientKey("2001:db8:1:2:3:4:5:6"),
+    );
+  });
+
+  it("handles a missing address rather than keying on undefined", () => {
+    expect(clientKey(undefined)).toBe("unknown");
+    expect(clientKey("")).toBe("unknown");
+  });
+
+  it("passes compressed forms through rather than mangling them", () => {
+    expect(clientKey("::1")).toBe("::1");
+  });
+});
+
+/**
+ * Minimal D1 stand-in backed by an array. Enough to exercise the sliding
+ * window: COUNT/MIN over a bucket, INSERT, and DELETE.
+ */
+function fakeDb() {
+  const rows: { bucket: string; ts: number }[] = [];
+  return {
+    rows,
+    batch: async () => [],
+    prepare(sql: string) {
+      const state: unknown[] = [];
+      const api = {
+        bind(...args: unknown[]) {
+          state.push(...args);
+          return api;
+        },
+        async first() {
+          const [bucket, windowStart] = state as [string, number];
+          const inWindow = rows.filter(
+            (r) => r.bucket === bucket && r.ts > windowStart,
+          );
+          return {
+            n: inWindow.length,
+            oldest: inWindow.length
+              ? Math.min(...inWindow.map((r) => r.ts))
+              : null,
+          };
+        },
+        async run() {
+          if (sql.includes("INSERT INTO rate_limit")) {
+            const [bucket, ts] = state as [string, number];
+            rows.push({ bucket, ts });
+          }
+          return { success: true };
+        },
+      };
+      return api;
+    },
+  };
+}
+
+describe("checkRateLimit — shared sliding window", () => {
+  it("allows up to the limit and refuses the one after it", async () => {
+    const db = fakeDb();
+    for (let i = 0; i < 5; i++) {
+      const r = await checkRateLimit(db, "book:1.2.3.4", 5, 3_600_000);
+      expect(r.allowed).toBe(true);
+    }
+    const sixth = await checkRateLimit(db, "book:1.2.3.4", 5, 3_600_000);
+    expect(sixth.allowed).toBe(false);
+    expect(sixth.resetIn).toBeGreaterThan(0);
+  });
+
+  it("counts each bucket separately, so one client cannot exhaust another", async () => {
+    const db = fakeDb();
+    for (let i = 0; i < 5; i++) {
+      await checkRateLimit(db, "book:1.2.3.4", 5, 3_600_000);
+    }
+    const other = await checkRateLimit(db, "book:5.6.7.8", 5, 3_600_000);
+    expect(other.allowed).toBe(true);
+  });
+
+  it("keeps surfaces apart, so browsing dates cannot use up the booking budget", async () => {
+    const db = fakeDb();
+    for (let i = 0; i < 5; i++) {
+      await checkRateLimit(db, "slots:1.2.3.4", 5, 3_600_000);
+    }
+    const booking = await checkRateLimit(db, "book:1.2.3.4", 5, 3_600_000);
+    expect(booking.allowed).toBe(true);
+  });
+
+  it("does not record a request it refused", async () => {
+    const db = fakeDb();
+    for (let i = 0; i < 6; i++) {
+      await checkRateLimit(db, "book:1.2.3.4", 5, 3_600_000);
+    }
+    // Six calls, five allowed — the refused one must not have been written, or
+    // a blocked flood would grow the table without bound.
+    expect(db.rows.length).toBe(5);
+  });
+
+  it("fails OPEN and flags degraded when the binding is missing", async () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    const r = await checkRateLimit(null, "book:1.2.3.4", 5, 3_600_000);
+    expect(r.allowed).toBe(true);
+    expect(r.degraded).toBe(true);
+    // Failing open is a deliberate trade on this Worker, but it must never be
+    // silent — that is how a limiter stops working without anyone noticing.
+    expect(err).toHaveBeenCalled();
+    err.mockRestore();
+  });
+
+  it("fails OPEN and flags degraded when the datastore throws", async () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    const broken = {
+      batch: async () => {
+        throw new Error("D1 unreachable");
+      },
+      prepare: () => {
+        throw new Error("D1 unreachable");
+      },
+    };
+    const r = await checkRateLimit(broken, "book:1.2.3.4", 5, 3_600_000);
+    expect(r.allowed).toBe(true);
+    expect(r.degraded).toBe(true);
+    expect(err).toHaveBeenCalled();
+    err.mockRestore();
+  });
+});

--- a/workers/booking-worker.js
+++ b/workers/booking-worker.js
@@ -29,37 +29,15 @@
 
 /* ------------------------ Rate Limiting ------------------------ */
 
-const rateLimitStore = new Map();
-
-function cleanupRateLimitStore(windowMs) {
-  const now = Date.now();
-  for (const [key, data] of rateLimitStore.entries()) {
-    if (now - data.windowStart > windowMs * 2) {
-      rateLimitStore.delete(key);
-    }
-  }
-}
-
-function checkRateLimit(identifier, maxRequests, windowMs) {
-  const now = Date.now();
-  const key = `rate:${identifier}`;
-
-  let data = rateLimitStore.get(key);
-
-  if (!data || now - data.windowStart > windowMs) {
-    data = { count: 1, windowStart: now };
-    rateLimitStore.set(key, data);
-    return { allowed: true, remaining: maxRequests - 1 };
-  }
-
-  if (data.count >= maxRequests) {
-    const resetIn = Math.ceil((data.windowStart + windowMs - now) / 1000);
-    return { allowed: false, remaining: 0, resetIn };
-  }
-
-  data.count++;
-  return { allowed: true, remaining: maxRequests - data.count };
-}
+// D1-backed and shared across isolates. The Map that used to live here counted
+// per-isolate, so "5 bookings per hour" was really 5 per isolate with the count
+// resetting on every cold start. See workers/lib/rate-limit-d1.js for why this
+// Worker uses D1 while the demo Workers use KV.
+import {
+  checkRateLimit,
+  checkRateLimitEnforcement,
+  clientKey,
+} from "./lib/rate-limit-d1.js";
 
 /* ------------------------ Token Cache ------------------------ */
 
@@ -101,28 +79,45 @@ export default {
 
     try {
       // Health check
-      if (request.method === "GET" && path === "/")
+      if (request.method === "GET" && path === "/") {
+        // Reports whether the limiter is ENFORCING, not merely reachable. The
+        // limiter this replaced failed silently — a counter that counts nothing
+        // looks identical from outside to one that works — so /health returns
+        // 503 when it cannot prove enforcement.
+        const rateLimit = await checkRateLimitEnforcement(env.DB);
         return json(
           {
-            ok: true,
+            ok: rateLimit.ok,
             service: "CushLabs Booking API v1",
             endpoints: ["/slots/:date", "/book"],
+            rateLimit,
           },
-          200,
+          rateLimit.ok ? 200 : 503,
           request,
           env,
         );
+      }
 
       // Debug endpoint
       if (request.method === "GET" && path === "/debug") {
         if (env.DEBUG_ENABLED !== "true") {
-          return json({ ok: false, error: "Debug endpoint is disabled" }, 404, request, env);
+          return json(
+            { ok: false, error: "Debug endpoint is disabled" },
+            404,
+            request,
+            env,
+          );
         }
 
         if (env.DEBUG_KEY) {
           const providedKey = request.headers.get("X-Debug-Key");
           if (providedKey !== env.DEBUG_KEY) {
-            return json({ ok: false, error: "Unauthorized" }, 401, request, env);
+            return json(
+              { ok: false, error: "Unauthorized" },
+              401,
+              request,
+              env,
+            );
           }
         }
 
@@ -136,10 +131,14 @@ export default {
               has_calendar_id: !!(env.CALENDAR_ID || env.GOOGLE_CALENDAR_ID),
               has_personal_calendar_id: !!env.PERSONAL_CALENDAR_ID,
               timezone: env.TIMEZONE || "America/Mexico_City (default)",
-              weekday_morning: env.WEEKDAY_MORNING_HOURS || "09:00-14:00 (default)",
-              weekday_afternoon: env.WEEKDAY_AFTERNOON_HOURS || "16:00-20:00 (default)",
+              weekday_morning:
+                env.WEEKDAY_MORNING_HOURS || "09:00-14:00 (default)",
+              weekday_afternoon:
+                env.WEEKDAY_AFTERNOON_HOURS || "16:00-20:00 (default)",
               saturday_hours: env.SATURDAY_HOURS || "09:00-13:00 (default)",
-              allowed_origins: env.ALLOWED_ORIGINS ? "(configured)" : "* (default)",
+              allowed_origins: env.ALLOWED_ORIGINS
+                ? "(configured)"
+                : "* (default)",
             },
           },
           200,
@@ -156,8 +155,44 @@ export default {
         if (!skipCache) {
           const cachedResult = getCachedSlots(dateStr);
           if (cachedResult) {
-            return json({ ok: true, slots: cachedResult.slots, cached: true }, 200, request, env);
+            return json(
+              { ok: true, slots: cachedResult.slots, cached: true },
+              200,
+              request,
+              env,
+            );
           }
+        }
+
+        // Only a cache MISS reaches Google, so only a miss is rate limited. A
+        // cached response costs nothing and must not consume anyone's budget —
+        // limiting it would punish the ordinary case of a visitor clicking
+        // through several dates on the booking widget.
+        //
+        // 60/hour per /64 is generous for a human browsing dates and still caps
+        // what a scraper can pull from the Calendar API quota. Note ?nocache=1
+        // bypasses the cache, so this is also what stops that being a free
+        // passthrough to Google.
+        const slotsCheck = await checkRateLimit(
+          env.DB,
+          `slots:${clientKey(
+            request.headers.get("CF-Connecting-IP") ||
+              request.headers.get("X-Forwarded-For")?.split(",")[0]?.trim(),
+          )}`,
+          parseInt(env.SLOTS_RATE_LIMIT_MAX || "60"),
+          3600000,
+        );
+        if (!slotsCheck.allowed) {
+          return json(
+            {
+              ok: false,
+              error: t(lang, "rate_limited"),
+              retryAfter: slotsCheck.resetIn,
+            },
+            429,
+            request,
+            env,
+          );
         }
 
         const showDebug = url.searchParams.get("debug") === "1";
@@ -178,12 +213,19 @@ export default {
           request.headers.get("X-Forwarded-For")?.split(",")[0]?.trim() ||
           "unknown";
 
-        cleanupRateLimitStore(windowMs);
-
-        const rateCheck = checkRateLimit(clientIP, maxRequests, windowMs);
+        const rateCheck = await checkRateLimit(
+          env.DB,
+          `book:${clientKey(clientIP)}`,
+          maxRequests,
+          windowMs,
+        );
         if (!rateCheck.allowed) {
           return json(
-            { ok: false, error: t(lang, "rate_limited"), retryAfter: rateCheck.resetIn },
+            {
+              ok: false,
+              error: t(lang, "rate_limited"),
+              retryAfter: rateCheck.resetIn,
+            },
             429,
             request,
             env,
@@ -203,7 +245,12 @@ export default {
       return json({ ok: false, error: "Not found" }, 404, request, env);
     } catch (err) {
       console.error("Worker error:", err);
-      return json({ ok: false, error: err?.message || String(err) }, 500, request, env);
+      return json(
+        { ok: false, error: err?.message || String(err) },
+        500,
+        request,
+        env,
+      );
     }
   },
 };
@@ -243,7 +290,8 @@ async function getAvailableSlots(dateStr, env, timeZone) {
   // Fetch busy times from BOTH calendars to avoid double-bookings:
   //   GOOGLE_CALENDAR_ID = rcushmaniii@gmail.com (bookings created here)
   //   PERSONAL_CALENDAR_ID = shared work calendar (checked for conflicts only)
-  const personalCalendar = env.PERSONAL_CALENDAR_ID || env.GOOGLE_CALENDAR_ID || env.CALENDAR_ID;
+  const personalCalendar =
+    env.PERSONAL_CALENDAR_ID || env.GOOGLE_CALENDAR_ID || env.CALENDAR_ID;
   const workCalendar = env.GOOGLE_CALENDAR_ID || env.CALENDAR_ID;
 
   const freeBusy = await fetchJSON(

--- a/workers/lib/rate-limit-d1.js
+++ b/workers/lib/rate-limit-d1.js
@@ -1,0 +1,223 @@
+/**
+ * Rate limiting for the booking Worker — D1-backed, shared across isolates.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHY THIS EXISTS ALONGSIDE lib/rate-limit.js (KV)
+ *
+ * The demo Workers (camila-demo, demo-chat) use the KV limiter in this same
+ * directory. Two reasons the booking Worker does not:
+ *
+ *   Write budget. KV's free tier allows roughly 1,000 writes/day account-wide
+ *   and that limiter spends 2 per allowed request. GET /slots is called on page
+ *   load by the booking widget, so a few hundred visitors would exhaust it — and
+ *   the KV limiter FAILS CLOSED, so running out of writes would take bookings
+ *   offline entirely. That is a self-inflicted outage on the site's conversion
+ *   path. D1's free tier is 100k row writes/day, which this cannot approach.
+ *
+ *   Failure direction. Failing closed is right for the demos, where the
+ *   protected resource is a paid API key and a broken demo is recoverable. It is
+ *   wrong here: refusing every booking because the datastore blipped costs real
+ *   business, while a brief unmetered window costs some junk calendar events
+ *   that can be deleted. See checkRateLimit below — the degraded case is
+ *   returned explicitly and logged, never silent.
+ *
+ * WHY NOT THE IN-MEMORY MAP THIS REPLACED
+ *
+ * The previous limiter was a module-level Map. Each isolate keeps its own copy
+ * and isolates are recycled freely, so "5 bookings per hour" was really 5 per
+ * isolate. A client opening a few parallel connections got a multiple of the
+ * limit and the count reset on every cold start.
+ *
+ * WHY NOT CLOUDFLARE'S NATIVE [[ratelimits]] BINDING
+ *
+ * Measured on cushlabs-whatsapp, 2026-07-30: 420 sequential requests over one
+ * keep-alive socket were refused at exactly the limit, but 1,500 requests over
+ * 25 parallel connections were not refused at all. Its counter is isolate-local
+ * too. That is a fine cheap first line in front of a surface that authenticates
+ * before it spends — but POST /book creates a real calendar event with no
+ * authentication and GET /slots burns Google Calendar quota, so both act before
+ * they authenticate and need a genuinely shared counter.
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+/**
+ * Collapse a client address to the unit a limit should actually apply to.
+ *
+ * IPv4 whole; IPv6 truncated to its /64.
+ *
+ * A full IPv6 /128 is close to useless as a limiter key. Hosts rotate temporary
+ * addresses under RFC 4941, every device on a LAN has its own, and a residential
+ * subscriber is handed an entire /64 — so an abuser has 18 quintillion keys and
+ * each request lands in a fresh bucket. Not theoretical: on cushlabs-whatsapp,
+ * keying on the raw address let 1,500 requests from one machine through with
+ * zero refusals. /64 is the smallest block routed to a single subscriber.
+ */
+export function clientKey(ip) {
+  if (!ip) return "unknown";
+  if (!ip.includes(":")) return ip;
+  const hextets = ip.split(":");
+  // Guard against "::"-compressed forms that expand to fewer than 4 groups.
+  if (hextets.length < 4 || ip.includes("::")) return ip;
+  return `${hextets.slice(0, 4).join(":")}::/64`;
+}
+
+/**
+ * Create the counter table if absent.
+ *
+ * Cheap to call per request — D1 no-ops an existing CREATE ... IF NOT EXISTS —
+ * and it means a fresh or restored database cannot leave the limiter silently
+ * broken because a migration step was missed.
+ */
+async function ensureSchema(db) {
+  await db.batch([
+    db.prepare(
+      `CREATE TABLE IF NOT EXISTS rate_limit (
+         bucket TEXT NOT NULL,
+         ts     INTEGER NOT NULL
+       )`,
+    ),
+    db.prepare(
+      `CREATE INDEX IF NOT EXISTS idx_rate_limit_bucket_ts
+         ON rate_limit (bucket, ts)`,
+    ),
+  ]);
+}
+
+/**
+ * Sliding-window check against the shared counter.
+ *
+ * @param {D1Database} db
+ * @param {string} bucket      surface + client key, e.g. "book:203.0.113.7"
+ * @param {number} maxRequests
+ * @param {number} windowMs
+ * @returns {Promise<{allowed:boolean, remaining:number, resetIn:number, degraded?:boolean}>}
+ *
+ * FAILS OPEN and reports `degraded: true` when D1 is unreachable. See the header
+ * for why that is the right direction on this Worker specifically. The caller
+ * logs it; it is never silent.
+ *
+ * ACCURACY UNDER CONCURRENCY, measured against production 2026-07-30: 100
+ * requests over 20-way parallelism against a limit of 60 → 81 allowed, 19
+ * refused. The count is read before the insert, so requests arriving together
+ * can all see the same pre-insert total and slip through. The overshoot is
+ * bounded by how many land in one round trip, roughly 35% at that concurrency.
+ *
+ * That is fine for what this guards — a ceiling on Google Calendar quota and on
+ * junk bookings, where a handful over the line costs nothing. It is NOT exact
+ * quota accounting, so do not reuse this where the limit is a hard contractual
+ * or billing boundary. Inserting before counting would tighten it, at the cost
+ * of letting a refused request consume a slot and keep an attacker locked out
+ * past the window — a worse trade here than the overshoot.
+ */
+export async function checkRateLimit(db, bucket, maxRequests, windowMs) {
+  if (!db) {
+    console.error(
+      "[rate-limit] D1 binding absent — request allowed UNMETERED. Check wrangler.toml.",
+    );
+    return {
+      allowed: true,
+      remaining: maxRequests,
+      resetIn: 0,
+      degraded: true,
+    };
+  }
+
+  const now = Date.now();
+  const windowStart = now - windowMs;
+
+  try {
+    await ensureSchema(db);
+
+    const row = await db
+      .prepare(
+        `SELECT COUNT(*) AS n, MIN(ts) AS oldest
+           FROM rate_limit
+          WHERE bucket = ? AND ts > ?`,
+      )
+      .bind(bucket, windowStart)
+      .first();
+
+    const count = Number(row?.n ?? 0);
+
+    if (count >= maxRequests) {
+      // Time until the oldest request still inside the window ages out.
+      const oldest = Number(row?.oldest ?? now);
+      const resetIn = Math.max(1, Math.ceil((oldest + windowMs - now) / 1000));
+      return { allowed: false, remaining: 0, resetIn };
+    }
+
+    await db
+      .prepare(`INSERT INTO rate_limit (bucket, ts) VALUES (?, ?)`)
+      .bind(bucket, now)
+      .run();
+
+    // Probabilistic GC: ~2% of allowed requests purge rows older than any window
+    // this Worker uses. Keeps the table bounded without a cron job, and leaves
+    // the other 98% of responses untouched.
+    if (Math.random() < 0.02) {
+      await db
+        .prepare(`DELETE FROM rate_limit WHERE ts < ?`)
+        .bind(now - 24 * 60 * 60 * 1000)
+        .run();
+    }
+
+    return {
+      allowed: true,
+      remaining: Math.max(0, maxRequests - count - 1),
+      resetIn: 0,
+    };
+  } catch (error) {
+    console.error(
+      `[rate-limit] D1 unavailable — request allowed UNMETERED: ${error.message}`,
+    );
+    return {
+      allowed: true,
+      remaining: maxRequests,
+      resetIn: 0,
+      degraded: true,
+    };
+  }
+}
+
+/**
+ * Prove the limiter is enforcing, not merely reachable.
+ *
+ * The failure this replaces was silent — a limiter that counts nothing looks
+ * identical from outside to one that counts correctly. This drives past a small
+ * limit on a throwaway bucket and reports whether anything was actually refused,
+ * so /health can fail loudly instead of reporting a green tick over a limiter
+ * that stopped working.
+ *
+ * Uses a unique bucket per call so it can never consume a real client's budget
+ * and never depends on state left by a previous check.
+ */
+export async function checkRateLimitEnforcement(db) {
+  if (!db) {
+    return {
+      ok: false,
+      detail: "D1 binding absent — requests are NOT limited",
+    };
+  }
+  const bucket = `selftest:${Date.now()}:${Math.random()}`;
+  try {
+    let refused = 0;
+    for (let i = 0; i < 5; i++) {
+      const r = await checkRateLimit(db, bucket, 3, 60_000);
+      if (r.degraded) {
+        return {
+          ok: false,
+          detail: "D1 unreachable — limiter is failing open",
+        };
+      }
+      if (!r.allowed) refused++;
+    }
+    return refused > 0
+      ? { ok: true, detail: `enforcing (${refused}/5 probes refused)` }
+      : {
+          ok: false,
+          detail: "limiter answered but refused nothing over a 3-call limit",
+        };
+  } catch (error) {
+    return { ok: false, detail: error.message };
+  }
+}

--- a/workers/lib/rate-limit.js
+++ b/workers/lib/rate-limit.js
@@ -11,9 +11,27 @@
  * WHY NOT CLOUDFLARE'S NATIVE RATE LIMITING BINDING:
  * Tried first and empirically rejected on 2026-07-26. With
  * `simple = { limit = 10, period = 60 }` the binding returned
- * `{"success":true}` on every call including request 14 — it is a no-op on
- * this account (Workers free plan). Verified via wrangler tail, not assumed.
- * Shipping it would have been worse than the Map: false confidence.
+ * `{"success":true}` on every call including request 14. Shipping it would
+ * have been worse than the Map: false confidence.
+ *
+ * CORRECTION, 2026-07-30 — the observation above was right, the diagnosis was
+ * not, and the difference matters if anyone reconsiders this later. The binding
+ * is NOT a no-op on this account. Measured on cushlabs-whatsapp with
+ * `simple = { limit = 300, period = 60 }`:
+ *
+ *   420 sequential requests over ONE keep-alive socket → first 429 at #302
+ *   1,500 requests over 25 parallel connections        → zero 429s
+ *
+ * The counter is ISOLATE-LOCAL. Fourteen ordinary HTTP requests land on enough
+ * different isolates that none of them individually reaches the limit, which is
+ * exactly what was seen here. The binding works; it just cannot see traffic
+ * spread across connections.
+ *
+ * The practical conclusion for THIS file is unchanged — a public endpoint
+ * holding a paid API key needs a counter that is genuinely shared, and the
+ * binding is not one. But it is a reasonable cheap first line in front of a
+ * surface that authenticates before it spends, which is how cushlabs-whatsapp
+ * and cushlabs-connect now use it.
  *
  * WHY NOT DURABLE OBJECTS: they require a paid Workers plan.
  *
@@ -79,7 +97,9 @@ export async function enforceRateLimit(env, ip) {
   if (!kv || typeof kv.get !== "function") {
     // Configuration error, not a transient fault. Deny: an unmetered public
     // endpoint spending on an API key is the exact failure being prevented.
-    console.error("rate-limit: RATE_LIMIT KV binding missing — denying request");
+    console.error(
+      "rate-limit: RATE_LIMIT KV binding missing — denying request",
+    );
     return { allowed: false, scope: "unavailable" };
   }
 
@@ -108,7 +128,9 @@ export async function enforceRateLimit(env, ip) {
   try {
     await Promise.all([
       kv.put(ipKey, String(ipCount + 1), { expirationTtl: TTL_SECONDS }),
-      kv.put(globalKey, String(globalCount + 1), { expirationTtl: TTL_SECONDS }),
+      kv.put(globalKey, String(globalCount + 1), {
+        expirationTtl: TTL_SECONDS,
+      }),
     ]);
   } catch (error) {
     console.error(`rate-limit: KV write failed: ${error.message}`);
@@ -125,7 +147,9 @@ export async function enforceRateLimit(env, ip) {
  * @param {string} [lang] "es" for Spanish.
  */
 export function rateLimitMessage(scope, lang) {
-  const spanish = String(lang || "").toLowerCase().startsWith("es");
+  const spanish = String(lang || "")
+    .toLowerCase()
+    .startsWith("es");
 
   if (scope === "global") {
     return spanish

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,6 +2,16 @@ name = "cushlabs-booking"
 main = "workers/booking-worker.js"
 compatibility_date = "2025-10-11"
 
+# Backs the rate limiter. POST /book creates a real calendar event and GET
+# /slots burns Google Calendar quota, both without authentication, so the
+# counter has to be shared across isolates — an in-memory Map (what this
+# replaced) counted per-isolate and enforced almost nothing. See
+# workers/lib/rate-limit-d1.js.
+[[d1_databases]]
+binding = "DB"
+database_name = "cushlabs-booking"
+database_id = "9a3ee9e6-77f5-4ff2-b0e2-49da7456d523"
+
 [observability]
 enabled = true
 


### PR DESCRIPTION
The booking Worker advertised "5 bookings per hour" and enforced close to nothing. The counter was a module-level `Map`, so it was really 5 **per isolate**, resetting on every cold start.

That matters more here than on the other Workers: `POST /book` creates a real calendar event with **no authentication**, and `GET /slots` burns Google Calendar quota. Both act before they authenticate.

**Why not the Cloudflare binding** (used by the sibling Workers): its counter is isolate-local too — measured on `cushlabs-whatsapp`, 420 sequential requests over one socket refused at exactly the limit, 1,500 over 25 parallel connections refused none.

**Why not the KV limiter** already in this repo (used by the demo Workers): KV's free tier is ~1,000 writes/day and it spends 2 per allowed request. `/slots` runs on page load, so a few hundred visitors exhaust it — and it fails **closed**, taking bookings offline. D1 gives 100k row writes/day.

**Also corrected a stale note** in the KV module recording the CF binding as "a no-op on this account." The observation was right, the diagnosis wrong — 14 sequential requests spread across isolates. Left alone it would have talked the next person out of using the binding where it *is* the right tool.

Other changes:
- `/slots` limited on cache **miss only**, 60/hr — a cached response costs nothing and shouldn't consume budget. Also closes `?nocache=1` as a free passthrough to Google.
- Keyed by **/64**, not the raw address (IPv6 /128s rotate under RFC 4941).
- `GET /` reports whether the limiter is **enforcing** and 503s if it can't prove it.

**Verified in production** on the case the CF binding failed: 100 requests over 20-way parallelism → **81 allowed, 19 refused**. The 81-vs-60 overshoot is the read-before-insert race, documented at the function with the measured number — it's a ceiling, not exact accounting. `/slots` still returns real availability; `/health` reports `enforcing (2/5 probes refused)`. 31 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)