### PR TITLE
docs(session-log): record the rebrand ripple, drop the out-of-repo items

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -184,9 +184,19 @@ Documented in CLAUDE.md and memory `feedback_tailwind4_color_collision`. Custom 
 
 ### Immediate Next Steps
 
-- [ ] Clerk login UX + enable Google auth.
-- [ ] Cut the onboarding survey ~75%; seed voice/facts by scraping the client's own Facebook replies,
-      then tweak with the client. First paying client would not complete the long form.
+- [ ] **The rebrand is not finished outside this repo.** A palette fingerprint across `~/Projects`
+      found the retired 3D mark still shipping in: `cushlabs-messenger-bot/fb-content/cushlabs-app-icon-1024.png`
+      (the Meta app icon **every client sees in the Facebook consent dialog** — highest stakes),
+      `cushlabs-ai-voice-agent/public/` (favicons + `images/voice_agent_logo.webp`, live on
+      voice.cushlabs.ai), `cushlabs-OS-dashboard/public/images/logo-{light,dark}.png`, and
+      `react-vite-tailwind-base/public/` (the starter — every new project inherits the old mark).
+- [ ] Merge PR #243 (rebased onto v3, safe now) and triage PR #204, open since 2026-07-26.
+- [ ] External surfaces still on the old mark and not fixable from a repo: WhatsApp Business profile,
+      LinkedIn (company + personal), Facebook page, Google Business Profile, GitHub org avatar, IG.
+      `cushlabs-logo-instagram-profile-v2.png` is ready to upload for the last one.
+
+> Clerk login UX and the onboarding-survey rewrite were raised this session but belong to other
+> repos, not this one. Not tracked here.
 
 ### Technical Debt
 


### PR DESCRIPTION
docs(session-log): record the rebrand ripple, drop the out-of-repo items

Two corrections to the 2026-08-10 entry.

The next-steps list carried Clerk login UX and the survey rewrite. Both
were raised in conversation but belong to other repos, so a future
session reading this file would go looking for code that is not here.
Removed, with a line saying where they are not.

Replaced with the thing this session actually found and never wrote
down: a palette fingerprint across ~/Projects showing the retired 3D
mark still shipping in four places. The Meta app icon in
cushlabs-messenger-bot is the highest-stakes one - it is what every
client sees in the Facebook consent dialog when they connect a Page.
voice.cushlabs.ai and the OS dashboard are live surfaces. The
react-vite-tailwind-base starter matters because every new project
scaffolded from it inherits the old mark, so it keeps propagating until
fixed.

Also lists the external surfaces that no repo change can reach -
WhatsApp Business, LinkedIn, the Facebook page, GBP, GitHub org avatar,
Instagram - and notes the regenerated IG avatar is ready to upload.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
