### PR TITLE
fix(copy): two live pages disagreed about whether review replies are included

### DIFF
--- a/src/pages/competitive-intelligence.astro
+++ b/src/pages/competitive-intelligence.astro
@@ -11,6 +11,7 @@ const included = [
   { title: "Google Business Profile audit", desc: "Weekly scoring of your GBP against competitors — photos, hours, description, categories, reviews" },
   { title: "One priority action per week", desc: "The single highest-leverage thing you can do this week — specific, not generic. Delivered to WhatsApp every Monday" },
   { title: "Review intelligence", desc: "What customers are saying, what themes are emerging, how your response rate compares to competitors" },
+  { title: "Google review management", desc: "Unanswered reviews are caught and a reply is drafted in your voice — you approve it and it posts to Google automatically" },
   { title: "Alert detection", desc: "Immediate notification when a competitor makes a significant move or your position drops sharply" },
   { title: "Bilingual reports (EN/ES)", desc: "Delivered in the language you prefer — English or Spanish" },
 ];
@@ -18,7 +19,6 @@ const included = [
 const notIncluded = [
   "Social media monitoring (Google Maps and Google Business Profile only)",
   "Paid ad campaign management or Google Ads optimization",
-  "Responding to reviews on your behalf (available as a separate add-on)",
 ];
 
 const bestFor = [
@@ -48,9 +48,15 @@ const comparison = [
        Profile review UI) span nearly the full frame, same composition challenge as the
        homepage hero — middle band is the darkest overlay stop, not the lightest, so the
        headline has solid backing wherever it lands. The screen shows a DRAFTED reply
-       waiting for her click, not an auto-sent one — keep copy scoped to "review
-       intelligence" (what's included), never to automated reply-sending (that's the
-       explicit notIncluded line below; it's a separate add-on). -->
+       waiting for her click, which is exactly right — the reply is drafted for the
+       owner and posts on her approval.
+
+       SCOPE CORRECTED 2026-08-09. This page used to exclude review replies as "a
+       separate add-on" while /pricing/ sold "Google review management — approve a
+       reply and it posts to Google automatically" as an included plan feature. Two
+       live pages contradicting each other on what the customer is buying. Robert
+       settled it: review management is IN the plan. Do not reintroduce it as an
+       add-on here without changing the pricing page in the same edit. -->
   <section class="ci-hero relative flex items-center text-slate-50">
     <Container size="md">
       <div class="max-w-3xl mx-auto text-center py-24 flex flex-col items-center">

--- a/src/pages/es/competitive-intelligence.astro
+++ b/src/pages/es/competitive-intelligence.astro
@@ -11,6 +11,7 @@ const included = [
   { title: "Auditoría del Perfil de Negocio en Google", desc: "Puntuación semanal de tu perfil comparado con competidores — fotos, horarios, descripción, categorías, reseñas" },
   { title: "Una acción prioritaria por semana", desc: "La acción de mayor impacto que puedes tomar esta semana — específica, no genérica. Enviada por WhatsApp cada lunes" },
   { title: "Inteligencia de reseñas", desc: "Qué dicen tus clientes, qué temas emergen y cómo tu tasa de respuesta se compara con la competencia" },
+  { title: "Gestión de reseñas de Google", desc: "Detectamos las reseñas sin contestar y redactamos la respuesta con tu tono — tú la apruebas y se publica en Google automáticamente" },
   { title: "Detección de alertas", desc: "Notificación inmediata cuando un competidor hace un movimiento significativo o tu posición baja bruscamente" },
   { title: "Reportes bilingües (EN/ES)", desc: "Entregados en el idioma que prefieras — inglés o español" },
 ];
@@ -18,7 +19,6 @@ const included = [
 const notIncluded = [
   "Monitoreo de redes sociales (solo Google Maps y Perfil de Negocio en Google)",
   "Gestión de campañas pagadas o Google Ads",
-  "Responder reseñas en tu nombre (disponible como servicio adicional)",
 ];
 
 const bestFor = [


### PR DESCRIPTION
**`/pricing/`** sold it as part of the plan, with a checkmark:

> Google review management — approve a reply and it posts to Google automatically

**`/competitive-intelligence/`** listed it under what is *not* included:

> Responding to reviews on your behalf (available as a separate add-on)

A prospect reading both couldn't tell what they were buying — and the "separate add-on" was named with **no price and nowhere to click**.

There may have been a real distinction underneath (assisted vs fully done-for-you), but nothing on either page said so. And the notes on Azúcar record review management as done-for-you for her, because she's too busy to work a queue.

**Settled: review management is in the plan.** Pricing was right; this page was stale.

- Dropped the exclusion line from `notIncluded`, both locales
- Added "Google review management" to what **is** included, worded to match the pricing page's promise rather than paraphrase it

## How this surfaced

I was about to build `/google-reviews/` for MarketSignal. It isn't needed — **`/competitive-intelligence/` already is the MarketSignal page**, with the photographic hero and links from the homepage, `/services/` and the footer. A second page would have repeated the duplicate-entry problem we removed from the portfolio earlier this week.

The contradiction was the real defect.

The hero comment now records the correction and says not to reintroduce the add-on framing without editing the pricing page in the same change — that's how the two drifted apart.

Spanish audited for Iberian markers, clean. Build passes: 124 pages, gate 124/124. Verified in built output that the exclusion is gone and the inclusion renders in both locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)