### PR TITLE
fix(website-chatbot): drop the Facebook dig from the hero badge

### DIFF
--- a/src/pages/es/website-chatbot.astro
+++ b/src/pages/es/website-chatbot.astro
@@ -57,7 +57,7 @@ const comparison = [
       <div class="text-center max-w-4xl mx-auto">
         <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-cush-orange/10 border border-cush-orange/20 text-cush-orange text-sm font-semibold mb-8">
           <span class="w-2 h-2 rounded-full bg-green-500 animate-pulse"></span>
-          Un widget de chat para tu sitio web — no otra página de Facebook
+          En tu sitio web, 24/7 · Bilingüe EN/ES
         </div>
 
         <h1 class="font-display text-fluid-4xl font-bold text-gray-900 dark:text-white mb-6 leading-tight tracking-tight">

--- a/src/pages/website-chatbot.astro
+++ b/src/pages/website-chatbot.astro
@@ -57,7 +57,7 @@ const comparison = [
       <div class="text-center max-w-4xl mx-auto">
         <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-cush-orange/10 border border-cush-orange/20 text-cush-orange text-sm font-semibold mb-8">
           <span class="w-2 h-2 rounded-full bg-green-500 animate-pulse"></span>
-          A chat widget for your website — not another Facebook page
+          On your website, 24/7 · Bilingual EN/ES
         </div>
 
         <h1 class="font-display text-fluid-4xl font-bold text-gray-900 dark:text-white mb-6 leading-tight tracking-tight">


### PR DESCRIPTION
## Summary
- Badge on `/website-chatbot/` said "not another Facebook page" — read as an unintended jab at Facebook and didn't communicate what the product actually does
- Replaced with "On your website, 24/7 · Bilingual EN/ES" (EN) / "En tu sitio web, 24/7 · Bilingüe EN/ES" (ES) — same spec+benefit structure as the other three hero badges, no comparison

## Test plan
- [x] `npx astro check` — 0 errors
- [x] `npm run build` — 126 pages built clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)