### PR TITLE
fix(docs): reconcile advertised trial length and MX payment methods to the live site

### DIFF
--- a/docs/AI-ASSISTANT-ONBOARDING.md
+++ b/docs/AI-ASSISTANT-ONBOARDING.md
@@ -24,7 +24,7 @@ Real errors a prior assistant shipped by NOT reading the docs below:
 
 ## 1. What CushLabs sells — one product, three tiers
 
-**One managed monthly subscription per business.** No à-la-carte menu, no setup fee. You pick a tier; CushLabs builds, trains, deploys, and maintains everything. Every plan includes **up to 2 locations**, **unlimited conversations (fair use)**, a **2-week free trial**, and **no contract**.
+**One managed monthly subscription per business.** No à-la-carte menu, no setup fee. You pick a tier; CushLabs builds, trains, deploys, and maintains everything. Every plan includes **up to 2 locations**, **unlimited conversations (fair use)**, a **1-week free trial**, and **no contract**.
 
 | Tier                              | MXN/mo     | USD/mo   | What it adds                                                                                             |
 | --------------------------------- | ---------- | -------- | -------------------------------------------------------------------------------------------------------- |
@@ -36,7 +36,7 @@ Real errors a prior assistant shipped by NOT reading the docs below:
 - **Voice overage (Ultra):** $8.50 MXN / $0.59 USD per minute past 300 min/loc/mo.
 - **Currency follows the MARKET, not the language:** MXN for Mexico + Central/South America; USD for US + Canada. USD figures are **independently anchored marketing numbers — never a live FX conversion.** Do not auto-convert.
 
-**"What do we charge 1,990 pesos for?" (Basic, verbatim):** AI Messenger Assistant on Facebook (24/7, bilingual, full feature set) + Google review management (owner-approved) + owner lead alerts + fully managed (setup, training, support). Per business, up to 2 locations, no setup fee, no contract, 2-week free trial, unlimited conversations (fair use), CFDI invoice included.
+**"What do we charge 1,990 pesos for?" (Basic, verbatim):** AI Messenger Assistant on Facebook (24/7, bilingual, full feature set) + Google review management (owner-approved) + owner lead alerts + fully managed (setup, training, support). Per business, up to 2 locations, no setup fee, no contract, 1-week free trial, unlimited conversations (fair use), CFDI invoice included.
 
 ---
 

--- a/docs/outreach/salones-outreach-es.md
+++ b/docs/outreach/salones-outreach-es.md
@@ -34,7 +34,7 @@ Pick one; rotate to avoid pattern-matching. Warm, respectful, short. First touch
 
 **Follow-up 1**
 
-> Hola de nuevo 🙂 Le dejo aquí el link por si quiere echarle un ojo cuando tenga un momento: https://www.cushlabs.ai/salones/ — son 2 semanas de prueba gratis, sin contratos.
+> Hola de nuevo 🙂 Le dejo aquí el link por si quiere echarle un ojo cuando tenga un momento: https://www.cushlabs.ai/salones/ — es una semana de prueba gratis, sin contratos.
 
 **Follow-up 2 (final, soft close)**
 
@@ -44,14 +44,14 @@ Pick one; rotate to avoid pattern-matching. Warm, respectful, short. First touch
 
 ## Objection bank (quick replies)
 
