### PR TITLE
copy(messenger): make the hero badge state capability instead of arguing

### DIFF
--- a/src/pages/es/messenger-assistant.astro
+++ b/src/pages/es/messenger-assistant.astro
@@ -141,9 +141,18 @@ const themes = [
   <section class="ma-hero relative flex items-center text-slate-50">
     <Container size="md">
       <div class="max-w-3xl mx-auto text-center py-24 flex flex-col items-center">
+        <!-- Badge, not an eyebrow: a capability statement, deliberately NOT a
+             proof-claim. The previous copy read "Already live with a real client
+             — in production now", which stacked three reassurances into one line
+             and argued for something the page demonstrates 200px lower, where the
+             live-bot chips let a visitor message a production assistant on the
+             spot. Demonstrating beats asserting. Both facts here are
+             ADVERTISED-COMMITMENTS List 1 (Theme 1 "under 5 seconds, 24/7",
+             Theme 2 "English & Spanish automatically"). Keep it to shipped
+             capability; do not turn it back into a status boast. -->
         <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-white/10 border border-white/20 text-white text-sm font-semibold mb-8 backdrop-blur-sm">
           <span class="w-2 h-2 rounded-full bg-green-400 animate-pulse"></span>
-          Ya está activo con un cliente real — en producción ahora mismo
+          Bilingüe EN/ES · Responde en menos de 5 segundos
         </div>
 
         <h1 class="ma-h1 font-display font-bold text-white">

--- a/src/pages/messenger-assistant.astro
+++ b/src/pages/messenger-assistant.astro
@@ -145,9 +145,18 @@ const themes = [
   <section class="ma-hero relative flex items-center text-slate-50">
     <Container size="md">
       <div class="max-w-3xl mx-auto text-center py-24 flex flex-col items-center">
+        <!-- Badge, not an eyebrow: a capability statement, deliberately NOT a
+             proof-claim. The previous copy read "Already live with a real client
+             — in production now", which stacked three reassurances into one line
+             and argued for something the page demonstrates 200px lower, where the
+             live-bot chips let a visitor message a production assistant on the
+             spot. Demonstrating beats asserting. Both facts here are
+             ADVERTISED-COMMITMENTS List 1 (Theme 1 "under 5 seconds, 24/7",
+             Theme 2 "English & Spanish automatically"). Keep it to shipped
+             capability; do not turn it back into a status boast. -->
         <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-white/10 border border-white/20 text-white text-sm font-semibold mb-8 backdrop-blur-sm">
           <span class="w-2 h-2 rounded-full bg-green-400 animate-pulse"></span>
-          Already live with a real client — in production now
+          Bilingual EN/ES · Replies in under 5 seconds
         </div>
 
         <h1 class="ma-h1 font-display font-bold text-white">


### PR DESCRIPTION
The badge read **"Already live with a real client — in production now"**. Robert called it defensive, and he was right — three reassurances stacked into one line is what you write when you expect to be doubted.

The deeper problem was **redundancy**. Two hundred pixels below it, the page offers two chips that let a visitor message a live production assistant on the spot. That's proof. The badge was arguing for something the page can simply demonstrate, and arguing always reads weaker than demonstrating.

| | |
|---|---|
| EN | `Bilingual EN/ES · Replies in under 5 seconds` |
| ES | `Bilingüe EN/ES · Responde en menos de 5 segundos` |

Both are **ADVERTISED-COMMITMENTS List 1** — Theme 1 "under 5 seconds, 24/7" and Theme 2 "English & Spanish automatically". So this trades an unfalsifiable status boast for two claims the product actually has to satisfy.

A comment above the badge in both files records the reasoning (including the badge-vs-eyebrow distinction) so it doesn't drift back into a proof-claim.

Build passes: 120 pages, gate 120/120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)