### PR TITLE
feat(portfolio): publish CushLabs Connect

### DIFF
--- a/src/data/projectCardsEs.ts
+++ b/src/data/projectCardsEs.ts
@@ -48,6 +48,11 @@ export const esCardCopy: Record<string, EsCardCopy> = {
     tagline:
       "Agentes telefónicos con IA que contestan llamadas, califican prospectos y agendan citas — 24/7, con respuesta en menos de 500 ms",
   },
+  "cushlabs-connect": {
+    title: "CushLabs Connect — Plataforma WhatsApp Multi-Tenant",
+    tagline:
+      "Plataforma de WhatsApp como Meta Tech Provider — un negocio conecta su propia cuenta en minutos y envía recordatorios de citas que sus clientes sí leen",
+  },
   // Updated 2026-08-07 to surface Google reputation management, a core CushLabs
   // service that was described in the body of the entry but absent from the card.
   "cushlabs-marketsignal": {

--- a/src/data/projects.generated.json
+++ b/src/data/projects.generated.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-08-08T04:35:41.417Z",
-  "count": 35,
+  "generatedAt": "2026-08-08T05:36:01.159Z",
+  "count": 36,
   "projects": [
     {
       "id": 1108213747,
@@ -324,7 +324,7 @@
       },
       "stars": 0,
       "forks": 1,
-      "lastPushed": "2026-08-08T04:24:05Z",
+      "lastPushed": "2026-08-08T05:32:10Z",
       "createdAt": "2026-02-23T01:31:09Z",
       "isFeatured": true,
       "isArchived": false,
@@ -474,15 +474,15 @@
       "status": "Production",
       "language": "TypeScript",
       "languages": {
-        "TypeScript": 758561,
-        "JavaScript": 218328,
+        "TypeScript": 790749,
+        "JavaScript": 222718,
         "PowerShell": 7945,
-        "HTML": 733,
-        "CSS": 323
+        "CSS": 4047,
+        "HTML": 1562
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-08-07T21:40:17Z",
+      "lastPushed": "2026-08-08T05:30:12Z",
       "createdAt": "2026-04-06T23:20:56Z",
       "isFeatured": true,
       "isArchived": false,
@@ -634,7 +634,7 @@
       },
       "stars": 0,
       "forks": 0,
-      "lastPushed": "2026-08-08T04:35:12Z",
+      "lastPushed": "2026-08-08T04:41:58Z",
       "createdAt": "2026-03-30T19:46:00Z",
       "isFeatured": true,
       "isArchived": false,
@@ -858,6 +858,103 @@
       ],
       "videoUrl": "https://cdn.cushlabs.ai/ny-eng/video/ny-eng-brief.mp4",
       "videoPoster": "https://cdn.cushlabs.ai/ny-eng/video/ny-eng-brief-poster.jpg"
+    },
+    {
+      "id": 1268645928,
+      "name": "cushlabs-connect",
+      "title": "CushLabs Connect — Multi-Tenant WhatsApp Platform",
+      "description": "Multi-tenant WhatsApp reminders & confirmations platform — CushLabs as a Meta Tech Provider; businesses connect their own WhatsApp via Embedded Signup. v2 of cushlabs-whatsapp.",
+      "summary": "A multi-tenant WhatsApp messaging platform. CushLabs operates as a Meta **Tech",
+      "url": "https://github.com/RCushmaniii/cushlabs-connect",
+      "demoUrl": null,
+      "liveUrl": "https://connect.cushlabs.ai/",
+      "homepage": null,
+      "topics": [
+        "cloudflare-workers",
+        "d1",
+        "embedded-signup",
+        "hono",
+        "multi-tenant",
+        "react",
+        "saas",
+        "tailwindcss",
+        "typescript",
+        "whatsapp",
+        "whatsapp-cloud-api"
+      ],
+      "categories": [
+        "AI Automation"
+      ],
+      "tags": [
+        "cloudflare-workers",
+        "d1",
+        "embedded-signup",
+        "hono",
+        "multi-tenant",
+        "react",
+        "saas",
+        "tailwindcss",
+        "typescript",
+        "whatsapp",
+        "whatsapp-cloud-api",
+        "meta-tech-provider"
+      ],
+      "stack": [
+        "Cloudflare Workers",
+        "Hono",
+        "TypeScript (strict)",
+        "Cloudflare D1",
+        "Cloudflare Cron Triggers",
+        "WhatsApp Cloud API",
+        "Meta Embedded Signup",
+        "React + Vite + Tailwind (admin console)",
+        "Clerk (admin auth)",
+        "Cloudflare Pages"
+      ],
+      "status": "Production",
+      "language": "TypeScript",
+      "languages": {
+        "TypeScript": 294554,
+        "HTML": 124023,
+        "JavaScript": 4795,
+        "CSS": 439
+      },
+      "stars": 0,
+      "forks": 0,
+      "lastPushed": "2026-08-08T05:35:31Z",
+      "createdAt": "2026-06-13T19:20:38Z",
+      "isFeatured": true,
+      "isArchived": false,
+      "isPrivate": true,
+      "tagline": "A Meta Tech Provider platform that lets a business connect its own WhatsApp account in minutes and send appointment reminders patients actually read.",
+      "thumbnail": "https://cdn.cushlabs.ai/cushlabs-connect/images/portfolio/card-connect.webp",
+      "problem": "An appointment-driven business loses real money every time someone does not show up. WhatsApp is\nwhere Mexican customers actually read messages, but sending on it legitimately is genuinely hard:\nbusiness verification, a WhatsApp Business Account, message templates approved one at a time,\nMeta App Review, and ongoing compliance rules that change. Most small businesses cannot clear\nthose gates, and most developers do not want to. The alternative — a per-client build — means a\nseparate deployment, a separate review cycle, and a separate thing to maintain for every business\nserved, which stops working economically almost immediately.\n",
+      "solution": "CushLabs operates as a Meta Tech Provider so client businesses never touch the WhatsApp API. A business connects its own WhatsApp Business Account through Embedded Signup — a Facebook-hosted flow that takes minutes and leaves the business owning its own account and its own customer relationships. From there a single Cloudflare Worker sends that tenant's reminders and confirmations on their behalf, with per-tenant isolation in D1 and a scheduled job driving the send window. One approved Meta app serves every tenant, so onboarding a business is configuration rather than a new deployment and a new review cycle.\n",
+      "keyFeatures": [
+        "Meta App Review approved on the first submission — both WhatsApp permissions hold Advanced Access",
+        "Proven end to end: an approved template sent from a real WhatsApp Business Account to a real phone",
+        "Businesses connect their own WhatsApp account through Embedded Signup and keep ownership of it",
+        "One approved Meta app serves every tenant — onboarding is configuration, not a new deploy or a new review",
+        "Reminders and confirmations run unattended on a schedule, so follow-up never depends on anyone remembering",
+        "Built from a system already live in production, so the multi-tenant rewrite started from proven behavior"
+      ],
+      "metrics": [
+        "Meta App Review cleared in 16 days, approved on the first submission",
+        "Both WhatsApp permissions confirmed at Advanced Access on the Graph API, not just the dashboard",
+        "163 automated tests across 7 files",
+        "One Worker and one approved Meta app serve every tenant — zero per-client deployments"
+      ],
+      "priority": 6,
+      "dateCompleted": null,
+      "slides": [
+        {
+          "src": "https://cdn.cushlabs.ai/cushlabs-connect/images/portfolio/card-connect.webp",
+          "altEn": "CushLabs Connect — Multi-Tenant WhatsApp Platform",
+          "altEs": "CushLabs Connect — Multi-Tenant WhatsApp Platform"
+        }
+      ],
+      "videoUrl": null,
+      "videoPoster": null
     },
     {
       "id": 1174690198,
@@ -3288,8 +3385,8 @@
       "status": null,
       "language": "Astro",
       "languages": {
-        "Astro": 851223,
-        "TypeScript": 382320,
+        "Astro": 851942,
+        "TypeScript": 382581,
         "JavaScript": 154925,
         "HTML": 61067,
         "Python": 6606,
@@ -3297,7 +3394,7 @@
       },
       "stars": 3,
       "forks": 0,
-      "lastPushed": "2026-08-07T02:36:01Z",
+      "lastPushed": "2026-08-08T05:34:45Z",
       "createdAt": "2026-01-08T03:52:43Z",
       "isFeatured": false,
       "isArchived": false,

--- a/src/pages/es/projects/[slug].astro
+++ b/src/pages/es/projects/[slug].astro
@@ -31,6 +31,7 @@ const metaTitles: Record<string, string> = {
   'biojalisco-pitch': ES_TITLE_BIOJALISCO_PITCH,
   'expat-driver-license-prep': 'ExpatDrive — Examen de Licencia Bilingüe',
   'cushlabs-marketsignal': 'MarketSignal — Reputación en Google e Inteligencia Local',
+  'cushlabs-connect': 'CushLabs Connect — Plataforma WhatsApp Multi-Tenant',
 };
 
 // For projects without a Spanish title override, use interpunct separator (·) instead of
@@ -55,6 +56,7 @@ const metaDescriptions: Record<string, string> = {
   // Added 2026-08-07 — surfaces Google reputation management, absent from every
   // card-level surface until now.
   'cushlabs-marketsignal': 'Gestión de reputación en Google y monitoreo de competidores para negocios multi-sucursal en México — respuestas a reseñas con IA y una acción semanal.',
+  'cushlabs-connect': 'Plataforma de WhatsApp multi-tenant como Meta Tech Provider — cada negocio conecta su propia cuenta y envía recordatorios de citas que sus clientes leen.',
 };
 
 // For ES pages falling back to English GitHub descriptions, prefix with the project

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -50,6 +50,7 @@ const metaDescriptions: Record<string, string> = {
   // truncated mid-sentence at "one actionable..." and never named reputation
   // management — a core service, not a footnote.
   'cushlabs-marketsignal': 'Google reputation management and Maps competitor tracking for multi-location businesses in Mexico — AI-drafted review replies and a weekly action item.',
+  'cushlabs-connect': 'Multi-tenant WhatsApp platform built as a Meta Tech Provider — businesses connect their own account via Embedded Signup and send appointment reminders.',
 };
 
 const rawDescription = (


### PR DESCRIPTION
Companion to https://github.com/RCushmaniii/cushlabs-connect/pull/38

Adds CushLabs Connect to the portfolio — 35 → 36 projects, featured at priority 6.

Includes the ES card copy and EN/ES meta titles and descriptions up front, so the Spanish page never falls back to English the way MarketSignal's and the Messenger slugs' did. Same silent-fallback class of bug, pre-empted rather than fixed later.

Build passes: 118 pages, meta-description gate 118/118 in the 120-160 range, metaTitles within 30-60. Spanish is Mexican Professional Spanish; Iberian-marker audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)