-| Si dice…                               | Responde…                                                                                                                                                                          |
-| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| "Ya uso Booksy / una app de citas"     | "¡Perfecto, no la quita! Esa app manda recordatorios, pero no contesta los mensajes de sus clientas en Instagram o Facebook. Eso es justo lo que yo hago. Se complementan."        |
-| "Está muy caro / no tengo presupuesto" | "Le entiendo. Son $1,990 al mes, todo incluido — y con una sola clienta al mes que no se le escape ya se pagó. Por eso le ofrezco 2 semanas gratis: lo prueba sin arriesgar nada." |
-| "No le sé a la tecnología"             | "No se preocupe, yo lo configuro y lo cuido todo. Usted solo atiende a las clientas que le lleguen listas para agendar."                                                           |
-| "¿Suena a robot?"                      | "Para nada — habla con la voz de su salón, en español, natural y cálido. Si quiere le mando un ejemplo."                                                                           |
-| "Déjame pensarlo"                      | "¡Claro! Le dejo el link para cuando guste: https://www.cushlabs.ai/salones/ La prueba gratis está disponible cuando decida."                                                      |
-| "¿Cómo te pago?"                       | "Por SPEI u OXXO, lo que le sea más fácil, y le doy factura sin costo extra."                                                                                                      |
+| Si dice…                               | Responde…                                                                                                                                                                           |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "Ya uso Booksy / una app de citas"     | "¡Perfecto, no la quita! Esa app manda recordatorios, pero no contesta los mensajes de sus clientas en Instagram o Facebook. Eso es justo lo que yo hago. Se complementan."         |
+| "Está muy caro / no tengo presupuesto" | "Le entiendo. Son $1,990 al mes, todo incluido — y con una sola clienta al mes que no se le escape ya se pagó. Por eso le ofrezco una semana gratis: lo prueba sin arriesgar nada." |
+| "No le sé a la tecnología"             | "No se preocupe, yo lo configuro y lo cuido todo. Usted solo atiende a las clientas que le lleguen listas para agendar."                                                            |
+| "¿Suena a robot?"                      | "Para nada — habla con la voz de su salón, en español, natural y cálido. Si quiere le mando un ejemplo."                                                                            |
+| "Déjame pensarlo"                      | "¡Claro! Le dejo el link para cuando guste: https://www.cushlabs.ai/salones/ La prueba gratis está disponible cuando decida."                                                       |
+| "¿Cómo te pago?"                       | "Por transferencia bancaria, y le doy su factura sin costo extra."                                                                                                                  |
 
 ---
 
@@ -71,7 +71,7 @@ When they arrive, run the **qualification flow** (see strategy doc §7B): págin
 - [ ] **`PUBLIC_WHATSAPP_NUMBER` confirmed** in the cushlabs env (landing CTA falls back to +52 33 1559 0572 if unset).
 - [ ] **Client intake:** their FB/IG page access + a list of services & prices (the only things needed to train the assistant).
 - [ ] **WhatsApp utility templates** drafted + submitted for approval (appointment reminders).
-- [ ] **Payment:** SPEI account + OXXO reference ready; CFDI invoicing set up.
+- [ ] **Payment:** bank-transfer account ready; CFDI invoicing set up. (OXXO and card are roadmap via Mercado Pago — **not live, do not offer them.**)
 - [ ] **First case study:** capture before/after (response time, citas recovered) from client #1 for social proof.
 
 ---

--- a/docs/strategy/ADVERTISED-COMMITMENTS.md
+++ b/docs/strategy/ADVERTISED-COMMITMENTS.md
@@ -95,9 +95,19 @@ Three tiers. One flat monthly price each. **Per business, includes up to 2 locat
 ### 2.2 Universal terms (apply to every tier)
 
 - **Locations:** every plan includes **up to 2 locations**; additional locations **+$690 MXN/mo** ( **+$49 USD/mo** ) each.
-- **No setup fee. No contracts. 2-week free trial. Unlimited conversations (fair use).**
-- **Payment (MXN):** SPEI or OXXO; **CFDI invoice included.**
+- **No setup fee. No contracts. 1-week free trial. Unlimited conversations (fair use).**
+- **Payment (MXN):** bank transfer / _transferencia_ (rides SPEI); **CFDI invoice included.**
+  **OXXO and card are roadmap via Mercado Pago — not live, never advertise them.**
 - **Payment (USD):** card; invoice included.
+- **Billing:** monthly, **in advance**. Prepay discounts: **quarterly 5%, annual 10%**, applied to
+  the recurring subscription only.
+
+> **Reconciled to the live site 2026-08-05.** This block had said "2-week free trial" and "SPEI or
+> OXXO" since before 2026-07-08. Both were wrong: `PricingSection.astro`, `terms.astro` and
+> `es/terms.astro` all say **1 week** and **bank transfer only**, and have since PRs #174/#181.
+> This is the same failure as the 2026-08-04 WhatsApp allowlist miss (`a-134`) — the site moved and
+> the file the copywriting system reads did not. Trial length and payment methods are the two lines
+> most likely to reach a prospect verbatim; check them first at every reconciliation.
 
 ### 2.3 Currency rule (do not break this)
 
@@ -479,7 +489,7 @@ directly. Do the following to establish durable connectivity:
 8. **Answer "what do we charge 1,990 pesos for?" from §2.1 Basic**, not from memory: AI Messenger
    Assistant (24/7, the full §4 feature set) + Google review management (owner-approved) + owner lead
    alerts + fully-managed (setup/training/support), per business incl. up to 2 locations, no setup fee,
