### PR TITLE
fix(whatsapp): frame the hero photo correctly on tablets and phones

### DIFF
--- a/src/pages/es/whatsapp.astro
+++ b/src/pages/es/whatsapp.astro
@@ -74,7 +74,7 @@ const trust = [
        recordatorio de WhatsApp en español con botones CONFIRMAR / REAGENDAR.
        Mercado, producto, idioma e interacción en un solo cuadro. No la
        cambies por un degradado abstracto. -->
-  <section class="wa-hero relative flex items-center min-h-[100svh] text-slate-50">
+  <section class="wa-hero relative flex items-center text-slate-50">
     <Container size="md">
       <div class="max-w-3xl mx-auto text-center py-24 flex flex-col items-center">
         <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-white/10 border border-white/20 text-white text-sm font-semibold mb-8 backdrop-blur-sm">
@@ -229,6 +229,7 @@ const trust = [
      mismo degradado oscuro y mismo punto focal 55% 30%, que es el que deja
      legible la pantalla del celular detrás del titular. */
   .wa-hero {
+    min-height: 100svh;
     background-color: #1a120e;
     background-image:
       linear-gradient(
@@ -241,6 +242,18 @@ const trust = [
     background-size: cover;
     background-position: 55% 30%;
     background-repeat: no-repeat;
+  }
+
+  /* The photo is 16:9. `cover` scales to fill whichever axis is short, so on a
+     viewport taller than it is wide it zooms hard and throws the phone off the
+     left edge — the phone is the proof, so losing it defeats the hero. The real
+     variable is aspect ratio, not width, so gate on that: demand less vertical
+     fill and bias the crop back toward the phone. */
+  @media (max-aspect-ratio: 1 / 1) {
+    .wa-hero {
+      min-height: 78svh;
+      background-position: 40% 30%;
+    }
   }
 
   /* Escala tipográfica copiada de la página original. La escala de hero por
@@ -265,9 +278,12 @@ const trust = [
     text-shadow: 0 1px 14px rgba(0, 0, 0, 0.5);
   }
 
+  /* Phones crop hardest and the text column sits directly over the image, so
+     hold the phone in frame and deepen the overlay for legibility. */
   @media (max-width: 640px) {
     .wa-hero {
-      background-position: 38% 32%;
+      min-height: 84svh;
+      background-position: 36% 32%;
       background-image:
         linear-gradient(
           to bottom,

--- a/src/pages/whatsapp.astro
+++ b/src/pages/whatsapp.astro
@@ -73,7 +73,7 @@ const trust = [
        Market, product, language and interaction in one frame. Do not swap it
        for an abstract gradient. Overlay values and focal point (55% 30%) are
        the originals, tuned so the phone screen stays legible. -->
-  <section class="wa-hero relative flex items-center min-h-[100svh] text-slate-50">
+  <section class="wa-hero relative flex items-center text-slate-50">
     <Container size="md">
       <div class="max-w-3xl mx-auto text-center py-24 flex flex-col items-center">
         <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-white/10 border border-white/20 text-white text-sm font-semibold mb-8 backdrop-blur-sm">
@@ -236,6 +236,7 @@ const trust = [
      A new filename is the only reliable fix for an immutable asset: change the
      name whenever you replace or re-add an image under /images/. */
   .wa-hero {
+    min-height: 100svh;
     background-color: #1a120e;
     background-image:
       linear-gradient(
@@ -248,6 +249,18 @@ const trust = [
     background-size: cover;
     background-position: 55% 30%;
     background-repeat: no-repeat;
+  }
+
+  /* The photo is 16:9. `cover` scales to fill whichever axis is short, so on a
+     viewport taller than it is wide it zooms hard and throws the phone off the
+     left edge — the phone is the proof, so losing it defeats the hero. The real
+     variable is aspect ratio, not width, so gate on that: demand less vertical
+     fill and bias the crop back toward the phone. */
+  @media (max-aspect-ratio: 1 / 1) {
+    .wa-hero {
+      min-height: 78svh;
+      background-position: 40% 30%;
+    }
   }
 
   /* Type scale copied from the original page. The site's default hero scale is
@@ -275,9 +288,12 @@ const trust = [
   /* On narrow screens the frame crops toward the subject, so bias the focal
      point right to keep the woman and the phone in shot, and deepen the
      overlay because the text column now sits directly over the image. */
+  /* Phones crop hardest and the text column sits directly over the image, so
+     hold the phone in frame and deepen the overlay for legibility. */
   @media (max-width: 640px) {
     .wa-hero {
-      background-position: 38% 32%;
+      min-height: 84svh;
+      background-position: 36% 32%;
       background-image:
         linear-gradient(
           to bottom,


### PR DESCRIPTION
The hero looked right on desktop and broke on anything taller than it is wide.

At 820×1180 the photograph zoomed hard and **sliced the phone in half** against the left edge — and the phone showing a real WhatsApp reminder with CONFIRMAR / REAGENDAR is the only proof on the page.

## Cause

Aspect ratio, not width. The photo is 16:9 and `cover` scales to fill whichever axis is short, so a portrait viewport demands a huge horizontal crop. A width breakpoint was the wrong instrument — a 1024-wide tablet in **landscape** was fine while an 820-wide tablet in **portrait** was not.

Gated on aspect ratio instead: below 1:1 the hero asks for less vertical fill (`78svh`) and biases the crop toward the phone (`40%`). Phones keep a tighter tier at `84svh` / `36%` with the deeper overlay, since the text column sits directly over the image there.

`min-height` moved out of the Tailwind class into the stylesheet so the media queries can override it without a specificity fight.

## Verified by screenshot, not by reasoning

1920×1080 · 1440×900 · 1280×800 · 1024×768 · 820×1180 · 768×1024 · 430×932 · 390×844 · 360×780

The phone and its message are legible at every one.

## Noted, not fixed here

The site header **overlaps its own logo with the "About" link** at roughly 760–900px wide. Pre-existing and site-wide — it reproduces on the homepage — so it doesn't belong in this change.

Build passes: 120 pages, gate 120/120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)