### PR TITLE
feat(portfolio): surface Google reputation management on MarketSignal's card

### DIFF
--- a/src/data/projectCardsEs.ts
+++ b/src/data/projectCardsEs.ts
@@ -48,10 +48,13 @@ export const esCardCopy: Record<string, EsCardCopy> = {
     tagline:
       "Agentes telefónicos con IA que contestan llamadas, califican prospectos y agendan citas — 24/7, con respuesta en menos de 500 ms",
   },
+  // Updated 2026-08-07 to surface Google reputation management, a core CushLabs
+  // service that was described in the body of the entry but absent from the card.
   "cushlabs-marketsignal": {
-    title: "MarketSignal — Inteligencia Competitiva Local con IA",
+    title:
+      "MarketSignal — Reputación en Google e Inteligencia Competitiva Local",
     tagline:
-      "Monitoreo de competidores en Google Maps — reportes semanales directo a tu WhatsApp",
+      "Gestión de reputación en Google y monitoreo de competidores — respuestas a reseñas redactadas con IA y una acción clave por semana, directo a tu WhatsApp",
   },
   "cushlabs-sticker-gen": {
     tagline:

--- a/src/data/projects.generated.json
+++ b/src/data/projects.generated.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-06T18:31:00.686Z",
+  "generatedAt": "2026-08-08T04:35:41.417Z",
   "count": 35,
   "projects": [
     {
@@ -251,157 +251,6 @@
       "videoPoster": "https://cdn.cushlabs.ai/ny-ai-chatbot/video/ny-eng-chatbot-brief-poster.jpg"
     },
     {
-      "id": 1203303335,
-      "name": "cushlabs-messenger-bot",
-      "title": "CushLabs Messenger",
-      "description": "Multi-tenant Facebook Messenger AI platform — one Cloudflare Worker serving many business Pages via page_id routing, with bilingual (EN/es-MX) Claude assistants, Vectorize RAG, structured business facts, and human handoff.",
-      "summary": "> Multi-tenant Facebook Messenger AI platform — one Cloudflare Worker serving many business Pages with bilingual (EN/es-MX) Claude-powered assistants, RAG knowledge bases, structured business facts, a",
-      "url": "https://github.com/RCushmaniii/cushlabs-messenger-bot",
-      "demoUrl": "https://m.me/cushlabs",
-      "liveUrl": "",
-      "homepage": null,
-      "topics": [
-        "ai-assistant",
-        "anthropic",
-        "bilingual",
-        "chatbot",
-        "claude",
-        "cloudflare-workers",
-        "facebook-messenger",
-        "messenger-bot",
-        "qdrant",
-        "rag",
-        "typescript",
-        "workers-ai"
-      ],
-      "categories": [
-        "AI Automation"
-      ],
-      "tags": [
-        "ai-assistant",
-        "anthropic",
-        "bilingual",
-        "chatbot",
-        "claude",
-        "cloudflare-workers",
-        "facebook-messenger",
-        "messenger-bot",
-        "qdrant",
-        "rag",
-        "typescript",
-        "workers-ai",
-        "claude-ai",
-        "multi-tenant",
-        "facebook",
-        "vector-search",
-        "conversational-ai"
-      ],
-      "stack": [
-        "Cloudflare Workers",
-        "TypeScript",
-        "Claude API (Haiku + Sonnet)",
-        "Cloudflare Vectorize (vector search)",
-        "Cloudflare Workers AI (embeddings)",
-        "Cloudflare KV (tenant config + session state)",
-        "Cloudflare D1 (analytics)",
-        "Upstash Redis (rate limiting)",
-        "Clerk (operator console auth)",
-        "Meta Messenger Platform",
-        "Sentry (error monitoring)",
-        "GitHub Actions (CI/CD)"
-      ],
-      "status": "Production",
-      "language": "TypeScript",
-      "languages": {
-        "TypeScript": 751505,
-        "JavaScript": 211470,
-        "PowerShell": 7945,
-        "HTML": 733,
-        "CSS": 323
-      },
-      "stars": 0,
-      "forks": 0,
-      "lastPushed": "2026-08-06T18:27:01Z",
-      "createdAt": "2026-04-06T23:20:56Z",
-      "isFeatured": true,
-      "isArchived": false,
-      "isPrivate": true,
-      "tagline": "The 24/7 bilingual AI assistant for Facebook Messenger — built from your business's own content, so no lead goes cold.",
-      "thumbnail": "https://cdn.cushlabs.ai/cushlabs-messenger-bot/images/portfolio/card-messenger.webp",
-      "problem": "Businesses that market on Facebook get Messenger questions about pricing, hours, and services at all\nhours, in whatever language the customer speaks. Nobody watches the inbox around the clock, customers\nexpect fast answers, and a generic auto-reply — or a chatbot that invents details — costs real\nbusiness. The usual agency fix is a separate bot build per client: separate deploy, separate Meta app,\nseparate review cycle, separate thing to maintain. That does not scale past a couple of clients.\n",
-      "solution": "One Cloudflare Worker serves every connected Page. Each inbound webhook is routed by page_id to that tenant's own system prompt, per-Page access token, structured business facts, and tenant-scoped vector index — so onboarding a client is a config and content operation, not a deploy. A two-layer router sends pleasantries to Claude Haiku and real questions to Claude Sonnet with RAG context. Hard facts (hours, pricing, address, booking URL) live as structured records injected verbatim and marked authoritative, so a price change is a one-field edit that is live on the next message with no re-embed. When a customer wants a person, the bot goes quiet and alerts the operator, who replies from the Page Inbox.\n",
-      "keyFeatures": [
-        "Answers customer questions in under 5 seconds, 24/7 — nights, weekends, holidays",
-        "English and Spanish automatically, following whatever the customer writes, with no manual switching",
-        "Answers come from the client's own approved content — it never invents a price or makes up a promise",
-        "Hours and pricing come back exact every time, because they are stored as data, not as prose the AI has to interpret",
-        "Hands off to a person with full context when a customer asks, alerts the owner, then resumes on its own",
-        "One Worker, many client Pages — a new client onboards as configuration, with no code change and no Meta re-review"
-      ],
-      "metrics": [
-        "2 live client Pages running on a single Worker deployment",
-        "485 automated tests across 29 files, covering the decision layer and not just API plumbing",
-        "53 scripted QA scenarios run against production before a client goes live, cross-tenant isolation included",
-        "~50 seconds from merge to live, typecheck and tests gated"
-      ],
-      "priority": 3,
-      "dateCompleted": null,
-      "slides": [
-        {
-          "src": "https://cdn.cushlabs.ai/cushlabs-messenger-bot/images/portfolio/card-messenger.webp",
-          "altEn": "CushLabs Messenger",
-          "altEs": "CushLabs Messenger"
-        },
-        {
-          "src": "https://cdn.cushlabs.ai/cushlabs-messenger-bot/images/hero-en-01.webp",
-          "altEn": "CushLabs Messenger",
-          "altEs": "CushLabs Messenger"
-        },
-        {
-          "src": "https://cdn.cushlabs.ai/cushlabs-messenger-bot/images/hero-en-02.webp",
-          "altEn": "CushLabs Messenger",
-          "altEs": "CushLabs Messenger"
-        },
-        {
-          "src": "https://cdn.cushlabs.ai/cushlabs-messenger-bot/images/hero-en-03.webp",
-          "altEn": "CushLabs Messenger",
-          "altEs": "CushLabs Messenger"
-        },
-        {
-          "src": "https://cdn.cushlabs.ai/cushlabs-messenger-bot/images/hero-en-04.webp",
-          "altEn": "CushLabs Messenger",
-          "altEs": "CushLabs Messenger"
-        },
-        {
-          "src": "https://cdn.cushlabs.ai/cushlabs-messenger-bot/images/hero-en-05.webp",
-          "altEn": "CushLabs Messenger",
-          "altEs": "CushLabs Messenger"
-        },
-        {
-          "src": "https://cdn.cushlabs.ai/cushlabs-messenger-bot/images/hero-en-06.webp",
-          "altEn": "CushLabs Messenger",
-          "altEs": "CushLabs Messenger"
-        },
-        {
-          "src": "https://cdn.cushlabs.ai/cushlabs-messenger-bot/images/hero-en-07.webp",
-          "altEn": "CushLabs Messenger",
-          "altEs": "CushLabs Messenger"
-        },
-        {
-          "src": "https://cdn.cushlabs.ai/cushlabs-messenger-bot/images/hero-en-08.webp",
-          "altEn": "CushLabs Messenger",
-          "altEs": "CushLabs Messenger"
-        },
-        {
-          "src": "https://cdn.cushlabs.ai/cushlabs-messenger-bot/images/hero-en-09.webp",
-          "altEn": "CushLabs Messenger",
-          "altEs": "CushLabs Messenger"
-        }
-      ],
-      "videoUrl": "https://cdn.cushlabs.ai/cushlabs-messenger-bot/images/portfolio/24_7_AI_Sales_Assistant.mp4",
-      "videoPoster": null
-    },
-    {
       "id": 1164355422,
       "name": "cushlabs-ai-voice-agent",
       "title": "AI Voice Agent Platform",
@@ -468,14 +317,14 @@
       "status": "Production",
       "language": "HTML",
       "languages": {
-        "HTML": 516363,
-        "JavaScript": 172769,
+        "HTML": 516882,
+        "JavaScript": 178138,
         "CSS": 8475,
         "Dockerfile": 358
       },
       "stars": 0,
       "forks": 1,
-      "lastPushed": "2026-08-06T18:14:41Z",
+      "lastPushed": "2026-08-08T04:24:05Z",
       "createdAt": "2026-02-23T01:31:09Z",
       "isFeatured": true,
       "isArchived": false,
@@ -563,10 +412,161 @@
       "videoPoster": "https://cdn.cushlabs.ai/cushlabs-ai-voice-agent/video/voice-cushlabs-brief-poster.webp"
     },
     {
+      "id": 1203303335,
+      "name": "cushlabs-messenger-bot",
+      "title": "CushLabs Messenger",
+      "description": "Multi-tenant Facebook Messenger AI platform — one Cloudflare Worker serving many business Pages via page_id routing, with bilingual (EN/es-MX) Claude assistants, Vectorize RAG, structured business facts, and human handoff.",
+      "summary": "> Multi-tenant Facebook Messenger AI platform — one Cloudflare Worker serving many business Pages with bilingual (EN/es-MX) Claude-powered assistants, RAG knowledge bases, structured business facts, a",
+      "url": "https://github.com/RCushmaniii/cushlabs-messenger-bot",
+      "demoUrl": "https://m.me/cushlabs",
+      "liveUrl": "",
+      "homepage": null,
+      "topics": [
+        "ai-assistant",
+        "anthropic",
+        "bilingual",
+        "chatbot",
+        "claude",
+        "cloudflare-workers",
+        "facebook-messenger",
+        "messenger-bot",
+        "qdrant",
+        "rag",
+        "typescript",
+        "workers-ai"
+      ],
+      "categories": [
+        "AI Automation"
+      ],
+      "tags": [
+        "ai-assistant",
+        "anthropic",
+        "bilingual",
+        "chatbot",
+        "claude",
+        "cloudflare-workers",
+        "facebook-messenger",
+        "messenger-bot",
+        "qdrant",
+        "rag",
+        "typescript",
+        "workers-ai",
+        "claude-ai",
+        "multi-tenant",
+        "facebook",
+        "vector-search",
+        "conversational-ai"
+      ],
+      "stack": [
+        "Cloudflare Workers",
+        "TypeScript",
+        "Claude API (Haiku + Sonnet)",
+        "Cloudflare Vectorize (vector search)",
+        "Cloudflare Workers AI (embeddings)",
+        "Cloudflare KV (tenant config + session state)",
+        "Cloudflare D1 (analytics)",
+        "Upstash Redis (rate limiting)",
+        "Clerk (operator console auth)",
+        "Meta Messenger Platform",
+        "Sentry (error monitoring)",
+        "GitHub Actions (CI/CD)"
+      ],
+      "status": "Production",
+      "language": "TypeScript",
+      "languages": {
+        "TypeScript": 758561,
+        "JavaScript": 218328,
+        "PowerShell": 7945,
+        "HTML": 733,
+        "CSS": 323
+      },
+      "stars": 0,
+      "forks": 0,
+      "lastPushed": "2026-08-07T21:40:17Z",
+      "createdAt": "2026-04-06T23:20:56Z",
+      "isFeatured": true,
+      "isArchived": false,
+      "isPrivate": true,
+      "tagline": "The 24/7 bilingual AI assistant for Facebook Messenger — built from your business's own content, so no lead goes cold.",
+      "thumbnail": "https://cdn.cushlabs.ai/cushlabs-messenger-bot/images/portfolio/card-messenger.webp",
+      "problem": "Businesses that market on Facebook get Messenger questions about pricing, hours, and services at all\nhours, in whatever language the customer speaks. Nobody watches the inbox around the clock, customers\nexpect fast answers, and a generic auto-reply — or a chatbot that invents details — costs real\nbusiness. The usual agency fix is a separate bot build per client: separate deploy, separate Meta app,\nseparate review cycle, separate thing to maintain. That does not scale past a couple of clients.\n",
+      "solution": "One Cloudflare Worker serves every connected Page. Each inbound webhook is routed by page_id to that tenant's own system prompt, per-Page access token, structured business facts, and tenant-scoped vector index — so onboarding a client is a config and content operation, not a deploy. A two-layer router sends pleasantries to Claude Haiku and real questions to Claude Sonnet with RAG context. Hard facts (hours, pricing, address, booking URL) live as structured records injected verbatim and marked authoritative, so a price change is a one-field edit that is live on the next message with no re-embed. When a customer wants a person, the bot goes quiet and alerts the operator, who replies from the Page Inbox.\n",
+      "keyFeatures": [
+        "Answers customer questions in under 5 seconds, 24/7 — nights, weekends, holidays",
+        "English and Spanish automatically, following whatever the customer writes, with no manual switching",
+        "Answers come from the client's own approved content — it never invents a price or makes up a promise",
+        "Hours and pricing come back exact every time, because they are stored as data, not as prose the AI has to interpret",
+        "Hands off to a person with full context when a customer asks, alerts the owner, then resumes on its own",
+        "One Worker, many client Pages — a new client onboards as configuration, with no code change and no Meta re-review"
+      ],
+      "metrics": [
+        "2 live client Pages running on a single Worker deployment",
+        "485 automated tests across 29 files, covering the decision layer and not just API plumbing",
+        "53 scripted QA scenarios run against production before a client goes live, cross-tenant isolation included",
+        "~50 seconds from merge to live, typecheck and tests gated"
+      ],
+      "priority": 3,
+      "dateCompleted": null,
+      "slides": [
+        {
+          "src": "https://cdn.cushlabs.ai/cushlabs-messenger-bot/images/portfolio/card-messenger.webp",
+          "altEn": "CushLabs Messenger",
+          "altEs": "CushLabs Messenger"
+        },
+        {
+          "src": "https://cdn.cushlabs.ai/cushlabs-messenger-bot/images/hero-en-01.webp",
+          "altEn": "CushLabs Messenger",
+          "altEs": "CushLabs Messenger"
+        },
+        {
+          "src": "https://cdn.cushlabs.ai/cushlabs-messenger-bot/images/hero-en-02.webp",
+          "altEn": "CushLabs Messenger",
+          "altEs": "CushLabs Messenger"
+        },
+        {
+          "src": "https://cdn.cushlabs.ai/cushlabs-messenger-bot/images/hero-en-03.webp",
+          "altEn": "CushLabs Messenger",
+          "altEs": "CushLabs Messenger"
+        },
+        {
+          "src": "https://cdn.cushlabs.ai/cushlabs-messenger-bot/images/hero-en-04.webp",
+          "altEn": "CushLabs Messenger",
+          "altEs": "CushLabs Messenger"
+        },
+        {
+          "src": "https://cdn.cushlabs.ai/cushlabs-messenger-bot/images/hero-en-05.webp",
+          "altEn": "CushLabs Messenger",
+          "altEs": "CushLabs Messenger"
+        },
+        {
+          "src": "https://cdn.cushlabs.ai/cushlabs-messenger-bot/images/hero-en-06.webp",
+          "altEn": "CushLabs Messenger",
+          "altEs": "CushLabs Messenger"
+        },
+        {
+          "src": "https://cdn.cushlabs.ai/cushlabs-messenger-bot/images/hero-en-07.webp",
+          "altEn": "CushLabs Messenger",
+          "altEs": "CushLabs Messenger"
+        },
+        {
+          "src": "https://cdn.cushlabs.ai/cushlabs-messenger-bot/images/hero-en-08.webp",
+          "altEn": "CushLabs Messenger",
+          "altEs": "CushLabs Messenger"
+        },
+        {
+          "src": "https://cdn.cushlabs.ai/cushlabs-messenger-bot/images/hero-en-09.webp",
+          "altEn": "CushLabs Messenger",
+          "altEs": "CushLabs Messenger"
+        }
+      ],
+      "videoUrl": "https://cdn.cushlabs.ai/cushlabs-messenger-bot/images/portfolio/24_7_AI_Sales_Assistant.mp4",
+      "videoPoster": null
+    },
+    {
       "id": 1196535593,
       "name": "cushlabs-marketsignal",
-      "title": "MarketSignal — AI-Powered Local Competitive Intelligence",
-      "description": "AI-powered local competitive intelligence platform. Monitors Google Maps rankings, reviews, and competitor activity for multi-location businesses — delivering weekly insights via WhatsApp.",
+      "title": "MarketSignal — Google Reputation & Local Competitive Intelligence",
+      "description": "Google reputation management and local competitive intelligence for multi-location businesses in Mexico — AI-drafted review replies via the Google Business Profile API, plus Google Maps rank and competitor tracking delivered weekly over WhatsApp.",
       "summary": "> AI-powered local competitive intelligence for multi-location businesses.",
       "url": "https://github.com/RCushmaniii/cushlabs-marketsignal",
       "demoUrl": null,
@@ -625,7 +625,7 @@
       "status": null,
       "language": "TypeScript",
       "languages": {
-        "TypeScript": 1347275,
+        "TypeScript": 1350331,
         "JavaScript": 58671,
         "HTML": 29745,
         "CSS": 10386,
@@ -634,12 +634,12 @@
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-08-06T15:49:12Z",
+      "lastPushed": "2026-08-08T04:35:12Z",
       "createdAt": "2026-03-30T19:46:00Z",
       "isFeatured": true,
       "isArchived": false,
       "isPrivate": true,
-      "tagline": "Google Maps competitor tracking — weekly reports delivered straight to WhatsApp",
+      "tagline": "Google reputation and competitor tracking — AI-drafted review replies plus one weekly action item, delivered to WhatsApp",
       "thumbnail": "https://cdn.cushlabs.ai/cushlabs-marketsignal/portfolio/marketsignal/thumb-en.webp",
       "problem": "Local businesses in Mexico have no affordable way to systematically track their\nGoogle Maps rankings, monitor competitor activity, or receive actionable insights.\nThey rely on gut instinct or expensive enterprise tools that don't support the\nMexican market. MarketSignal fills that gap with AI-powered weekly reports\ndelivered directly to WhatsApp.\n",
       "solution": "MarketSignal captures weekly snapshots of Google Maps position, review count,\nand rating for every tracked location, then surfaces week-over-week deltas\nautomatically. Claude (Sonnet) turns that raw delta data into plain-language\ninsight and one specific, high-impact action item per location — not just a\ndashboard of charts. Reports are formatted for WhatsApp readability and land\nin the channel where Mexican business owners already operate, so insights get\nread instead of ignored.\n",
@@ -778,7 +778,7 @@
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-08-06T18:13:11Z",
+      "lastPushed": "2026-08-08T04:24:57Z",
       "createdAt": "2025-03-23T03:27:14Z",
       "isFeatured": true,
       "isArchived": false,
@@ -1192,13 +1192,13 @@
       "status": "Production",
       "language": "TypeScript",
       "languages": {
-        "TypeScript": 521810,
+        "TypeScript": 578505,
         "JavaScript": 12040,
         "CSS": 1268
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-08-06T16:46:44Z",
+      "lastPushed": "2026-08-07T02:48:37Z",
       "createdAt": "2026-03-17T18:08:51Z",
       "isFeatured": false,
       "isArchived": false,
@@ -3288,8 +3288,8 @@
       "status": null,
       "language": "Astro",
       "languages": {
-        "Astro": 850553,
-        "TypeScript": 382018,
+        "Astro": 851223,
+        "TypeScript": 382320,
         "JavaScript": 154925,
         "HTML": 61067,
         "Python": 6606,
@@ -3297,7 +3297,7 @@
       },
       "stars": 3,
       "forks": 0,
-      "lastPushed": "2026-08-06T16:46:38Z",
+      "lastPushed": "2026-08-07T02:36:01Z",
       "createdAt": "2026-01-08T03:52:43Z",
       "isFeatured": false,
       "isArchived": false,
@@ -3939,7 +3939,7 @@
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-08-06T16:46:26Z",
+      "lastPushed": "2026-08-06T23:34:33Z",
       "createdAt": "2026-01-13T22:16:37Z",
       "isFeatured": false,
       "isArchived": false,
@@ -4391,7 +4391,7 @@
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-08-06T16:46:56Z",
+      "lastPushed": "2026-08-06T22:01:11Z",
       "createdAt": "2025-12-18T20:18:05Z",
       "isFeatured": false,
       "isArchived": false,

--- a/src/pages/es/projects/[slug].astro
+++ b/src/pages/es/projects/[slug].astro
@@ -30,7 +30,7 @@ const metaTitles: Record<string, string> = {
   'ny-ai-chatbot': 'Chatbot IA para Sitios Web de PYMES',
   'biojalisco-pitch': ES_TITLE_BIOJALISCO_PITCH,
   'expat-driver-license-prep': 'ExpatDrive — Examen de Licencia Bilingüe',
-  'cushlabs-marketsignal': 'MarketSignal — Inteligencia Competitiva Local',
+  'cushlabs-marketsignal': 'MarketSignal — Reputación en Google e Inteligencia Local',
 };
 
 // For projects without a Spanish title override, use interpunct separator (·) instead of
@@ -52,6 +52,9 @@ const metaDescriptions: Record<string, string> = {
   // through to the English GitHub description with the title prefixed — English
   // copy served as the meta description on an es-MX page.
   'cushlabs-messenger-bot': 'El asistente con IA que atiende tu página de Facebook las 24 horas — responde en español o inglés con tus precios, horarios y políticas reales.',
+  // Added 2026-08-07 — surfaces Google reputation management, absent from every
+  // card-level surface until now.
+  'cushlabs-marketsignal': 'Gestión de reputación en Google y monitoreo de competidores para negocios multi-sucursal en México — respuestas a reseñas con IA y una acción semanal.',
 };
 
 // For ES pages falling back to English GitHub descriptions, prefix with the project

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -26,7 +26,7 @@ const metaTitles: Record<string, string> = {
   'ai-chatbot-saas': 'Converso AI — Bilingual AI Chatbot SaaS',
   'ny-ai-chatbot': 'AI Chatbot Widget for Small Business Websites',
   'expat-driver-license-prep': 'ExpatDrive — Bilingual License Exam Prep',
-  'cushlabs-marketsignal': 'MarketSignal — Local Competitive Intelligence',
+  'cushlabs-marketsignal': 'MarketSignal — Google Reputation & Competitor Intel',
 };
 
 const title = `${metaTitles[project.name] || project.title} | CushLabs.ai`;
@@ -46,6 +46,10 @@ const metaDescriptions: Record<string, string> = {
   // repo description, which opens on "Multi-tenant ... page_id routing" and
   // was being truncated mid-sentence in the search snippet.
   'cushlabs-messenger-bot': 'The 24/7 bilingual AI assistant for Facebook Messenger — answers your customers in English or Spanish using your own prices, hours and policies.',
+  // Added 2026-08-07. Previously fell back to the GitHub description, which was
+  // truncated mid-sentence at "one actionable..." and never named reputation
+  // management — a core service, not a footnote.
+  'cushlabs-marketsignal': 'Google reputation management and Maps competitor tracking for multi-location businesses in Mexico — AI-drafted review replies and a weekly action item.',
 };
 
 const rawDescription = (


### PR DESCRIPTION
Companion to https://github.com/RCushmaniii/cushlabs-marketsignal/pull/278

Reputation management was documented in MarketSignal's entry body but absent from every card-level surface — the only thing most people read.

## Fixed

| Surface | Before |
|---|---|
| ES card title + tagline | competitor tracking only |
| EN `metaTitle` | `MarketSignal — Local Competitive Intelligence` |
| EN `metaDescription` | **none** — fell back to GitHub desc |
| ES `metaDescription` | **none** — fell back to *English* GitHub desc, truncated mid-sentence at "one actionable..." |
| GitHub repo description | monitoring framing, no reputation management |

English copy served as the meta description on an es-MX page, and cut off. Same silent-fallback failure as the Messenger slugs in #224.

## Notes

**MarketSignal was already featured.** `src/data/portfolio-order.json` has it at priority 4 with `featured: true`, and that file overrides `PORTFOLIO.md` (`generate-projects.ts:545`). No change was needed — it renders in the Featured filter today.

Spanish is Mexican Professional Spanish (`reseñas`, `gestión de reputación`, `monitoreo`, tú form); Iberian-marker audit clean. Build passes: 118 pages, meta-description gate 116/116, metaTitle within 30-60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)