-   no contract, 2-week free trial, unlimited conversations (fair use), CFDI invoice.
+   no contract, 1-week free trial, unlimited conversations (fair use), CFDI invoice.
 
 **Sync protocol going forward:** any change to price, a guarantee, or an advertised feature is made in
 the marketing repo **and** reflected here in the _same_ PR; then this file's `Last reconciled` date is

--- a/docs/strategy/MEXICO-GTM-STRATEGY.md
+++ b/docs/strategy/MEXICO-GTM-STRATEGY.md
@@ -2,6 +2,19 @@
 
 > **Status:** Living strategy document. Started 2026-06-28.
 > **Owner:** Robert Cushman (Guadalajara, Mexico)
+>
+> ⚠️ **Two published terms in this file are stale (flagged 2026-08-05). The live site wins.**
+>
+> - **Free trial is 1 week, not 2.** Every "2-week free trial" below (lines ~226, 231, 260, 263, 271)
+>   predates the site-wide change and is history, not policy. `PricingSection.astro`, `terms.astro`
+>   and `es/terms.astro` all say 1 week. The strategic _reasoning_ in §"chains get the trial" is
+>   unchanged and still correct — only the number moved.
+> - **OXXO is not a live payment method.** "SPEI/OXXO" below (lines ~75, 114, 220, 226) describes the
+>   intended end state. Today MX payment is **bank transfer / transferencia + CFDI**; OXXO and card
+>   are roadmap via Mercado Pago. The market analysis at line ~57 (card-on-file alone reaches ~half
+>   of MX SMBs) is why OXXO is still on the roadmap and remains valid.
+>
+> Do not quote a prospect from this file. Quote from `ADVERTISED-COMMITMENTS.md` §2.2.
 > **Purpose:** Durable home for the MX-first repositioning — pricing, services, unit economics, market research, niche selection, decision trees, and go-to-market tactics. Supersedes the prior US-oriented model.
 
 ---
@@ -121,7 +134,7 @@ Good-Better-Best, all MXN/month, subscription, **no setup fee, no contract.** Ev
 
 The published price is **per business, and includes up to 2 locations**. Additional locations are a **flat +$690 MXN/mo each, across all tiers**.
 
