### PR TITLE
fix(portfolio): stop sending visitors to GitHub 404s on private repos

### DIFF
--- a/src/i18n/translations/en.ts
+++ b/src/i18n/translations/en.ts
@@ -137,6 +137,9 @@ export const en = {
     links: "Links",
     liveDemo: "Live demo",
     sourceCode: "Source code",
+    // Shown instead of "Source code" when the repo is private, so visitors are
+    // never sent to a GitHub 404. See the codeUrl logic in projects/[slug].astro.
+    visitSite: "Visit the site",
     lastUpdated: "Last updated",
     stars: "Stars",
     forks: "Forks",

--- a/src/i18n/translations/es.ts
+++ b/src/i18n/translations/es.ts
@@ -135,6 +135,9 @@ export const es = {
     links: "Enlaces",
     liveDemo: "Demo en vivo",
     sourceCode: "Código fuente",
+    // Se muestra en lugar de "Código fuente" cuando el repo es privado, para que
+    // nadie termine en un 404 de GitHub.
+    visitSite: "Visitar el sitio",
     lastUpdated: "Actualizado",
     stars: "Estrellas",
     forks: "Forks",

--- a/src/pages/es/projects/[slug].astro
+++ b/src/pages/es/projects/[slug].astro
@@ -81,7 +81,16 @@ const overrideDemoUrl =
     : override?.demoUrl?.[locale];
 const demoUrl =
   overrideDemoUrl || project.demoUrl || project.homepage || null;
-const codeUrl = project.url;
+
+// Ver la nota completa en la versión EN de esta página. Resumen: el repo privado
+// da 404 a cualquier visitante, así que nunca se enlaza GitHub cuando es privado;
+// se ofrece el sitio público, y si no hay ninguno no se muestra segundo botón.
+const isPrivateRepo = project.isPrivate === true;
+const codeUrl = isPrivateRepo ? null : project.url;
+const publicSiteUrl =
+  isPrivateRepo && project.liveUrl && project.liveUrl !== demoUrl
+    ? project.liveUrl
+    : null;
 
 const githubMatch = project.url.match(/github\.com\/([^/]+)\/([^/]+)(?:\/|$)/i);
 const ogImageUrl = githubMatch
@@ -212,15 +221,32 @@ const relatedProjects = scored.slice(0, 3).map(s => s.project);
                 </a>
               )
             }
