### PR TITLE
fix(header): stop the logo colliding with the nav on tablets

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,4 +1,16 @@
 ---
+// Nav breakpoint is `lg` (1024px), NOT `md` (768px). Do not lower it.
+//
+// The desktop nav is the brand lockup + seven links + theme toggle + language
+// switcher. Measured on 2026-08-09, that set does not fit beside the logo until
+// roughly 880px: at 768px and 800px the gap between the end of the brand and the
+// first nav link is 0px and the logo text visually collides with "About",
+// rendering as "CUSHLABSAbout" on every page of the site including the homepage.
+// 840px still only clears by 8px.
+//
+// So 768-1023px now gets the hamburger, which is the correct control for a
+// tablet anyway. If links are ever added to the nav, re-measure — the fit point
+// moves right with every item.
 import type { Locale } from "../i18n";
 import { getLocalizedPath, t } from "../i18n";
 
@@ -60,7 +72,7 @@ const isActiveLink = (href: string) => pathname === href || pathname === href.re
       <span><span class="text-gray-900 dark:text-white">CUSH</span><span class="text-cush-orange">LABS.AI</span></span>
     </a>
 
-    <nav class="hidden items-center gap-6 md:flex">
+    <nav class="hidden items-center gap-6 lg:flex">
       {navLinks.map(({ href, label }) => (
         <a
           href={href}
@@ -127,7 +139,7 @@ const isActiveLink = (href: string) => pathname === href || pathname === href.re
 
       <button
         type="button"
-        class="md:hidden rounded-lg border border-border bg-surface p-2 text-foreground hover:opacity-80 transition-all duration-300 hover:border-cush-orange/50"
+        class="lg:hidden rounded-lg border border-border bg-surface p-2 text-foreground hover:opacity-80 transition-all duration-300 hover:border-cush-orange/50"
         data-mobile-menu-toggle
         aria-label={locale === "es" ? "Abrir menú" : "Open menu"}
         aria-expanded="false"
@@ -148,7 +160,7 @@ const isActiveLink = (href: string) => pathname === href || pathname === href.re
 
   <div
     id="mobile-menu"
-    class="md:hidden hidden border-t border-border bg-white dark:bg-cush-gray-900"
+    class="lg:hidden hidden border-t border-border bg-white dark:bg-cush-gray-900"
   >
     <nav class="mx-auto max-w-7xl flex flex-col px-4 py-2">
       {navLinks.map(({ href, label }) => (


### PR DESCRIPTION
On **every page** of the site, including the homepage, the brand lockup ran into the first nav link between ~768px and ~870px — rendering as `CUSHLABSAbout`. Found while screenshotting the Messenger hero at tablet sizes.

The desktop nav switched on at `md` (768px), but the full set — brand lockup, seven links, theme toggle, language switcher — doesn't fit beside the logo until about 880px.

## Measured, not guessed

Read the bounding boxes of the brand and the first nav link across the range:

| Width | Gap | |
|---|---|---|
| 768px | 0px | collide |
| 800px | 0px | collide |
| 840px | 8px | tight |
| 880px | 28px | ok |
| 1024px | 100px | ok |

Raised the breakpoint to `lg` (1024px), so 768–1023px gets the hamburger — the right control for a tablet anyway. The desktop nav above 1024px is untouched, where it was already comfortable.

## Verified

Opened the menu at 768, 820, 900 and 1000px — all seven links render and are reachable at each. Re-measured the gap: now 100px at the first width where the desktop nav appears.

A comment at the top of `Header.astro` records the measurements and the reasoning, including the instruction to **re-measure if links are ever added** — the fit point moves right with every item.

Build passes: 124 pages, gate 124/124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)