-- **Mental model:** ~$1,000/location, first two bundled. `$690` fits the `…90` price aesthetic.
+- **Mental model:** ~$1,000/location, first two bundled. `$690`fits the`…90` price aesthetic.
 - **Why "up to 2" (not 1, not 4):** two locations is the most common "bigger than solo" case (salon + spa, or a second shop). The marginal delivery cost of a 2nd location is tiny (same AI brain, one account manager, one more Google profile), so bundling it buys goodwill cheaply. "First 4" was rejected — it gave away the _expensive_ locations; "up to 2" gives away the cheap one.
 - **Why $690 (not $990):** marginal work per extra location is genuinely low (we know it; the client doesn't). The add-on is a **land-grab / chain-capture lever**, not cost recovery. `$490` is the floor — below that, location 3 drops to ~half the effective rate of the bundled first two, which invites "so why am I paying $1,990 for the first two?", and it underprices recurring review-management labor.
 - **The formula scales cleanly, no brackets:** a 9-location Basic account = `$1,990 + 7 × $690 = $6,820/mo` (~$380 USD to run 9 locations). Chains get a fair auto-price; use "custom / let's talk" only when a shared-vs-per-location Facebook-page split justifies a discount (e.g. 9 locations on ONE shared FB page = ~1× Messenger workload → room to come down to ~$7,900 on higher tiers).

--- a/docs/strategy/PRODUCT-AND-PRICING-SUMMARY.md
+++ b/docs/strategy/PRODUCT-AND-PRICING-SUMMARY.md
@@ -1,6 +1,6 @@
 # CushLabs — Product & Pricing Summary
 
-**Last updated:** 2026-07-07
+**Last updated:** 2026-08-05 (trial length + MX payment methods reconciled to the live site)
 **Canonical price source:** `src/components/pricing/PricingSection.astro` (this doc mirrors it — if they ever disagree, the component wins).
 **Related:** `MEXICO-GTM-STRATEGY.md` (strategy, edge cases, USD rationale) · `MESSENGER-PREMIUM-UPGRADES-HELD.md` (premium roadmap).
 
@@ -14,7 +14,7 @@
 
 CushLabs sells **one product**: a fully-managed AI subscription for local/SMB businesses, billed monthly per business. There are no à-la-carte add-ons and no setup fee — you pick a tier, and everything in it is built, trained, deployed, and maintained for you.
 
-Every plan includes **up to 2 locations**, **unlimited conversations (fair use)**, a **2-week free trial**, and **no contract**.
+Every plan includes **up to 2 locations**, **unlimited conversations (fair use)**, a **1-week free trial**, and **no contract**.
 
 ### Pricing table
 
@@ -34,9 +34,10 @@ Every plan includes **up to 2 locations**, **unlimited conversations (fair use)*
 ### Terms that apply to every plan
 
 - **No setup fee. No contracts. Cancel anytime.**
-- **2-week free trial** on up to two locations. Larger multi-location rollouts run the trial on 1–2 locations first, then expand.
+- **1-week free trial** on up to two locations. Larger multi-location rollouts run the trial on 1–2 locations first, then expand.
 - **Unlimited conversations (fair use)** — internal soft cap ~1,000 conversations/mo/location.
-- **Payment:** 🇲🇽 SPEI · OXXO · CFDI invoice included. 🇺🇸🇨🇦 Pay by card · invoice included.
+- **Payment:** 🇲🇽 bank transfer / _transferencia_ (rides SPEI) · CFDI invoice included. 🇺🇸🇨🇦 Pay by card · invoice included. **OXXO and card in MX are roadmap via Mercado Pago — not live.**
+- **Billing:** monthly, **in advance**. Prepay: quarterly **5%**, annual **10%** off the recurring subscription only.
 
 ---
 
@@ -136,5 +137,5 @@ Every plan includes **up to 2 locations**, **unlimited conversations (fair use)*
 | Included locations                   | 2            | 2            | 2                     |
 | Extra location (MXN / USD)           | +$690 / +$49 | +$690 / +$49 | +$690 / +$49          |
 | Voice overage (MXN / USD)            | —            | —            | $8.50 / $0.59 per min |
-| Free trial                           | 2 weeks      | 2 weeks      | 2 weeks               |
+| Free trial                           | 1 week       | 1 week       | 1 week                |
 | Setup fee / contract                 | None / None  | None / None  | None / None           |

--- a/docs/voice-cushlabs-ai-briefing.md
+++ b/docs/voice-cushlabs-ai-briefing.md
@@ -17,6 +17,7 @@
 ## Current State of the Site (audited 2026-04-13)
 
 ### What exists and is working well
+
 - **Homepage** — Strong hero: "Stop Losing Leads to Voicemail." Good pain-first framing. Describes 4 capabilities (Lead Qualification, Appointment Booking, Customer Support, AI Front Desk). Has a "How It Works" 4-step process.
 - **Live Demo pages** — 5 demo agents: Clara (lead qual), James (exec coaching scheduler), Sophia (med spa front desk), Mike (home services dispatcher), David (real estate setter). These are the strongest asset on the site — they let prospects actually talk to the AI.
 - **Portfolio page** — Exists (not yet audited in detail)
@@ -25,11 +26,13 @@
 - **Bilingual toggle** — ES button exists in nav
 
 ### What is MISSING
+
 1. **No Services/Pricing page** — The biggest gap. A prospect who wants to know what it costs and what they get has nowhere to go. They either leave or have to book a call just to find out the price. This is the #1 thing to build.
 2. **No FAQ page** — Common objections (does it sound robotic? what if I go over minutes? do I need a developer?) are unanswered.
 3. **"New York, NY" in the footer** — WRONG. Robert is based in Mexico and serves US + Mexico. This needs to be removed or changed to "Serving US & Mexico."
 
 ### Messaging issues to fix
+
 - Footer says `"Built by Robert Cushman — powered by AI and voice."` — fine, keep it.
 - The `/nyc-coaching` demo page says **"NEW YORK ENGLISH"** as a brand — this is a different client brand (possibly the ny-english-teacher client). Make sure this isn't creating confusion about CushLabs' location/identity.
 - Homepage process step says **"Clara lives inside your CRM and Calendar"** — this hardcodes the demo agent name into generic copy. Should say "Your agent lives inside your CRM..." since every client gets a custom agent, not Clara.
@@ -40,6 +43,7 @@
 ## The Services/Pricing Page to Build
 
 ### URL
+
 `/services` (and `/es/services` for Spanish)
 
 ### What it should communicate
@@ -47,6 +51,7 @@
 This page should answer: **"What do I get, what does it cost, and how does this work?"**
 
 #### Price
+
 - **US:** $1,497/mo
 - **Mexico/LATAM:** $10,997 MXN/mes
 - 500 minutes included per month
@@ -55,6 +60,7 @@ This page should answer: **"What do I get, what does it cost, and how does this 
 - No setup fee. No long-term contract. Cancel anytime.
 
 #### What's included (feature list)
+
 - Natural-sounding AI voice matched to your brand
 - Answers every call on the first ring, 24/7
 - 500 minutes/mo included
@@ -67,6 +73,7 @@ This page should answer: **"What do I get, what does it cost, and how does this 
 - No IT team needed — fully managed setup and maintenance
 
 #### Pain-first framing (use this, don't lead with features)
+
 Lead with the cost of inaction. The buyer's real problem is missed calls = missed revenue. Frame it like this:
 
 - You miss 3–5 calls a day while you're with clients, driving, or at lunch.
@@ -76,6 +83,7 @@ Lead with the cost of inaction. The buyer's real problem is missed calls = misse
 - Your AI voice agent works 24/7 for $1,497/mo and never calls in sick.
 
 #### Who it's for (use these as "scenario cards" or bullet points)
+
 - **Home services companies** (plumbing, HVAC, roofing) — every missed call is a $1,200 job
 - **Med spas and clinics** — front desk that never puts callers on hold
 - **Real estate teams** — outbound follow-up and inbound lead qualification
@@ -83,25 +91,28 @@ Lead with the cost of inaction. The buyer's real problem is missed calls = misse
 - **Any business that misses calls** — if your phone rings and nobody picks up, this is for you
 
 #### How it works (keep it to 3–4 steps)
+
 1. **Discovery call (free)** — We learn your call flow, customer questions, and business rules
 2. **We build your agent** — Custom voice, persona, and scripts in days, not months
 3. **Connect your systems** — Calendar, CRM, text notifications
 4. **Go live + monthly optimization** — Launch, then we tune it based on real call data
 
 #### CTA
+
 Primary: "Start Free Trial" → `/consultation`
 Secondary: "Talk to Clara first" → demo embed or `/` anchor
 
 #### ROI block
+
 Include this comparison:
 
-| | Full-time receptionist | AI Voice Agent |
-|---|---|---|
-| Cost | $3,000–$4,500/mo | $1,497/mo |
-| Hours | 8/day, 5 days/week | 24/7, 365 days/year |
-| Sick days | Yes | Never |
-| Bilingual | Rarely | Always |
-| Appointment booking | Manual | Automatic |
+|                     | Full-time receptionist | AI Voice Agent      |
+| ------------------- | ---------------------- | ------------------- |
+| Cost                | $3,000–$4,500/mo       | $1,497/mo           |
+| Hours               | 8/day, 5 days/week     | 24/7, 365 days/year |
+| Sick days           | Yes                    | Never               |
+| Bilingual           | Rarely                 | Always              |
+| Appointment booking | Manual                 | Automatic           |
 
 ---
 
@@ -142,17 +153,17 @@ Yes. Happy to sign a mutual NDA before any sensitive business information is sha
 
 Before shipping the services page, verify these match cushlabs.ai exactly:
 
-| Element | cushlabs.ai | voice.cushlabs.ai |
-|---|---|---|
-| US Voice Agent price | $1,497/mo | Must match |
-| MX Voice Agent price | $10,997 MXN/mes | Must match |
-| Minutes included | 500 | Must match |
-| Overage rate | $0.50/min US / $8.50 MXN | Must match |
-| Free trial length | 2 weeks | Must match |
-| CTA text | "Start Free Trial" | Should match |
-| Consultation URL | /consultation/ | Already matches |
-| Location | "Serving US & Mexico" | Fix footer — remove "New York, NY" |
-| Free trial messaging | "No setup fee. No contract. Cancel anytime." | Add this |
+| Element              | cushlabs.ai                                  | voice.cushlabs.ai                  |
+| -------------------- | -------------------------------------------- | ---------------------------------- |
+| US Voice Agent price | $1,497/mo                                    | Must match                         |
+| MX Voice Agent price | $10,997 MXN/mes                              | Must match                         |
+| Minutes included     | 500                                          | Must match                         |
+| Overage rate         | $0.50/min US / $8.50 MXN                     | Must match                         |
+| Free trial length    | 1 week                                       | Must match                         |
+| CTA text             | "Start Free Trial"                           | Should match                       |
+| Consultation URL     | /consultation/                               | Already matches                    |
+| Location             | "Serving US & Mexico"                        | Fix footer — remove "New York, NY" |
+| Free trial messaging | "No setup fee. No contract. Cancel anytime." | Add this                           |
 
 ---
 
@@ -179,6 +190,7 @@ Add "SERVICES" as a primary nav link. This is the most important missing piece �
 ## Tone and Voice Guidelines
 
 Match the tone of cushlabs.ai:
+
 - **Direct, not corporate.** Write like a smart person talking to a business owner, not like a SaaS marketing team.
 - **Pain-first, not feature-first.** Lead with what it costs them NOT to have this.
 - **Confident without bragging.** Let the live demos do the selling — your job is to get them to try one.
@@ -198,4 +210,4 @@ Match the tone of cushlabs.ai:
 
 ---
 
-*Briefing written 2026-04-13 based on cushlabs.ai pricing overhaul (PR #66) and live site audit of voice.cushlabs.ai.*
+_Briefing written 2026-04-13 based on cushlabs.ai pricing overhaul (PR #66) and live site audit of voice.cushlabs.ai._


### PR DESCRIPTION
Six docs still advertised a **2-week free trial** and **OXXO** as a live MX payment method. The site says neither.

## Ground truth (three live sources, already in agreement)

| Source | Trial | MX payment |
|---|---|---|
| `src/components/pricing/PricingSection.astro` | 1 week | bank transfer + CFDI |
| `src/pages/terms.astro` | 1 week | bank transfer + CFDI |
| `src/pages/es/terms.astro` | 1 semana | transferencia bancaria + CFDI |

Landed via PRs #174 and #181. The site is correct and internally consistent — **only the docs drifted.**

## What was wrong

| File | Was |
|---|---|
| `docs/strategy/ADVERTISED-COMMITMENTS.md` | 2-week trial · "SPEI or OXXO" |
| `docs/strategy/PRODUCT-AND-PRICING-SUMMARY.md` | 2-week trial ×3 · "SPEI · OXXO" |
| `docs/AI-ASSISTANT-ONBOARDING.md` | 2-week trial ×2 |
| `docs/voice-cushlabs-ai-briefing.md` | trial-length parity row said 2 weeks |
| `docs/outreach/salones-outreach-es.md` | "2 semanas de prueba gratis" · "Por SPEI u OXXO" |
| `docs/strategy/MEXICO-GTM-STRATEGY.md` | both, in 7 places |

**This is `a-134` happening again** — the site moved and the files the copywriting system reads did not. `ADVERTISED-COMMITMENTS.md` is the one that matters most: every writing skill loads it before producing copy, so a stale line there propagates into everything generated afterward.

## The one with real exposure

`docs/outreach/salones-outreach-es.md` is **prospect-facing es-MX copy**. It promised a trial twice as long as offered and quoted a payment rail that does not exist ("Por SPEI u OXXO"). Corrected in Mexican Professional Spanish; audited clean against the full Iberian-marker list.

## Judgment call on the GTM doc

`MEXICO-GTM-STRATEGY.md` got a **banner, not a rewrite**. Its OXXO market analysis — card-on-file alone reaches only ~half of MX SMBs — is still valid strategy and is precisely why OXXO stays on the roadmap. Only the lines presenting OXXO as *currently offered*, and the trial number, are stale. Rewriting the reasoning would have destroyed the argument for the roadmap item.

## Also captured

Billing is **monthly in advance**, prepay **quarterly 5% / annual 10%**. That was on the live terms page but in none of the summary docs.

## Separate finding — PR #173 should be closed, not merged

`fix/pricing-alignment` has been open since 2026-07-09 and touches **24 files including live pages**. Its substance already landed through #174 and #181. Merging a 4-week-old branch over those would risk reverting them — and #176 in this same repo is literally titled *"restore content reverted by stale-base blog-hero merge."* That failure has already happened here once. **Recommend closing #173.**

Docs only. No source changes, no build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