-            <a
-              href={codeUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="inline-flex items-center justify-center gap-2 rounded-lg border border-border bg-canvas/40 px-5 py-3 text-sm font-display font-semibold text-foreground hover:opacity-90 transition-opacity"
-            >
-              {dict.project.sourceCode}
-              <span aria-hidden="true">&nearr;</span>
-            </a>
+            {
+              codeUrl && (
+                <a
+                  href={codeUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center justify-center gap-2 rounded-lg border border-border bg-canvas/40 px-5 py-3 text-sm font-display font-semibold text-foreground hover:opacity-90 transition-opacity"
+                >
+                  {dict.project.sourceCode}
+                  <span aria-hidden="true">&nearr;</span>
+                </a>
+              )
+            }
+            {
+              publicSiteUrl && (
+                <a
+                  href={publicSiteUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center justify-center gap-2 rounded-lg border border-border bg-canvas/40 px-5 py-3 text-sm font-display font-semibold text-foreground hover:opacity-90 transition-opacity"
+                >
+                  {dict.project.visitSite}
+                  <span aria-hidden="true">&nearr;</span>
+                </a>
+              )
+            }
           </div>
 
           <dl class="mt-6 space-y-3 text-sm">

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -72,7 +72,22 @@ const overrideDemoUrl =
     : override?.demoUrl?.[locale];
 const demoUrl =
   overrideDemoUrl || project.demoUrl || project.homepage || null;
-const codeUrl = project.url;
+
+// A private repo's GitHub URL is a 404 for every visitor — they are not signed
+// in as Robert. Ten of the published projects are private on purpose, so the
+// "Source code" button was sending real prospects to a dead page.
+//
+// Public repo  -> link the source, as before.
+// Private repo -> never link GitHub. Offer the public site instead, unless that
+//                 same URL is already rendered above as the Live demo button.
+// Private repo with nothing public -> render no second button at all. A missing
+//                 button is honest; a broken one is not.
+const isPrivateRepo = project.isPrivate === true;
+const codeUrl = isPrivateRepo ? null : project.url;
+const publicSiteUrl =
+  isPrivateRepo && project.liveUrl && project.liveUrl !== demoUrl
+    ? project.liveUrl
+    : null;
 
 const githubMatch = project.url.match(/github\.com\/([^/]+)\/([^/]+)(?:\/|$)/i);
 const ogImageUrl = githubMatch
@@ -201,15 +216,32 @@ const relatedProjects = scored.slice(0, 3).map(s => s.project);
                 </a>
               )
             }
-            <a
-              href={codeUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="inline-flex items-center justify-center gap-2 rounded-lg border border-border bg-canvas/40 px-5 py-3 text-sm font-display font-semibold text-foreground hover:opacity-90 transition-opacity"
-            >
-              {dict.project.sourceCode}
-              <span aria-hidden="true">↗</span>
-            </a>
+            {
+              codeUrl && (
+                <a
+                  href={codeUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center justify-center gap-2 rounded-lg border border-border bg-canvas/40 px-5 py-3 text-sm font-display font-semibold text-foreground hover:opacity-90 transition-opacity"
+                >
+                  {dict.project.sourceCode}
+                  <span aria-hidden="true">↗</span>
+                </a>
+              )
+            }
+            {
+              publicSiteUrl && (
+                <a
+                  href={publicSiteUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center justify-center gap-2 rounded-lg border border-border bg-canvas/40 px-5 py-3 text-sm font-display font-semibold text-foreground hover:opacity-90 transition-opacity"
+                >
+                  {dict.project.visitSite}
+                  <span aria-hidden="true">↗</span>
+                </a>
+              )
+            }
           </div>
 
           <dl class="mt-6 space-y-3 text-sm">


### PR DESCRIPTION
Ten of the 36 published projects are private repos. Every one of their project pages rendered a **Source code** button pointing at github.com — a 404 for anyone not signed in as Robert. That is every prospect and every hiring manager who ever clicked it.

The generated data already carried `isPrivate`; the template just never read it.

## New behaviour, both locales

| Case | Result |
|---|---|
| Public repo | `Source code` → GitHub, unchanged |
| Private repo | GitHub never linked. Public site offered as **Visit the site** / **Visitar el sitio** — unless that same URL already renders above as **Live demo**, in which case one button is enough |
| Private repo, nothing public | No second button. A missing button is honest; a broken one is not |

## Result per private project

All destinations checked live — every one returns 200.

| Project | Now shows |
|---|---|
| ny-ai-chatbot | Live demo + Visit the site |
| cushlabs-messenger-bot | Live demo (`m.me/cushlabs`) |
| cushlabs-marketsignal | Live demo (`marketsignal.cushlabs.ai`) |
| cushlabs-connect | Visit the site (`connect.cushlabs.ai`) |
| cushlabs-investment-model | Live demo + Visit the site |
| cushlabs-OS-dashboard | Live demo (`dashboard.cushlabs.ai`) |
| cushlabs-sticker-gen | Live demo (`stickers.cushlabs.ai`) |
| ai-scrabble-practice | Live demo (`scrabble-mini.netlify.app`) |
| cushlabs-image-portfolio | Live demo + Visit the site |
| **cushlabs-ai-marketing** | **No button — see below** |

## The one that can't be reconciled

`cushlabs-ai-marketing` is a Claude Code slash-command suite that runs in a terminal. It has no website and cannot have one, so there is no public destination. Its page now shows no second button rather than a dead link. It's MIT licensed, so making the repo public is the only route to a working Source code link — that's a call to make, not a code change.

## Verification

Audited the **built output**, not assumed: 0 of 10 private project pages still link GitHub; public repos untouched. Typecheck clean, build passes, 118 pages, gate 118/118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)